### PR TITLE
Fix header navigation wrapping

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,20 +45,21 @@
       });
     </script>
     <header class="border-b border-slate-200 bg-white/95 backdrop-blur">
-      <div class="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 md:flex-row md:items-center md:justify-between">
-        <div>
+      <div class="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-4 xl:flex-row xl:items-center xl:justify-between">
+        <div class="min-w-0 xl:flex-1">
           <a href="/" class="text-xs font-semibold uppercase tracking-[0.28em] text-slate-500">React on Rails Demo</a>
           <p class="mt-1 text-lg font-semibold text-slate-900">LocalHub Marketplace Demo</p>
           <p class="text-sm text-slate-600">Open-source SSR, client, and RSC comparisons built with React on Rails.</p>
         </div>
-        <nav class="flex flex-wrap gap-2 text-sm font-medium">
-          <%= link_to 'Home', '/', class: 'rounded-full border border-slate-200 px-4 py-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-100' %>
-          <%= link_to 'Why RSC', '/why-rsc', class: 'rounded-full border border-slate-200 px-4 py-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-100' %>
-          <%= link_to 'Measure', '/measure', class: 'rounded-full border border-slate-200 px-4 py-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-100' %>
-          <%= link_to 'Source', source_code_path, class: 'rounded-full border border-slate-200 px-4 py-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-100' %>
-          <%= link_to 'Contributing', contributing_guide_path, class: 'rounded-full border border-slate-200 px-4 py-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-100' %>
-          <%= link_to 'Issues', project_issues_path, class: 'rounded-full border border-slate-200 px-4 py-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-100' %>
-          <%= link_to 'Docs', 'https://reactonrails.com/docs', class: 'rounded-full border border-slate-200 px-4 py-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-100' %>
+        <nav class="flex flex-wrap gap-2 text-sm font-medium xl:flex-nowrap xl:justify-end">
+          <% nav_link_classes = 'whitespace-nowrap rounded-full border border-slate-200 px-4 py-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-100' %>
+          <%= link_to 'Home', '/', class: nav_link_classes %>
+          <%= link_to 'Why RSC', '/why-rsc', class: nav_link_classes %>
+          <%= link_to 'Measure', '/measure', class: nav_link_classes %>
+          <%= link_to 'Source', source_code_path, class: nav_link_classes %>
+          <%= link_to 'Contributing', contributing_guide_path, class: nav_link_classes %>
+          <%= link_to 'Issues', project_issues_path, class: nav_link_classes %>
+          <%= link_to 'Docs', 'https://reactonrails.com/docs', class: nav_link_classes %>
         </nav>
       </div>
     </header>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -69,7 +69,7 @@
     </main>
 
     <footer class="border-t border-slate-200 bg-white">
-      <div class="mx-auto flex max-w-6xl flex-col gap-3 px-4 py-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+      <div class="mx-auto flex max-w-7xl flex-col gap-3 px-4 py-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
         <p>Explore the code, compare the rendering strategies, and open a PR when you improve the demo.</p>
         <div class="flex flex-wrap gap-4">
           <%= link_to 'GitHub repo', source_code_path, class: 'transition hover:text-slate-900' %>


### PR DESCRIPTION
## Summary
- Keep the desktop header navigation on a single row at wide viewports.
- Move the side-by-side header layout to the `xl` breakpoint so medium widths stack cleanly instead of squeezing the nav.
- Share the pill link class in one ERB variable and prevent individual labels from breaking with `whitespace-nowrap`.

## Screenshots

### Before
![Before navbar wraps](https://raw.githubusercontent.com/ihabadham/react-on-rails-demo-marketplace-rsc/refs/heads/ihabadham/assets/navbar-layout-screenshots/rsc-navbar-before.png)

### After
![After navbar stays on one row](https://raw.githubusercontent.com/ihabadham/react-on-rails-demo-marketplace-rsc/refs/heads/ihabadham/assets/navbar-layout-screenshots/rsc-navbar-after.png)

## Verification
- Opened the homepage locally and verified the nav links stay on one row at 1280px.
- Verified 1024px uses the stacked header layout with the nav links still on one row.
- Verified narrower widths can wrap intentionally without breaking individual link labels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced application layout responsiveness and navigation styling consistency for improved visual experience across different screen sizes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react-on-rails-demo-marketplace-rsc/pull/53)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->