### PR TITLE
Add Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,11 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    uses: shakacode/.github/.github/workflows/claude-code-review.yml@main
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds automated Claude Code PR reviews using the shared reusable workflow from `shakacode/.github`
- Uses Claude Code's default model (currently Opus 4.6)
- Requires `CLAUDE_CODE_OAUTH_TOKEN` secret (org-level or repo-level)

## Test plan
- [ ] Ensure `CLAUDE_CODE_OAUTH_TOKEN` secret is available (org or repo level)
- [ ] Merge and verify review triggers on next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
