### PR TITLE
Add app links to Lighthouse compare

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "uri"
+
 class PagesController < ApplicationController
   REPORTS_DIR = Rails.root.join("public/lighthouse-reports")
   REPORT_BASENAME_RE = /\A([a-z0-9_-]+)_(ssr|client|rsc)-(desktop|mobile)\z/.freeze
@@ -24,6 +26,11 @@ class PagesController < ApplicationController
     # Default the slug + strategy display name from whichever side matches a known feature
     @feature_slug = @left_meta[:slug]
     @strategy     = @left_meta[:strategy]
+
+    @app_urls = { @left => @left_data[:app_url], @right => @right_data[:app_url] }
+    if @left_meta[:slug] == @right_meta[:slug] && @left_meta[:strategy] == @right_meta[:strategy]
+      @app_urls.merge!(app_urls_for(@feature_slug, @strategy))
+    end
   end
 
   private
@@ -50,6 +57,30 @@ class PagesController < ApplicationController
       si:        a["speed-index"]["numericValue"].to_f,
       bootup:    a["bootup-time"]["numericValue"].to_f,
       transfer:  a["total-byte-weight"]["numericValue"].to_f,
+      app_url:   app_url_from_report(j),
     }
+  end
+
+  def app_urls_for(slug, strategy)
+    %w[ssr client rsc].each_with_object({}) do |variant, urls|
+      basename = "#{slug}_#{variant}-#{strategy}"
+      urls[basename] = app_url_for_report(basename) if valid_report?(basename)
+    end
+  end
+
+  def app_url_for_report(name)
+    app_url_from_report(JSON.parse(File.read(REPORTS_DIR.join("#{name}.json"))))
+  end
+
+  def app_url_from_report(report)
+    raw_url = report["finalDisplayedUrl"].to_s
+    raw_url = report["finalUrl"].to_s if raw_url.empty?
+    return if raw_url.empty?
+
+    uri = URI.parse(raw_url)
+    path = uri.path.empty? ? "/" : uri.path
+    uri.query ? "#{path}?#{uri.query}" : path
+  rescue URI::InvalidURIError
+    raw_url
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -27,9 +27,16 @@ class PagesController < ApplicationController
     @feature_slug = @left_meta[:slug]
     @strategy     = @left_meta[:strategy]
 
+    # Seed from the two reports already parsed in load_report above; only the
+    # remaining variant (if any) still needs its JSON read.
     @app_urls = { @left => @left_data[:app_url], @right => @right_data[:app_url] }
     if @left_meta[:slug] == @right_meta[:slug] && @left_meta[:strategy] == @right_meta[:strategy]
-      @app_urls.merge!(app_urls_for(@feature_slug, @strategy))
+      %w[ssr client rsc].each do |variant|
+        basename = "#{@feature_slug}_#{variant}-#{@strategy}"
+        next if @app_urls.key?(basename) || !valid_report?(basename)
+
+        @app_urls[basename] = app_url_for_report(basename)
+      end
     end
   end
 
@@ -59,13 +66,6 @@ class PagesController < ApplicationController
       transfer:  a["total-byte-weight"]["numericValue"].to_f,
       app_url:   app_url_from_report(j),
     }
-  end
-
-  def app_urls_for(slug, strategy)
-    %w[ssr client rsc].each_with_object({}) do |variant, urls|
-      basename = "#{slug}_#{variant}-#{strategy}"
-      urls[basename] = app_url_for_report(basename) if valid_report?(basename)
-    end
   end
 
   def app_url_for_report(name)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -81,6 +81,6 @@ class PagesController < ApplicationController
     path = uri.path.empty? ? "/" : uri.path
     uri.query ? "#{path}?#{uri.query}" : path
   rescue URI::InvalidURIError
-    raw_url
+    nil
   end
 end

--- a/app/views/pages/lh_compare.html.erb
+++ b/app/views/pages/lh_compare.html.erb
@@ -28,11 +28,18 @@
   # Build pair-selector buttons. For the same feature/strategy we expose all three
   # interesting pairs: SSR↔RSC, Client↔RSC, SSR↔Client.
   pairs = []
+  app_links = []
   if same_feature && same_strategy
     %w[ssr client].each do |v|
       pairs << { left: "#{@feature_slug}_#{v}-#{@strategy}", right: "#{@feature_slug}_rsc-#{@strategy}", label: "#{variant_label[v]} vs RSC" }
     end
     pairs << { left: "#{@feature_slug}_ssr-#{@strategy}", right: "#{@feature_slug}_client-#{@strategy}", label: "SSR vs Client" }
+
+    %w[ssr client rsc].each do |v|
+      basename = "#{@feature_slug}_#{v}-#{@strategy}"
+      app_url = @app_urls[basename]
+      app_links << { basename: basename, url: app_url, label: "#{variant_label[v]} app" } if app_url
+    end
   end
 
   current_pair_key = "#{@left}|#{@right}"
@@ -85,6 +92,19 @@
         <a href="/lh-compare?left=<%= @right %>&right=<%= @left %>" class="rounded-full px-3 py-1 border border-white/30 text-white/80 hover:bg-white/10 hover:border-white/50" title="Swap left ↔ right">
           ⇄ Swap
         </a>
+      </div>
+    <% end %>
+
+    <% if app_links.any? %>
+      <div class="flex flex-wrap items-center gap-2 mt-3 text-xs">
+        <span class="text-slate-400 font-medium uppercase tracking-wider mr-1">Apps:</span>
+        <% app_links.each do |app| %>
+          <% active = [@left, @right].include?(app[:basename]) %>
+          <a href="<%= app[:url] %>" target="_blank" rel="noopener"
+             class="rounded-full px-3 py-1 border <%= active ? "bg-white/15 border-white text-white font-semibold" : "border-white/30 text-white/80 hover:bg-white/10 hover:border-white/50" %>">
+            <%= app[:label] %> ↗
+          </a>
+        <% end %>
       </div>
     <% end %>
   </div>
@@ -174,7 +194,12 @@
             <span class="text-slate-300">·</span>
             <code class="text-slate-500"><%= basename %></code>
           </div>
-          <a href="/lighthouse-reports/<%= basename %>.html" target="_blank" rel="noopener" class="text-xs text-indigo-600 hover:underline">Open standalone ↗</a>
+          <div class="flex items-center gap-3">
+            <% if @app_urls[basename] %>
+              <a href="<%= @app_urls[basename] %>" target="_blank" rel="noopener" class="text-xs text-emerald-700 hover:underline">Open app ↗</a>
+            <% end %>
+            <a href="/lighthouse-reports/<%= basename %>.html" target="_blank" rel="noopener" class="text-xs text-indigo-600 hover:underline">Open standalone ↗</a>
+          </div>
         </div>
         <iframe
           src="/lighthouse-reports/<%= basename %>.html"


### PR DESCRIPTION
## Summary
- derive measured app URLs from Lighthouse report metadata
- add SSR/Client/RSC app links to the compare page header
- add per-panel Open app links next to standalone Lighthouse report links

## Screenshots

### Header app links

#### Before
![Before: compare header without app links](https://github.com/user-attachments/assets/e9907746-155f-4b5a-9876-60d32a0cb56c)

#### After
![After: compare header with SSR, Client, and RSC app links](https://github.com/user-attachments/assets/6d64bfd8-caac-4f8b-a018-604d185cb383)

### Report panel Open app links

#### Before
![Before: Lighthouse report panel header without Open app links](https://github.com/user-attachments/assets/2a83ff05-de0f-4842-8b60-6241a80389e1)

#### After
![After: Lighthouse report panel header with Open app links](https://github.com/user-attachments/assets/3fca0c3c-0664-46ec-83ec-797bb4fbda68)

## Validation
- ruby -c app/controllers/pages_controller.rb
- erb -x -T - app/views/pages/lh_compare.html.erb | ruby -c
- bin/rails runner render check for compare app links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Open app" links in Lighthouse report comparisons, enabling direct access to tested applications (SSR, Client, and RSC variants) when comparing reports with matching feature and strategy.
  * App URLs are now automatically extracted from report data and displayed in the comparison interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react-on-rails-demo-marketplace-rsc/pull/60)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

