### PR TITLE
[codex] Add source and contributor links to demo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+- Fill in the user-facing change and why it matters.
+
+## Demo surfaces affected
+
+- [ ] Landing page / navigation
+- [ ] Restaurant search comparison
+- [ ] Blog comparison
+- [ ] Product page comparison
+- [ ] Product search comparison
+- [ ] Analytics / dashboard
+- [ ] Deployment / Control Plane
+- [ ] Docs / contributor experience
+
+## Test plan
+
+- List the commands, manual checks, or screenshots used to validate this PR.
+
+## Screenshots or metrics
+
+- Not applicable
+
+## Checklist
+
+- [ ] I kept the SSR, client, and RSC comparison honest, or documented why a route intentionally diverges
+- [ ] I updated docs, routes, or contributor guidance for any new user-facing entry point
+- [ ] I called out deploy, seed, or benchmark impacts when relevant

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing
+
+Thanks for improving the React on Rails marketplace demo.
+
+This repo exists to make SSR, client components, and React Server Components easy to compare in one place. Contributions should keep that comparison credible and easy to understand.
+
+## Before you start
+
+- Keep the user journeys aligned across the SSR, client, and RSC variants unless the change is explicitly about a behavioral difference.
+- Preserve the benchmark story. Artificially removing the slow parts of the demo makes the comparison less useful.
+- When you change the deployed experience, make the source code and contributor entry points easier to find, not harder.
+
+## Local setup
+
+1. Install Ruby `3.3.0`, PostgreSQL, and Node `20.x` or newer.
+2. Install dependencies:
+
+   ```bash
+   bundle install
+   pnpm install
+   ```
+
+3. Prepare the database:
+
+   ```bash
+   bin/rails db:prepare
+   ```
+
+4. Start the app:
+
+   ```bash
+   bin/dev
+   ```
+
+5. Open `http://localhost:3000`.
+
+## Useful routes
+
+- `/` for the demo landing page and project links
+- `/search/ssr`, `/search/client`, `/search/rsc`
+- `/blog/ssr`, `/blog/client`, `/blog/rsc`
+- `/product/ssr`, `/product/client`, `/product/rsc`
+- `/product-search/ssr`, `/product-search/client`, `/product-search/rsc`
+- `/analytics/ssr`, `/analytics/client`, `/analytics/rsc`
+- `/dashboard` for comparison metrics
+
+## Demo guardrails
+
+- Treat the variants as apples-to-apples comparisons. If you add a feature to one route family, check whether it belongs in the others too.
+- Keep realistic latency in place for the data-heavy flows. The demo is meant to show the architectural difference under load.
+- If you touch the RSC pipeline, confirm the SSR and client versions still render the same core information.
+- If you change deployment behavior, update [`.controlplane/README.md`](./.controlplane/README.md) as part of the same PR.
+
+## Documentation to read first
+
+- [README.md](./README.md)
+- [IMPLEMENTATION_TASKS.md](./IMPLEMENTATION_TASKS.md)
+- [BENCHMARKING.md](./BENCHMARKING.md)
+- [DOCS_MANIFEST.md](./DOCS_MANIFEST.md)
+
+## Pull requests
+
+Please keep PRs focused and include:
+
+- a short summary of what changed
+- a test plan with commands you ran or the checks you performed
+- screenshots or route notes for visible UI changes
+- benchmark notes if the change affects the comparison story
+
+If your work changes deployment or review-app behavior, mention that explicitly in the PR description.
+
+## Questions and follow-up
+
+- Repo issues: https://github.com/shakacode/react-server-components-marketplace-demo/issues
+- React on Rails docs: https://reactonrails.com/docs
+- ShakaCode forum: https://forum.shakacode.com/c/reactjs

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A restaurant marketplace discovery platform demonstrating how React Server Components with streaming dramatically improve Web Vitals compared to traditional SSR + lazy-loading.
 
+## Demo and Source
+
+- Live demo: https://rsc.reactonrails.com
+- Source code: https://github.com/shakacode/react-server-components-marketplace-demo
+- Contributor guide: [CONTRIBUTING.md](./CONTRIBUTING.md)
+- Issue tracker: https://github.com/shakacode/react-server-components-marketplace-demo/issues
+
 ## Quick Start
 
 **The Problem**: Public-facing marketplace pages with dynamic real-time content suffer poor Web Vitals (slow LCP, high CLS) using traditional SSR + lazy-loading.
@@ -327,6 +334,10 @@ A: Not implemented. Goal is proving RSC advantage without caching complexity.
 **Q: Can I use different data?**
 A: Yes, keep 10M orders. Change restaurant names/cuisines as desired.
 
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for local setup, demo guardrails, deployment notes, and PR expectations.
+
 ## Related Resources
 
 - React 19 Server Components: https://react.dev/blog/2024/12/19/react-19
@@ -336,5 +347,5 @@ A: Yes, keep 10M orders. Change restaurant names/cuisines as desired.
 
 ---
 
-**Status**: Ready for implementation
-**Next Step**: Read `IMPLEMENTATION_TASKS.md`, then start Task 1
+**Status**: Active demo app for React on Rails SSR, client, and RSC comparisons
+**Next Step**: Run the demo locally, compare the routes, and open an issue or PR for improvements

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,9 +6,7 @@ class HomeController < ApplicationController
 
   enable_async_react_rendering only: [:rsc]
 
-  def index
-    @name = 'World'
-  end
+  def index; end
 
   def rsc
     stream_view_containing_react_components(template: "/home/rsc")

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,58 +1,128 @@
-<div class="container mx-auto max-w-4xl px-4 py-8">
-  <h1 class="text-3xl font-bold mb-2">LocalHub Demo</h1>
-  <p class="text-gray-600 mb-8">React on Rails — SSR vs Client vs RSC Performance Comparison</p>
-
-  <%= react_component('HelloWorld', props: { name: @name }, prerender: true) %>
-
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-8">
-    <!-- Search Page Demo -->
-    <div class="border border-gray-200 rounded-xl p-6">
-      <h2 class="text-lg font-bold mb-2">Restaurant Search</h2>
-      <p class="text-sm text-gray-600 mb-4">Search page with real-time data streaming</p>
-      <div class="space-y-2">
-        <a href="/search/ssr" class="block text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 hover:bg-amber-100 transition-colors">V1: Full SSR</a>
-        <a href="/search/client" class="block text-sm text-blue-700 bg-blue-50 border border-blue-200 rounded-lg px-3 py-2 hover:bg-blue-100 transition-colors">V2: Client Components</a>
-        <a href="/search/rsc" class="block text-sm text-green-700 bg-green-50 border border-green-200 rounded-lg px-3 py-2 hover:bg-green-100 transition-colors">V3: RSC Streaming</a>
+<div class="mx-auto max-w-6xl px-4 py-10">
+  <section class="overflow-hidden rounded-3xl bg-slate-900 px-6 py-8 text-white shadow-xl md:px-8 md:py-10">
+    <div class="grid gap-8 lg:grid-cols-[minmax(0,1.7fr)_minmax(0,1fr)] lg:items-end">
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-[0.32em] text-cyan-200">Open Source Example</p>
+        <h1 class="mt-4 text-4xl font-semibold tracking-tight text-white md:text-5xl">LocalHub Marketplace Demo</h1>
+        <p class="mt-4 max-w-2xl text-base leading-7 text-slate-200 md:text-lg">
+          Compare full SSR, client components, and React Server Components across identical marketplace experiences.
+          This deployment is intentionally easy to inspect, fork, and improve.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <%= link_to 'Browse source on GitHub', source_code_path, class: 'rounded-full bg-cyan-300 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-200' %>
+          <%= link_to 'Read the contributor guide', contributing_guide_path, class: 'rounded-full border border-white/20 px-5 py-3 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/10' %>
+        </div>
       </div>
+
+      <dl class="grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
+        <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+          <dt class="text-xs font-semibold uppercase tracking-[0.24em] text-slate-300">LCP Improvement</dt>
+          <dd class="mt-2 text-2xl font-semibold text-white">59%</dd>
+          <p class="mt-2 text-sm text-slate-300">RSC versions render meaningful content faster under the same data load.</p>
+        </div>
+        <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+          <dt class="text-xs font-semibold uppercase tracking-[0.24em] text-slate-300">Routes to Compare</dt>
+          <dd class="mt-2 text-2xl font-semibold text-white">12</dd>
+          <p class="mt-2 text-sm text-slate-300">Four user journeys, each implemented with SSR, client, and RSC variants.</p>
+        </div>
+        <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+          <dt class="text-xs font-semibold uppercase tracking-[0.24em] text-slate-300">Contributor Paths</dt>
+          <dd class="mt-2 text-2xl font-semibold text-white">3</dd>
+          <p class="mt-2 text-sm text-slate-300">Source, issues, and contribution docs are all reachable directly from this app.</p>
+        </div>
+      </dl>
+    </div>
+  </section>
+
+  <section class="mt-8 grid gap-4 md:grid-cols-3">
+    <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <p class="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">Source</p>
+      <h2 class="mt-3 text-xl font-semibold text-slate-900">Inspect the implementation</h2>
+      <p class="mt-3 text-sm leading-6 text-slate-600">
+        Browse the Rails, React, and deployment code behind the demo without hunting through Slack or PR history.
+      </p>
+      <%= link_to 'Open the GitHub repo', source_code_path, class: 'mt-4 inline-flex text-sm font-semibold text-cyan-700 transition hover:text-cyan-600' %>
+    </article>
+
+    <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <p class="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">Contributing</p>
+      <h2 class="mt-3 text-xl font-semibold text-slate-900">Start from the right docs</h2>
+      <p class="mt-3 text-sm leading-6 text-slate-600">
+        Follow the contributor guide for setup, demo guardrails, PR expectations, and deployment touchpoints.
+      </p>
+      <%= link_to 'Read CONTRIBUTING.md', contributing_guide_path, class: 'mt-4 inline-flex text-sm font-semibold text-cyan-700 transition hover:text-cyan-600' %>
+    </article>
+
+    <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <p class="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">Support</p>
+      <h2 class="mt-3 text-xl font-semibold text-slate-900">Ask questions or report gaps</h2>
+      <p class="mt-3 text-sm leading-6 text-slate-600">
+        Use the issue tracker for repo work and React on Rails docs for framework-specific questions and background.
+      </p>
+      <div class="mt-4 flex flex-wrap gap-4">
+        <%= link_to 'Open an issue', project_issues_path, class: 'inline-flex text-sm font-semibold text-cyan-700 transition hover:text-cyan-600' %>
+        <%= link_to 'React on Rails docs', 'https://reactonrails.com/docs', class: 'inline-flex text-sm font-semibold text-cyan-700 transition hover:text-cyan-600' %>
+      </div>
+    </article>
+  </section>
+
+  <section class="mt-10">
+    <div class="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">Demo Routes</p>
+        <h2 class="mt-2 text-2xl font-semibold text-slate-900">Compare the same flows across rendering strategies</h2>
+      </div>
+      <p class="max-w-2xl text-sm leading-6 text-slate-600">
+        Each surface below keeps the user journey aligned so you can attribute the difference to rendering strategy, not feature scope.
+      </p>
     </div>
 
-    <!-- Blog Post Demo -->
-    <div class="border border-gray-200 rounded-xl p-6">
-      <h2 class="text-lg font-bold mb-2">Blog Post</h2>
-      <p class="text-sm text-gray-600 mb-4">Content page with markdown rendering</p>
-      <div class="space-y-2">
-        <a href="/blog/ssr" class="block text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 hover:bg-amber-100 transition-colors">V1: Full SSR</a>
-        <a href="/blog/client" class="block text-sm text-blue-700 bg-blue-50 border border-blue-200 rounded-lg px-3 py-2 hover:bg-blue-100 transition-colors">V2: Client Components</a>
-        <a href="/blog/rsc" class="block text-sm text-green-700 bg-green-50 border border-green-200 rounded-lg px-3 py-2 hover:bg-green-100 transition-colors">V3: RSC Streaming</a>
+    <div class="mt-6 grid grid-cols-1 gap-6 md:grid-cols-2">
+      <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h3 class="text-lg font-semibold text-slate-900">Restaurant Search</h3>
+        <p class="mt-2 text-sm text-slate-600">Classic marketplace discovery with real-time availability and streaming content.</p>
+        <div class="mt-4 space-y-2">
+          <a href="/search/ssr" class="block rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700 transition hover:bg-amber-100">V1: Full SSR</a>
+          <a href="/search/client" class="block rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-700 transition hover:bg-blue-100">V2: Client Components</a>
+          <a href="/search/rsc" class="block rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700 transition hover:bg-green-100">V3: RSC Streaming</a>
+        </div>
       </div>
-    </div>
 
-    <!-- Product Page Demo -->
-    <div class="border border-gray-200 rounded-xl p-6 ring-2 ring-indigo-200">
-      <div class="flex items-center gap-2 mb-2">
-        <h2 class="text-lg font-bold">Product Page</h2>
-        <span class="px-2 py-0.5 text-xs font-semibold bg-indigo-100 text-indigo-700 rounded-full">NEW</span>
+      <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h3 class="text-lg font-semibold text-slate-900">Blog Post</h3>
+        <p class="mt-2 text-sm text-slate-600">Markdown-heavy content that highlights the client bundle savings from server rendering.</p>
+        <div class="mt-4 space-y-2">
+          <a href="/blog/ssr" class="block rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700 transition hover:bg-amber-100">V1: Full SSR</a>
+          <a href="/blog/client" class="block rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-700 transition hover:bg-blue-100">V2: Client Components</a>
+          <a href="/blog/rsc" class="block rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700 transition hover:bg-green-100">V3: RSC Streaming</a>
+        </div>
       </div>
-      <p class="text-sm text-gray-600 mb-4">E-commerce product page with reviews &amp; charts</p>
-      <div class="space-y-2">
-        <a href="/product/ssr" class="block text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 hover:bg-amber-100 transition-colors">V1: Full SSR</a>
-        <a href="/product/client" class="block text-sm text-blue-700 bg-blue-50 border border-blue-200 rounded-lg px-3 py-2 hover:bg-blue-100 transition-colors">V2: Client Components</a>
-        <a href="/product/rsc" class="block text-sm text-green-700 bg-green-50 border border-green-200 rounded-lg px-3 py-2 hover:bg-green-100 transition-colors">V3: RSC Streaming</a>
-      </div>
-    </div>
 
-    <!-- Product Search Demo -->
-    <div class="border border-gray-200 rounded-xl p-6 ring-2 ring-indigo-200">
-      <div class="flex items-center gap-2 mb-2">
-        <h2 class="text-lg font-bold">Product Search</h2>
-        <span class="px-2 py-0.5 text-xs font-semibold bg-indigo-100 text-indigo-700 rounded-full">NEW</span>
+      <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm ring-1 ring-indigo-100">
+        <div class="flex items-center gap-2">
+          <h3 class="text-lg font-semibold text-slate-900">Product Page</h3>
+          <span class="rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-semibold text-indigo-700">NEW</span>
+        </div>
+        <p class="mt-2 text-sm text-slate-600">Detailed product pages with reviews, charts, and related content.</p>
+        <div class="mt-4 space-y-2">
+          <a href="/product/ssr" class="block rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700 transition hover:bg-amber-100">V1: Full SSR</a>
+          <a href="/product/client" class="block rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-700 transition hover:bg-blue-100">V2: Client Components</a>
+          <a href="/product/rsc" class="block rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700 transition hover:bg-green-100">V3: RSC Streaming</a>
+        </div>
       </div>
-      <p class="text-sm text-gray-600 mb-4">Faceted search with filters, sort &amp; pagination</p>
-      <div class="space-y-2">
-        <a href="/product-search/ssr" class="block text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 hover:bg-amber-100 transition-colors">V1: Full SSR</a>
-        <a href="/product-search/client" class="block text-sm text-blue-700 bg-blue-50 border border-blue-200 rounded-lg px-3 py-2 hover:bg-blue-100 transition-colors">V2: Client Components</a>
-        <a href="/product-search/rsc" class="block text-sm text-green-700 bg-green-50 border border-green-200 rounded-lg px-3 py-2 hover:bg-green-100 transition-colors">V3: RSC Streaming</a>
+
+      <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm ring-1 ring-indigo-100">
+        <div class="flex items-center gap-2">
+          <h3 class="text-lg font-semibold text-slate-900">Product Search</h3>
+          <span class="rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-semibold text-indigo-700">NEW</span>
+        </div>
+        <p class="mt-2 text-sm text-slate-600">Faceted search with filters, pagination, and server-streamed result sections.</p>
+        <div class="mt-4 space-y-2">
+          <a href="/product-search/ssr" class="block rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700 transition hover:bg-amber-100">V1: Full SSR</a>
+          <a href="/product-search/client" class="block rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-700 transition hover:bg-blue-100">V2: Client Components</a>
+          <a href="/product-search/rsc" class="block rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700 transition hover:bg-green-100">V3: RSC Streaming</a>
+        </div>
       </div>
     </div>
-  </div>
+  </section>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <%= yield :head %>
   </head>
 
-  <body>
+  <body class="min-h-screen bg-slate-50 text-slate-900">
     <script>
       window.addEventListener('error', function(event) {
         var err = event.error;
@@ -44,7 +44,39 @@
         }
       });
     </script>
-    <%= yield %>
+    <header class="border-b border-slate-200 bg-white/95 backdrop-blur">
+      <div class="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <a href="/" class="text-xs font-semibold uppercase tracking-[0.28em] text-slate-500">React on Rails Demo</a>
+          <p class="mt-1 text-lg font-semibold text-slate-900">LocalHub Marketplace Demo</p>
+          <p class="text-sm text-slate-600">Open-source SSR, client, and RSC comparisons built with React on Rails.</p>
+        </div>
+        <nav class="flex flex-wrap gap-2 text-sm font-medium">
+          <%= link_to 'Home', '/', class: 'rounded-full border border-slate-200 px-4 py-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-100' %>
+          <%= link_to 'Why RSC', '/why-rsc', class: 'rounded-full border border-slate-200 px-4 py-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-100' %>
+          <%= link_to 'Source', source_code_path, class: 'rounded-full border border-slate-200 px-4 py-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-100' %>
+          <%= link_to 'Contributing', contributing_guide_path, class: 'rounded-full border border-slate-200 px-4 py-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-100' %>
+          <%= link_to 'Issues', project_issues_path, class: 'rounded-full border border-slate-200 px-4 py-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-100' %>
+          <%= link_to 'Docs', 'https://reactonrails.com/docs', class: 'rounded-full border border-slate-200 px-4 py-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-100' %>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <%= yield %>
+    </main>
+
+    <footer class="border-t border-slate-200 bg-white">
+      <div class="mx-auto flex max-w-6xl flex-col gap-3 px-4 py-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+        <p>Explore the code, compare the rendering strategies, and open a PR when you improve the demo.</p>
+        <div class="flex flex-wrap gap-4">
+          <%= link_to 'GitHub repo', source_code_path, class: 'transition hover:text-slate-900' %>
+          <%= link_to 'Contributor guide', contributing_guide_path, class: 'transition hover:text-slate-900' %>
+          <%= link_to 'Forum', 'https://forum.shakacode.com/c/reactjs', class: 'transition hover:text-slate-900' %>
+          <%= link_to 'ShakaCode', 'https://www.shakacode.com', class: 'transition hover:text-slate-900' %>
+        </div>
+      </div>
+    </footer>
 
     <%= javascript_pack_tag 'client-bundle', async: true %>
   </body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,16 @@
 Rails.application.routes.draw do
   rsc_payload_route
+  repository_url = 'https://github.com/shakacode/react-server-components-marketplace-demo'
+  contributing_url = "#{repository_url}/blob/main/CONTRIBUTING.md"
+  issues_url = "#{repository_url}/issues"
+
   # Health check endpoint
   get 'up' => 'rails/health#show', as: :rails_health_check
 
-  # Root route (will be updated later)
   root 'home#index'
+  get '/source', to: redirect(repository_url, status: 308), as: :source_code
+  get '/contributing', to: redirect(contributing_url, status: 308), as: :contributing_guide
+  get '/issues', to: redirect(issues_url, status: 308), as: :project_issues
   get '/search-performance' => 'pages#search_performance'
   get '/rsc' => 'home#rsc'
   get '/why-rsc' => 'pages#why_rsc'


### PR DESCRIPTION
## Summary

- add stable `/source`, `/contributing`, and `/issues` routes that 308 redirect to the repo surfaces
- expose source, contributor, docs, and issue links in the shared app header/footer and redesign the landing page around open-source discovery
- add `CONTRIBUTING.md`, a pull request template, and README links so the repo matches the deployed app's contributor entry points

## Why

The deployed demo made it too hard to find the source code and contributor guidance from the site itself. This change makes the app self-identifying and gives contributors a clear path from the live demo to the repo, docs, and issue tracker.

## Impact

- visitors can jump from the demo to the GitHub repo and contributor docs without digging through Slack or old PRs
- maintainers get a contributor guide and PR template tailored to the SSR/client/RSC comparison workflow
- future demo entry points have a clearer expectation to keep source and contribution links discoverable

## Validation

- `ruby -c config/routes.rb`
- `ruby -c app/controllers/home_controller.rb`
- `ruby -rerb -e "ERB.new(File.read('app/views/layouts/application.html.erb')); ERB.new(File.read('app/views/home/index.html.erb')); puts 'ERB OK'"`
- `git diff --cached --check`

## Notes

- I did not run Rails/request specs because the repo does not currently include committed test scaffolding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation, routing redirects, and landing/layout UI updates with no business logic or data-path modifications.
> 
> **Overview**
> Makes the deployed demo self-identifying by adding stable redirect routes (e.g. `/source`, `/contributing`, `/issues`) and wiring them into a new shared header/footer navigation.
> 
> Redesigns the home/landing page to highlight open-source discovery and provide direct links to source, contributing guide, and issue tracker, and removes the unused `@name` prop from `HomeController#index`.
> 
> Adds repo contributor scaffolding (`CONTRIBUTING.md` and `.github/pull_request_template.md`) and updates `README.md` with explicit demo/source links and a contributing section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42087fa89a547e108ed8b9337cda4944d4759eea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned landing page with hero section, updated navigation, and demo routes overview
  * Added persistent header with navigation links (Home, Why RSC, Source, Contributing, Issues, Docs)
  * Added persistent footer with project links and information
  * New redirect routes for accessing source code, contributing guide, and issue tracker

* **Documentation**
  * Added contribution guidelines with local setup instructions and demo guardrails
  * Updated README with contributing section and links to demo, repository, and issue tracker

* **Refactor**
  * Simplified home controller initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->