### PR TITLE
Fix RSC markdown and type safety

### DIFF
--- a/app/javascript/components/product-search/SearchInput.tsx
+++ b/app/javascript/components/product-search/SearchInput.tsx
@@ -7,29 +7,45 @@ interface Props {
 
 export function SearchInput({ initialQuery, onSearch }: Props) {
   const [query, setQuery] = useState(initialQuery);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     setQuery(initialQuery);
   }, [initialQuery]);
 
+  useEffect(() => () => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+  }, []);
+
   const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setQuery(value);
 
-    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
     debounceRef.current = setTimeout(() => {
       onSearch(value);
+      debounceRef.current = null;
     }, 400);
   }, [onSearch]);
 
   const handleSubmit = useCallback((e: React.FormEvent) => {
     e.preventDefault();
-    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
     onSearch(query);
   }, [query, onSearch]);
 
   const handleClear = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
     setQuery('');
     onSearch('');
   }, [onSearch]);

--- a/app/javascript/loadable.d.ts
+++ b/app/javascript/loadable.d.ts
@@ -1,0 +1,58 @@
+declare module '@loadable/component' {
+  import type { ComponentType, ReactNode } from 'react';
+
+  interface LoadableOptions<Props extends object, Module> {
+    fallback?: ReactNode;
+    ssr?: boolean;
+    cacheKey?: (props: Props) => unknown;
+    resolveComponent?: (module: Module, props: Props) => ComponentType<Props>;
+  }
+
+  type LoadableComponent<Props extends object> = ComponentType<Props> & {
+    load(props?: Props): Promise<ComponentType<Props>>;
+    preload(props?: Props): void;
+  };
+
+  type PropsOf<Module> = Module extends { default: ComponentType<infer Props> }
+    ? Props extends object
+      ? Props
+      : Record<string, never>
+    : Record<string, never>;
+
+  interface LoadableReadyOptions {
+    chunkLoadingGlobal?: string;
+    namespace?: string;
+  }
+
+  export default function loadable<Module extends { default: ComponentType<any> }>(
+    loader: () => Promise<Module>,
+    options?: LoadableOptions<PropsOf<Module>, Module>
+  ): LoadableComponent<PropsOf<Module>>;
+
+  export default function loadable<Props extends object = Record<string, never>, Module = { default: ComponentType<Props> }>(
+    loader: (props: Props) => Promise<Module>,
+    options?: LoadableOptions<Props, Module>
+  ): LoadableComponent<Props>;
+
+  export function loadableReady(done?: () => void, options?: LoadableReadyOptions): Promise<void>;
+}
+
+declare module '@loadable/server' {
+  import type { ReactElement } from 'react';
+
+  type ChunkExtractorOptions = {
+    entrypoints?: string | string[];
+    inputFileSystem?: object;
+    namespace?: string;
+    outputPath?: string;
+    publicPath?: string;
+  } & ({ statsFile: string } | { stats: object });
+
+  export class ChunkExtractor {
+    constructor(options: ChunkExtractorOptions);
+    collectChunks(element: ReactElement): ReactElement;
+    getLinkTags(): string;
+    getScriptTags(): string;
+    getStyleTags(): string;
+  }
+}

--- a/app/javascript/utils/renderMarkdown.ts
+++ b/app/javascript/utils/renderMarkdown.ts
@@ -1,6 +1,7 @@
 import { Marked } from 'marked';
 import { markedHighlight } from 'marked-highlight';
 import hljs from 'highlight.js';
+import sanitizeHtml from 'sanitize-html';
 
 const marked = new Marked(
   markedHighlight({
@@ -15,5 +16,29 @@ const marked = new Marked(
 );
 
 export function renderMarkdown(content: string): string {
-  return marked.parse(content) as string;
+  const html = marked.parse(content) as string;
+
+  return sanitizeHtml(html, {
+    allowedTags: [
+      ...sanitizeHtml.defaults.allowedTags,
+      'del',
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+      'img',
+      'pre',
+      'span',
+    ],
+    allowedAttributes: {
+      ...sanitizeHtml.defaults.allowedAttributes,
+      a: ['href', 'name', 'target', 'rel'],
+      code: ['class'],
+      img: ['src', 'srcset', 'alt', 'title', 'width', 'height', 'loading'],
+      pre: ['class'],
+      span: ['class'],
+    },
+  });
 }


### PR DESCRIPTION
## Summary
- sanitize rendered markdown before it reaches dangerouslySetInnerHTML while preserving highlight.js classes
- add local @loadable/component and @loadable/server declarations with prop inference for dynamic imports
- make SearchInput debounce ref nullable and clear pending timeouts on submit, clear, and unmount

## Verification
- pnpm run type-check
- pnpm run lint:rsc
- git diff --check

## Notes
This replaces the stale broad best-practices branch with the still-relevant fixes from that work. Old review comments against removed/stale files are superseded by this focused diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Markdown sanitization directly affects XSS surface for blog content rendered via dangerouslySetInnerHTML; allowlist misconfiguration could strip needed markup or miss vectors.
> 
> **Overview**
> Hardens **markdown → HTML** used with `dangerouslySetInnerHTML` by running `marked` output through **`sanitize-html`**, with an allowlist that keeps headings, images, code blocks, and **highlight.js** `class` attributes on `code`/`pre`/`span`.
> 
> Adds local **`app/javascript/loadable.d.ts`** declarations for **`@loadable/component`** and **`@loadable/server`** (including prop inference from default exports) to improve type-checking for existing dynamic imports.
> 
> Tightens **`SearchInput`** debouncing: the timeout ref is explicitly nullable, pending timers are cleared on **submit**, **clear**, and **unmount**, and the ref is reset after the debounced callback runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd40e6a3385d5f0f79cd48f5d5c6b1daffddb7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->