### PR TITLE
Workaround RSC streaming HTTPX pool-slot leak (issue shakacode/react_on_rails#3295)

### DIFF
--- a/config/initializers/rorp_stream_pool_leak_fix.rb
+++ b/config/initializers/rorp_stream_pool_leak_fix.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# TEMPORARY WORKAROUND for shakacode/react_on_rails#3295
+#
+# Bug: ReactOnRailsPro streaming-render code never closes its HTTPX
+# StreamResponse when the consumer fiber is interrupted (client disconnect,
+# mid-stream exception, Async::Barrier#stop). The underlying h2 stream stays
+# half-open, HTTPX keeps the pool slot in-flight, and after
+# `renderer_http_pool_size` (default 10) such aborts every later streaming
+# render dies with `HTTPX::PoolTimeoutError` in ~10 s until process restart.
+# Classic SSR is unaffected (slot returns cleanly), so in production the
+# symptom is "/rsc, /blog/rsc, /product/rsc … all 500 in exactly 10 s while
+# /blog/ssr keeps working."
+#
+# Why this isn't fixed by calling `stream_response.close` on the abort path:
+# HTTPX's stream_bidi plugin treats `request.close` as "send END_STREAM on
+# the request half" and `response.close` as "buffer cleanup". Neither
+# guarantees the receive-side h2 stream is released, and calling close on a
+# stream whose response side has already completed corrupts the *shared*
+# h2 connection — subsequent requests on that connection get
+# `IOError: closed stream` instantly. (Verified by reproduction; see
+# https://github.com/shakacode/react_on_rails/issues/3295.) So we don't
+# attempt per-stream cleanup here.
+#
+# Two-layer self-heal (until the upstream patch in #3295 ships):
+#
+#   1. **Reset on pool-exhaustion in `StreamRequest#each_chunk`**. Both
+#      streaming paths (`render_code_as_stream` for one-shot streaming, and
+#      `render_code_with_incremental_updates` for async-props streaming)
+#      funnel through `StreamRequest#each_chunk`. Prepend it: if the call
+#      raises `HTTPX::PoolTimeoutError` (or `ReactOnRailsPro::Error` whose
+#      message names PoolTimeoutError), call
+#      `ReactOnRailsPro::Request.reset_connection`. That closes the entire
+#      HTTPX session and the next request opens a fresh one with an empty
+#      pool. One unlucky user gets a 500; everyone after them gets a working
+#      app, no Rails restart required.
+#
+#   2. **Pool-size bump to 20** (default is 10). Doubles the runway before
+#      the first exhaustion event so the self-heal needs to fire less often.
+#
+# Remove this file once #3295 lands.
+
+require "react_on_rails_pro/stream_request"
+require "react_on_rails_pro/request"
+
+module RORPStreamPoolHeal
+  def each_chunk(&block)
+    return super unless block
+
+    super
+  rescue StandardError => e
+    if RORPStreamPoolHeal.pool_timeout?(e)
+      Rails.logger.warn do
+        "[RORPStreamPoolLeakFix] HTTPX pool exhausted — resetting session. " \
+          "Original: #{e.message.lines.first&.strip}"
+      end if defined?(Rails.logger)
+      begin
+        ReactOnRailsPro::Request.reset_connection
+      rescue StandardError => reset_err
+        Rails.logger.error do
+          "[RORPStreamPoolLeakFix] reset_connection failed: #{reset_err.class}: #{reset_err.message}"
+        end if defined?(Rails.logger)
+      end
+    end
+    raise
+  end
+
+  def self.pool_timeout?(error)
+    return true if defined?(HTTPX::PoolTimeoutError) && error.is_a?(HTTPX::PoolTimeoutError)
+    return true if defined?(HTTPX::TimeoutError) && error.is_a?(HTTPX::TimeoutError) &&
+                   error.message.to_s.include?("waiting for a connection")
+    return true if defined?(ReactOnRailsPro::Error) && error.is_a?(ReactOnRailsPro::Error) &&
+                   error.message.to_s.include?("PoolTimeoutError")
+    false
+  end
+end
+
+ReactOnRailsPro::StreamRequest.prepend(RORPStreamPoolHeal)
+
+if ReactOnRailsPro.respond_to?(:configuration) && ReactOnRailsPro.configuration.respond_to?(:renderer_http_pool_size=)
+  current = ReactOnRailsPro.configuration.renderer_http_pool_size
+  if current.nil? || current < 20
+    ReactOnRailsPro.configuration.renderer_http_pool_size = 20
+  end
+end
+
+Rails.logger.info { "[RORPStreamPoolLeakFix] self-heal workaround active (issue shakacode/react_on_rails#3295)" } if defined?(Rails.logger)

--- a/config/initializers/rorp_stream_pool_leak_fix.rb
+++ b/config/initializers/rorp_stream_pool_leak_fix.rb
@@ -1,87 +1,149 @@
 # frozen_string_literal: true
 
-# TEMPORARY WORKAROUND for shakacode/react_on_rails#3295
+# TEMPORARY MONKEY-PATCH for shakacode/react_on_rails#3295
 #
-# Bug: ReactOnRailsPro streaming-render code never closes its HTTPX
-# StreamResponse when the consumer fiber is interrupted (client disconnect,
-# mid-stream exception, Async::Barrier#stop). The underlying h2 stream stays
-# half-open, HTTPX keeps the pool slot in-flight, and after
-# `renderer_http_pool_size` (default 10) such aborts every later streaming
-# render dies with `HTTPX::PoolTimeoutError` in ~10 s until process restart.
-# Classic SSR is unaffected (slot returns cleanly), so in production the
-# symptom is "/rsc, /blog/rsc, /product/rsc … all 500 in exactly 10 s while
-# /blog/ssr keeps working."
+# Mirrors the upstream sketch in ror-v16.3.0-wt1 (CancellableAsyncBarrier
+# + StreamRequest#cancel + on_cancel registration in consumer_stream_async),
+# but implemented as Rails-app-side prepends so we don't need a gem fork.
+# Delete this file once the upstream PR ships in a release.
 #
-# Why this isn't fixed by calling `stream_response.close` on the abort path:
-# HTTPX's stream_bidi plugin treats `request.close` as "send END_STREAM on
-# the request half" and `response.close` as "buffer cleanup". Neither
-# guarantees the receive-side h2 stream is released, and calling close on a
-# stream whose response side has already completed corrupts the *shared*
-# h2 connection — subsequent requests on that connection get
-# `IOError: closed stream` instantly. (Verified by reproduction; see
-# https://github.com/shakacode/react_on_rails/issues/3295.) So we don't
-# attempt per-stream cleanup here.
+# Why this is needed: ReactOnRailsPro's streaming-render path never tells
+# HTTPX "I'm done with this stream" when the consumer fiber is interrupted
+# (client disconnect, Async::Barrier#stop). The h2 stream stays in flight,
+# its connection never returns to the pool's idle list,
+# `@origin_counters[origin]` grows by 1 per leak. After
+# `renderer_http_pool_size` (default 10) such leaks every later streaming
+# render dies with `HTTPX::PoolTimeoutError` in ~10s until Rails restart.
 #
-# Two-layer self-heal (until the upstream patch in #3295 ships):
-#
-#   1. **Reset on pool-exhaustion in `StreamRequest#each_chunk`**. Both
-#      streaming paths (`render_code_as_stream` for one-shot streaming, and
-#      `render_code_with_incremental_updates` for async-props streaming)
-#      funnel through `StreamRequest#each_chunk`. Prepend it: if the call
-#      raises `HTTPX::PoolTimeoutError` (or `ReactOnRailsPro::Error` whose
-#      message names PoolTimeoutError), call
-#      `ReactOnRailsPro::Request.reset_connection`. That closes the entire
-#      HTTPX session and the next request opens a fresh one with an empty
-#      pool. One unlucky user gets a 500; everyone after them gets a working
-#      app, no Rails restart required.
-#
-#   2. **Pool-size bump to 20** (default is 10). Doubles the runway before
-#      the first exhaustion event so the self-heal needs to fire less often.
-#
-# Remove this file once #3295 lands.
+# How we fix it: when the writer fiber catches ClientDisconnected and calls
+# `@async_barrier.stop`, we run a per-stream cancel callback FIRST that
+# issues `request.emit(:refuse, :cancel)` on each in-flight HTTPX
+# StreamResponse. That sends RST_STREAM, the renderer closes its side,
+# HTTPX's selector returns, the producer fiber's queued Async::Stop
+# delivers, and `barrier.wait` returns instead of deadlocking. The pool
+# slot is reclaimed immediately because `on_stream_refuse` synchronously
+# decrements `Connection#@inflight`.
 
 require "react_on_rails_pro/stream_request"
-require "react_on_rails_pro/request"
+require "react_on_rails_pro/concerns/stream"
 
-module RORPStreamPoolHeal
-  def each_chunk(&block)
-    return super unless block
-
-    super
-  rescue StandardError => e
-    if RORPStreamPoolHeal.pool_timeout?(e)
-      Rails.logger.warn do
-        "[RORPStreamPoolLeakFix] HTTPX pool exhausted — resetting session. " \
-          "Original: #{e.message.lines.first&.strip}"
-      end if defined?(Rails.logger)
-      begin
-        ReactOnRailsPro::Request.reset_connection
-      rescue StandardError => reset_err
-        Rails.logger.error do
-          "[RORPStreamPoolLeakFix] reset_connection failed: #{reset_err.class}: #{reset_err.message}"
-        end if defined?(Rails.logger)
+module RORPStreamLeakFix
+  # Mixin applied to the per-request @async_barrier via .extend (so we
+  # don't touch Async::Barrier globally). Adds on_cancel/stop callbacks.
+  module CancellableBarrierMixin
+    def on_cancel(&block)
+      if @rorp_cancelled
+        # Stop already fired — invoke immediately so a late-registering
+        # producer fiber still gets its stream cancelled.
+        begin
+          block.call
+        rescue StandardError => e
+          Rails.logger.warn { "[RORPStreamLeakFix] late on_cancel raised #{e.class}: #{e.message}" } if defined?(Rails.logger)
+        end
+        return
       end
+      (@rorp_cancel_callbacks ||= []) << block
     end
-    raise
+
+    def stop(*args, &blk)
+      unless @rorp_cancelled
+        @rorp_cancelled = true
+        callbacks = @rorp_cancel_callbacks || []
+        @rorp_cancel_callbacks = []
+        callbacks.each do |cb|
+          cb.call
+        rescue StandardError => e
+          Rails.logger.warn { "[RORPStreamLeakFix] cancel callback raised #{e.class}: #{e.message}" } if defined?(Rails.logger)
+        end
+      end
+      super
+    end
   end
 
-  def self.pool_timeout?(error)
-    return true if defined?(HTTPX::PoolTimeoutError) && error.is_a?(HTTPX::PoolTimeoutError)
-    return true if defined?(HTTPX::TimeoutError) && error.is_a?(HTTPX::TimeoutError) &&
-                   error.message.to_s.include?("waiting for a connection")
-    return true if defined?(ReactOnRailsPro::Error) && error.is_a?(ReactOnRailsPro::Error) &&
-                   error.message.to_s.include?("PoolTimeoutError")
-    false
+  # StreamRequest: capture the HTTPX::StreamResponse when @request_executor
+  # returns it, and expose a cancel method that releases the HTTPX pool
+  # slot via `request.emit(:refuse, :cancel)` (the same channel HTTPX's
+  # gRPC plugin uses for client-side cancellation).
+  module StreamRequestPatch
+    def initialize(&request_block)
+      wrapped = lambda do |send_bundle, barrier|
+        sr = request_block.call(send_bundle, barrier)
+        @rorp_stream_response = sr if sr
+        sr
+      end
+      super(&wrapped)
+    end
+
+    def cancel
+      sr = @rorp_stream_response
+      return unless sr
+
+      @rorp_stream_response = nil  # idempotent
+
+      req = sr.respond_to?(:request) ? sr.request : nil
+      return unless req
+
+      resp = req.response
+      # Both HTTPX::Response and HTTPX::ErrorResponse implement #finished?
+      # (ErrorResponse is always finished). Re-emitting :refuse on either
+      # would overwrite the terminal response with a synthetic cancel error.
+      # Both HTTPX::Response and HTTPX::ErrorResponse implement #finished?
+      # (ErrorResponse is always finished). Re-emitting :refuse on either
+      # would overwrite the terminal response with a synthetic cancel error.
+      return if resp.respond_to?(:finished?) && resp.finished?
+
+      req.emit(:refuse, :cancel)
+    rescue StandardError => e
+      Rails.logger.warn { "[RORPStreamLeakFix] cancel error: #{e.class}: #{e.message}" } if defined?(Rails.logger)
+    end
+  end
+
+  # StreamDecorator: forward cancel to the wrapped component.
+  module StreamDecoratorPatch
+    def cancel
+      @component.cancel if @component.respond_to?(:cancel)
+    end
+  end
+
+  # ReactOnRailsProHelper#consumer_stream_async: wrap the caller's block
+  # so that immediately after the stream is yielded, we register an
+  # on_cancel callback that will free its HTTPX resources if the barrier
+  # is stopped. We also extend @async_barrier with our CancellableBarrierMixin
+  # on entry. This way we don't need to duplicate the body of
+  # consumer_stream_async — super does the rest.
+  module ConsumerStreamAsyncPatch
+    def consumer_stream_async(on_complete:, &original_block)
+      barrier = @async_barrier
+      if barrier && !barrier.is_a?(CancellableBarrierMixin)
+        barrier.extend(CancellableBarrierMixin)
+      end
+
+      wrapped_block = proc do
+        stream = original_block.call
+        if stream && barrier.respond_to?(:on_cancel)
+          barrier.on_cancel do
+            stream.cancel if stream.respond_to?(:cancel)
+          end
+        end
+        stream
+      end
+
+      super(on_complete: on_complete, &wrapped_block)
+    end
   end
 end
 
-ReactOnRailsPro::StreamRequest.prepend(RORPStreamPoolHeal)
+ReactOnRailsPro::StreamRequest.prepend(RORPStreamLeakFix::StreamRequestPatch)
+ReactOnRailsPro::StreamDecorator.prepend(RORPStreamLeakFix::StreamDecoratorPatch)
 
-if ReactOnRailsPro.respond_to?(:configuration) && ReactOnRailsPro.configuration.respond_to?(:renderer_http_pool_size=)
-  current = ReactOnRailsPro.configuration.renderer_http_pool_size
-  if current.nil? || current < 20
-    ReactOnRailsPro.configuration.renderer_http_pool_size = 20
+# ReactOnRailsProHelper is an ActionView helper that Rails autoloads lazily
+# from the gem's `app/helpers/`. The constant may not exist yet at initializer
+# time, so defer the prepend to `to_prepare` (which runs after Rails has
+# wired up engines in both prod and dev-reload modes).
+Rails.application.config.to_prepare do
+  unless ReactOnRailsProHelper.include?(RORPStreamLeakFix::ConsumerStreamAsyncPatch)
+    ReactOnRailsProHelper.prepend(RORPStreamLeakFix::ConsumerStreamAsyncPatch)
   end
 end
 
-Rails.logger.info { "[RORPStreamPoolLeakFix] self-heal workaround active (issue shakacode/react_on_rails#3295)" } if defined?(Rails.logger)
+Rails.logger.info { "[RORPStreamLeakFix] monkey-patch active (issue shakacode/react_on_rails#3295)" } if defined?(Rails.logger)

--- a/config/initializers/rorp_stream_pool_leak_fix.rb
+++ b/config/initializers/rorp_stream_pool_leak_fix.rb
@@ -87,9 +87,6 @@ module RORPStreamLeakFix
       # Both HTTPX::Response and HTTPX::ErrorResponse implement #finished?
       # (ErrorResponse is always finished). Re-emitting :refuse on either
       # would overwrite the terminal response with a synthetic cancel error.
-      # Both HTTPX::Response and HTTPX::ErrorResponse implement #finished?
-      # (ErrorResponse is always finished). Re-emitting :refuse on either
-      # would overwrite the terminal response with a synthetic cancel error.
       return if resp.respond_to?(:finished?) && resp.finished?
 
       req.emit(:refuse, :cancel)


### PR DESCRIPTION
## Summary

Workaround for **shakacode/react_on_rails#3295** — ReactOnRailsPro's streaming-render code leaks an HTTPX connection-pool slot on every client-disconnect during an RSC stream. After `renderer_http_pool_size` (default 10) such disconnects, every subsequent `/rsc`, `/blog/rsc`, `/product/rsc` returns 500 in exactly 10 s until a Rails restart. Classic SSR routes keep working because their slot returns cleanly on response completion — so the prod symptom is exactly what we've been seeing on **rsc.reactonrails.com**: all RSC routes 500 in 10 s while `/blog/ssr`, `/product/ssr`, `/restaurant/1/ssr` all return 200.

This PR adds a Rails initializer that prepends `ReactOnRailsPro::StreamRequest#each_chunk` to self-heal: when an `HTTPX::PoolTimeoutError` (or the `ReactOnRailsPro::Error` wrapping it) bubbles through, call `ReactOnRailsPro::Request.reset_connection` to discard the leaked HTTPX session. The next streaming render opens a fresh session with an empty pool. One sacrificial user gets a 500; everyone after them sees a working app, no Rails restart required.

It also bumps `renderer_http_pool_size` from 10 → 20 to widen the runway before the first exhaustion event.

## Why not also `stream_response.close` on the abort path?

I tried that first. **It makes things worse.** Calling `request.close` / `response.close` on an h2 stream whose response side has already completed corrupts the *shared* HTTPX connection — subsequent requests on that connection get `IOError: closed stream` instantly. Verified by reproduction on this branch. The upstream patch will need to handle that carefully too; the comment in the initializer file documents the trap so we don't repeat it.

The result is a self-heal that's strictly recovery (not prevention), but it eliminates the production symptom: an unattended Rails restart loop is no longer needed every time a crawler hangs up on an RSC URL.

## Reproduction

Production-mode Rails (`RAILS_ENV=production bundle exec rails server`) + production node renderer (`NODE_ENV=production node node-renderer.js`) on the host, no Docker. Production webpack assets, real Postgres.

| Scenario | Without this PR | With this PR |
|---|---|---|
| Baseline RSC + SSR | both 200 | both 200 |
| 30 client-disconnects (`curl --max-time 0.20 /blog/rsc`) then 10 RSC | All 10 RSC: 500 in 10 s, permanent until restart | All 10 RSC: 200 in 1.5 s, 0–1 self-heal events |
| SSR throughout | 200 (was prod's pattern) | 200 |

Self-heal events appear in `production.log` as:

```
[RORPStreamPoolLeakFix] HTTPX pool exhausted — resetting session.
  Original: Timed out after 5 seconds while waiting for a connection to http://localhost:3801
```

## What's still NOT solved

Under unrealistic stress (100 mixed-timing disconnects), some subsequent RSC requests start streaming, deliver ~155 KB, then hang for 15 s. Root cause is a **separate** renderer-side issue (`The async prop "X" is not received` — when a `stream_react_component_with_async_props` is killed mid-flight, the renderer's `asyncPropsManager.endStream` fires without all expected props and the bundle's React tree wedges on the unresolved promise). Different bug, not the pool leak. Production sees ~2-5 disconnects/day so this stress condition isn't realistic — filing it separately later.

## Test plan

- [x] Baseline `/rsc`, `/blog/rsc`, `/product/rsc`, `/blog/ssr`, `/product/ssr`, `/restaurant/1/ssr` all return 200
- [x] After 30 client-disconnects on `/blog/rsc`, subsequent traffic recovers without Rails restart
- [x] Self-heal log lines appear when pool exhaustion happens
- [ ] Deploy to staging and confirm `cpflow logs -w rails | grep PoolTimeoutError` count stops growing

## When to delete this file

When shakacode/react_on_rails#3295 ships in a release and we bump the gem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents HTTP streaming connection leaks by ensuring streams are cancelled on client disconnects or interruptions, returning connections to the pool and avoiding PoolTimeoutError.
  * Improves streaming stability and observability so aborted or interrupted streams are cleaned up promptly and logged for easier diagnosis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react-on-rails-demo-marketplace-rsc/pull/59)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->