### PR TITLE
Bump react_on_rails to v16.5.1 with RSC streaming flush fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/shakacode/react_on_rails.git
-  revision: da37b46080e4fa5b2b7097a63861b61a2a8ad314
+  revision: 03e7787ea0faaef7bcd44dd3b794352c7acbc54d
   branch: upcoming-v16.3.0
   glob: react_on_rails/*.gemspec
   specs:
-    react_on_rails (16.4.0)
+    react_on_rails (16.5.1)
       addressable
       connection_pool
       execjs (~> 2.5)
@@ -14,20 +14,20 @@ GIT
 
 GIT
   remote: https://github.com/shakacode/react_on_rails.git
-  revision: da37b46080e4fa5b2b7097a63861b61a2a8ad314
+  revision: 03e7787ea0faaef7bcd44dd3b794352c7acbc54d
   branch: upcoming-v16.3.0
   glob: react_on_rails_pro/*.gemspec
   specs:
-    react_on_rails_pro (16.4.0)
+    react_on_rails_pro (16.5.1)
       addressable
-      async (>= 2.6)
+      async (>= 2.29)
       connection_pool
       execjs (~> 2.9)
       http-2 (>= 1.1.1)
       httpx (>= 1.7.0)
       jwt (~> 2.7)
       rainbow
-      react_on_rails (= 16.4.0)
+      react_on_rails (= 16.5.1)
 
 GEM
   remote: https://rubygems.org/
@@ -105,10 +105,10 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
-    async (2.35.0)
+    async (2.39.0)
       console (~> 1.29)
       fiber-annotation
       io-event (~> 1.11)
@@ -116,7 +116,7 @@ GEM
       traces (~> 0.18)
     base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.1)
     bindex (0.8.1)
     bootsnap (1.19.0)
       msgpack (~> 1.2)
@@ -136,7 +136,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
     connection_pool (2.5.5)
-    console (1.34.2)
+    console (1.34.3)
       fiber-annotation
       fiber-local (~> 1.1)
       json
@@ -147,9 +147,9 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
     drb (2.2.3)
-    erb (6.0.1)
+    erb (6.0.2)
     erubi (1.13.1)
-    execjs (2.10.0)
+    execjs (2.10.1)
     factory_bot (6.5.6)
       activesupport (>= 6.1.0)
     factory_bot_rails (6.5.1)
@@ -163,31 +163,32 @@ GEM
     fiber-storage (1.0.1)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    http-2 (1.1.1)
-    httpx (1.7.2)
-      http-2 (>= 1.0.0)
-    i18n (1.14.7)
+    http-2 (1.1.3)
+    httpx (1.7.6)
+      http-2 (>= 1.1.3)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.2.2)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.8.2)
-    io-event (1.14.2)
-    irb (1.16.0)
+    io-event (1.15.1)
+    irb (1.17.0)
       pp (>= 0.6.0)
+      prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.18.0)
+    json (2.19.3)
     jwt (2.10.2)
       base64
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.25.0)
+    loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -201,10 +202,11 @@ GEM
     method_source (1.1.0)
     metrics (0.15.0)
     mini_mime (1.1.5)
-    minitest (6.0.0)
+    minitest (6.0.4)
+      drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
-    net-imap (0.6.2)
+    net-imap (0.6.3)
       date
       net-protocol
     net-pop (0.1.2)
@@ -214,21 +216,21 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.18.10-aarch64-linux-gnu)
+    nokogiri (1.19.2-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.10-aarch64-linux-musl)
+    nokogiri (1.19.2-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.18.10-arm-linux-gnu)
+    nokogiri (1.19.2-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.10-arm-linux-musl)
+    nokogiri (1.19.2-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.18.10-arm64-darwin)
+    nokogiri (1.19.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-darwin)
+    nokogiri (1.19.2-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-linux-gnu)
+    nokogiri (1.19.2-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-linux-musl)
+    nokogiri (1.19.2-x86_64-linux-musl)
       racc (~> 1.4)
     package_json (0.2.0)
     parallel (1.27.0)
@@ -245,7 +247,7 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.7.0)
+    prism (1.9.0)
     pry (0.16.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -256,14 +258,14 @@ GEM
     psych (5.3.1)
       date
       stringio
-    public_suffix (7.0.0)
+    public_suffix (7.0.5)
     puma (6.6.1)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.2.4)
+    rack (3.2.6)
     rack-proxy (0.7.7)
       rack
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)
@@ -288,8 +290,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.2)
-      loofah (~> 2.21)
+    rails-html-sanitizer (1.7.0)
+      loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (7.2.3)
       actionpack (= 7.2.3)
@@ -302,8 +304,8 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.3.1)
-    rdoc (7.0.1)
+    rake (13.4.1)
+    rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
       tsort
@@ -360,7 +362,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    semantic_range (3.1.0)
+    semantic_range (3.1.1)
     shakapacker (9.5.0)
       activesupport (>= 5.2)
       package_json
@@ -378,8 +380,8 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
-    thor (1.4.0)
-    timeout (0.6.0)
+    thor (1.5.0)
+    timeout (0.6.1)
     traces (0.18.2)
     tsort (0.2.0)
     turbo-rails (2.0.20)
@@ -403,7 +405,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.4)
+    zeitwerk (2.7.5)
 
 PLATFORMS
   aarch64-linux

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-dom": "^19.0.0",
     "react-on-rails-pro": "github:shakacode/react-on-rails-builds#v16.5.1-rsc-flush-fix&path:react-on-rails-pro",
     "react-on-rails-pro-node-renderer": "github:shakacode/react-on-rails-builds#v16.5.1-rsc-flush-fix&path:react-on-rails-pro-node-renderer",
-    "react-on-rails-rsc": "19.0.5-rc.1",
+    "react-on-rails-rsc": "github:shakacode/react_on_rails_rsc#perf/rsc-revive-model-walk",
     "web-vitals": "^4.2.0"
   },
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -39,14 +39,14 @@
     "marked-highlight": "^2.2.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-on-rails-pro": "github:shakacode/react-on-rails-builds#upcoming-v16.3.0&path:react-on-rails-pro",
-    "react-on-rails-pro-node-renderer": "github:shakacode/react-on-rails-builds#upcoming-v16.3.0&path:react-on-rails-pro-node-renderer",
+    "react-on-rails-pro": "github:shakacode/react-on-rails-builds#v16.5.1-rsc-flush-fix&path:react-on-rails-pro",
+    "react-on-rails-pro-node-renderer": "github:shakacode/react-on-rails-builds#v16.5.1-rsc-flush-fix&path:react-on-rails-pro-node-renderer",
     "react-on-rails-rsc": "19.0.5-rc.1",
     "web-vitals": "^4.2.0"
   },
   "pnpm": {
     "overrides": {
-      "react-on-rails": "github:shakacode/react-on-rails-builds#upcoming-v16.3.0&path:react-on-rails",
+      "react-on-rails": "github:shakacode/react-on-rails-builds#v16.5.1-rsc-flush-fix&path:react-on-rails",
       "shakapacker": "9.5.0"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  react-on-rails: github:shakacode/react-on-rails-builds#upcoming-v16.3.0&path:react-on-rails
+  react-on-rails: github:shakacode/react-on-rails-builds#v16.5.1-rsc-flush-fix&path:react-on-rails
   shakapacker: 9.5.0
 
 importers:
@@ -64,11 +64,11 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       react-on-rails-pro:
-        specifier: github:shakacode/react-on-rails-builds#upcoming-v16.3.0&path:react-on-rails-pro
-        version: git+https://git@github.com:shakacode/react-on-rails-builds.git#909e26603db9f52f5172e4c42cc22758610d8bd5&path:react-on-rails-pro(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@19.0.5-rc.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4)
+        specifier: github:shakacode/react-on-rails-builds#v16.5.1-rsc-flush-fix&path:react-on-rails-pro
+        version: git+https://git@github.com:shakacode/react-on-rails-builds.git#0499ae9e5074fbf6976f799fea09c9764170f776&path:react-on-rails-pro(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@19.0.5-rc.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4)
       react-on-rails-pro-node-renderer:
-        specifier: github:shakacode/react-on-rails-builds#upcoming-v16.3.0&path:react-on-rails-pro-node-renderer
-        version: git+https://git@github.com:shakacode/react-on-rails-builds.git#909e26603db9f52f5172e4c42cc22758610d8bd5&path:react-on-rails-pro-node-renderer
+        specifier: github:shakacode/react-on-rails-builds#v16.5.1-rsc-flush-fix&path:react-on-rails-pro-node-renderer
+        version: git+https://git@github.com:shakacode/react-on-rails-builds.git#0499ae9e5074fbf6976f799fea09c9764170f776&path:react-on-rails-pro-node-renderer
       react-on-rails-rsc:
         specifier: 19.0.5-rc.1
         version: 19.0.5-rc.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
@@ -2635,8 +2635,8 @@ packages:
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
 
-  fastify@5.8.2:
-    resolution: {integrity: sha512-lZmt3navvZG915IE+f7/TIVamxIwmBd+OMB+O9WBzcpIwOo6F0LTh0sluoMFk5VkrKTvvrwIaoJPkir4Z+jtAg==}
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3928,9 +3928,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
-  react-on-rails-pro-node-renderer@git+https://git@github.com:shakacode/react-on-rails-builds.git#909e26603db9f52f5172e4c42cc22758610d8bd5&path:react-on-rails-pro-node-renderer:
-    resolution: {commit: 909e26603db9f52f5172e4c42cc22758610d8bd5, path: react-on-rails-pro-node-renderer, repo: git@github.com:shakacode/react-on-rails-builds.git, type: git}
-    version: 16.4.0
+  react-on-rails-pro-node-renderer@git+https://git@github.com:shakacode/react-on-rails-builds.git#0499ae9e5074fbf6976f799fea09c9764170f776&path:react-on-rails-pro-node-renderer:
+    resolution: {commit: 0499ae9e5074fbf6976f799fea09c9764170f776, path: react-on-rails-pro-node-renderer, repo: git@github.com:shakacode/react-on-rails-builds.git, type: git}
+    version: 16.5.1
     peerDependencies:
       '@honeybadger-io/js': '>=4.0.0'
       '@sentry/node': '>=5.0.0 <11.0.0'
@@ -3943,9 +3943,9 @@ packages:
       '@sentry/tracing':
         optional: true
 
-  react-on-rails-pro@git+https://git@github.com:shakacode/react-on-rails-builds.git#909e26603db9f52f5172e4c42cc22758610d8bd5&path:react-on-rails-pro:
-    resolution: {commit: 909e26603db9f52f5172e4c42cc22758610d8bd5, path: react-on-rails-pro, repo: git@github.com:shakacode/react-on-rails-builds.git, type: git}
-    version: 16.4.0
+  react-on-rails-pro@git+https://git@github.com:shakacode/react-on-rails-builds.git#0499ae9e5074fbf6976f799fea09c9764170f776&path:react-on-rails-pro:
+    resolution: {commit: 0499ae9e5074fbf6976f799fea09c9764170f776, path: react-on-rails-pro, repo: git@github.com:shakacode/react-on-rails-builds.git, type: git}
+    version: 16.5.1
     peerDependencies:
       '@tanstack/react-router': '>=1.139.0 <2.0.0'
       react: '>= 16'
@@ -3964,9 +3964,9 @@ packages:
       react-dom: ^19.0.3
       webpack: ^5.59.0
 
-  react-on-rails@git+https://git@github.com:shakacode/react-on-rails-builds.git#909e26603db9f52f5172e4c42cc22758610d8bd5&path:react-on-rails:
-    resolution: {commit: 909e26603db9f52f5172e4c42cc22758610d8bd5, path: react-on-rails, repo: git@github.com:shakacode/react-on-rails-builds.git, type: git}
-    version: 16.4.0
+  react-on-rails@git+https://git@github.com:shakacode/react-on-rails-builds.git#0499ae9e5074fbf6976f799fea09c9764170f776&path:react-on-rails:
+    resolution: {commit: 0499ae9e5074fbf6976f799fea09c9764170f776, path: react-on-rails, repo: git@github.com:shakacode/react-on-rails-builds.git, type: git}
+    version: 16.5.1
     peerDependencies:
       react: '>= 16'
       react-dom: '>= 16'
@@ -7656,7 +7656,7 @@ snapshots:
 
   fastify-plugin@5.1.0: {}
 
-  fastify@5.8.2:
+  fastify@5.8.5:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
       '@fastify/error': 4.2.0
@@ -9050,21 +9050,21 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-on-rails-pro-node-renderer@git+https://git@github.com:shakacode/react-on-rails-builds.git#909e26603db9f52f5172e4c42cc22758610d8bd5&path:react-on-rails-pro-node-renderer:
+  react-on-rails-pro-node-renderer@git+https://git@github.com:shakacode/react-on-rails-builds.git#0499ae9e5074fbf6976f799fea09c9764170f776&path:react-on-rails-pro-node-renderer:
     dependencies:
       '@fastify/formbody': 8.0.2
       '@fastify/multipart': 9.4.0
-      fastify: 5.8.2
+      fastify: 5.8.5
       fs-extra: 11.3.4
       jsonwebtoken: 9.0.3
       lockfile: 1.0.4
       pino: 9.14.0
 
-  react-on-rails-pro@git+https://git@github.com:shakacode/react-on-rails-builds.git#909e26603db9f52f5172e4c42cc22758610d8bd5&path:react-on-rails-pro(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@19.0.5-rc.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4):
+  react-on-rails-pro@git+https://git@github.com:shakacode/react-on-rails-builds.git#0499ae9e5074fbf6976f799fea09c9764170f776&path:react-on-rails-pro(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@19.0.5-rc.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      react-on-rails: git+https://git@github.com:shakacode/react-on-rails-builds.git#909e26603db9f52f5172e4c42cc22758610d8bd5&path:react-on-rails(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-on-rails: git+https://git@github.com:shakacode/react-on-rails-builds.git#0499ae9e5074fbf6976f799fea09c9764170f776&path:react-on-rails(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
       react-on-rails-rsc: 19.0.5-rc.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
 
@@ -9077,7 +9077,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.21)(webpack-cli@5.1.4)
       webpack-sources: 3.3.4
 
-  react-on-rails@git+https://git@github.com:shakacode/react-on-rails-builds.git#909e26603db9f52f5172e4c42cc22758610d8bd5&path:react-on-rails(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-on-rails@git+https://git@github.com:shakacode/react-on-rails-builds.git#0499ae9e5074fbf6976f799fea09c9764170f776&path:react-on-rails(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,13 +65,13 @@ importers:
         version: 19.2.4(react@19.2.4)
       react-on-rails-pro:
         specifier: github:shakacode/react-on-rails-builds#v16.5.1-rsc-flush-fix&path:react-on-rails-pro
-        version: git+https://git@github.com:shakacode/react-on-rails-builds.git#0499ae9e5074fbf6976f799fea09c9764170f776&path:react-on-rails-pro(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@19.0.5-rc.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4)
+        version: git+https://git@github.com:shakacode/react-on-rails-builds.git#0499ae9e5074fbf6976f799fea09c9764170f776&path:react-on-rails-pro(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@https://codeload.github.com/shakacode/react_on_rails_rsc/tar.gz/67b27f08a66f96340db89c806dad476e3cf7d35d(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4)
       react-on-rails-pro-node-renderer:
         specifier: github:shakacode/react-on-rails-builds#v16.5.1-rsc-flush-fix&path:react-on-rails-pro-node-renderer
         version: git+https://git@github.com:shakacode/react-on-rails-builds.git#0499ae9e5074fbf6976f799fea09c9764170f776&path:react-on-rails-pro-node-renderer
       react-on-rails-rsc:
-        specifier: 19.0.5-rc.1
-        version: 19.0.5-rc.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
+        specifier: github:shakacode/react_on_rails_rsc#perf/rsc-revive-model-walk
+        version: https://codeload.github.com/shakacode/react_on_rails_rsc/tar.gz/67b27f08a66f96340db89c806dad476e3cf7d35d(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
       web-vitals:
         specifier: ^4.2.0
         version: 4.2.4
@@ -3957,8 +3957,9 @@ packages:
       react-on-rails-rsc:
         optional: true
 
-  react-on-rails-rsc@19.0.5-rc.1:
-    resolution: {integrity: sha512-Qf+pT82eKsicLW29/2Mfz6H3Cq+2rn5tDGSTy2tdvMGsQhq5gVFwnhLKE66FasH/gvFjoTIZJmUFy7PLmHoMMw==}
+  react-on-rails-rsc@https://codeload.github.com/shakacode/react_on_rails_rsc/tar.gz/67b27f08a66f96340db89c806dad476e3cf7d35d:
+    resolution: {tarball: https://codeload.github.com/shakacode/react_on_rails_rsc/tar.gz/67b27f08a66f96340db89c806dad476e3cf7d35d}
+    version: 19.0.5-rc.1
     peerDependencies:
       react: ^19.0.3
       react-dom: ^19.0.3
@@ -9060,15 +9061,15 @@ snapshots:
       lockfile: 1.0.4
       pino: 9.14.0
 
-  react-on-rails-pro@git+https://git@github.com:shakacode/react-on-rails-builds.git#0499ae9e5074fbf6976f799fea09c9764170f776&path:react-on-rails-pro(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@19.0.5-rc.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4):
+  react-on-rails-pro@git+https://git@github.com:shakacode/react-on-rails-builds.git#0499ae9e5074fbf6976f799fea09c9764170f776&path:react-on-rails-pro(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@https://codeload.github.com/shakacode/react_on_rails_rsc/tar.gz/67b27f08a66f96340db89c806dad476e3cf7d35d(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-on-rails: git+https://git@github.com:shakacode/react-on-rails-builds.git#0499ae9e5074fbf6976f799fea09c9764170f776&path:react-on-rails(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
-      react-on-rails-rsc: 19.0.5-rc.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
+      react-on-rails-rsc: https://codeload.github.com/shakacode/react_on_rails_rsc/tar.gz/67b27f08a66f96340db89c806dad476e3cf7d35d(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
 
-  react-on-rails-rsc@19.0.5-rc.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4):
+  react-on-rails-rsc@https://codeload.github.com/shakacode/react_on_rails_rsc/tar.gz/67b27f08a66f96340db89c806dad476e3cf7d35d(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2


### PR DESCRIPTION
## Summary
- Bumps `react-on-rails`, `react-on-rails-pro`, and `react-on-rails-pro-node-renderer` from the `upcoming-v16.3.0` branch pointer to the `v16.5.1-rsc-flush-fix` tag on `shakacode/react-on-rails-builds` (resolved SHA `0499ae9e`)
- Corresponding Ruby gems resolve to commit `03e7787e` on `shakacode/react_on_rails` upcoming-v16.3.0
- Switches `react-on-rails-rsc` to the `perf/rsc-revive-model-walk` branch for model-walk perf improvements (resolved SHA `67b27f08`)

## Why
The upstream fix ([shakacode/react_on_rails#3196](https://github.com/shakacode/react_on_rails/pull/3196)) replaces the `setTimeout(0)` chunk-batching in `injectRSCPayload` with React's `destination.flush()` signal plus a `setTimeout` fallback. Without it, RSC shell + resolved content were batched into one ~70KB chunk, adding ~400ms to FCP on RSC pages.

## Test plan
- [x] `pnpm install` succeeds; webpack production build succeeds
- [x] `bundle install` resolves to `react_on_rails 16.5.1` (03e7787e)
- [x] Quick Puppeteer check on `/blog/rsc` — FCP 404ms, SSR 314ms (was 700–900ms pre-fix)
- [x] `/blog/rsc` and `/search/rsc` render in production mode
- [ ] Full benchmark sweep (throttled + non-throttled across all RSC/SSR/Client variants) — optional

> **Note:** this build requires Node.js 20+ (new Fastify 5.8.5 in node-renderer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies for improved stability and performance optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->