### PR TITLE
chore: bump react_on_rails to 16.7.0.rc.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,12 +17,8 @@ gem 'turbo-rails'
 gem 'stimulus-rails'
 
 # React on Rails
-gem 'react_on_rails', git: 'https://github.com/shakacode/react_on_rails.git',
-                       branch: 'upcoming-v16.3.0',
-                       glob: 'react_on_rails/*.gemspec'
-gem 'react_on_rails_pro', git: 'https://github.com/shakacode/react_on_rails.git',
-                            branch: 'upcoming-v16.3.0',
-                            glob: 'react_on_rails_pro/*.gemspec'
+gem 'react_on_rails', '16.7.0.rc.0'
+gem 'react_on_rails_pro', '16.7.0.rc.0'
 gem 'httpx', '~> 1.7'
 
 # Shakapacker for webpack integration

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,3 @@
-GIT
-  remote: https://github.com/shakacode/react_on_rails.git
-  revision: 3d571c327af034c81af4a31e785841195a0a2b7d
-  branch: upcoming-v16.3.0
-  glob: react_on_rails/*.gemspec
-  specs:
-    react_on_rails (16.7.0.rc.0)
-      addressable
-      connection_pool
-      execjs (~> 2.5)
-      rails (>= 5.2)
-      rainbow (~> 3.0)
-      shakapacker (>= 6.0)
-
-GIT
-  remote: https://github.com/shakacode/react_on_rails.git
-  revision: 3d571c327af034c81af4a31e785841195a0a2b7d
-  branch: upcoming-v16.3.0
-  glob: react_on_rails_pro/*.gemspec
-  specs:
-    react_on_rails_pro (16.7.0.rc.0)
-      addressable
-      async (>= 2.29)
-      connection_pool
-      execjs (~> 2.9)
-      http-2 (>= 1.1.1)
-      httpx (~> 1.5)
-      jwt (~> 2.7)
-      rainbow
-      react_on_rails (= 16.7.0.rc.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -183,7 +152,7 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     json (2.19.3)
-    jwt (2.10.2)
+    jwt (3.2.0)
       base64
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
@@ -309,6 +278,23 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    react_on_rails (16.7.0.rc.0)
+      addressable
+      connection_pool
+      execjs (~> 2.5)
+      rails (>= 5.2)
+      rainbow (~> 3.0)
+      shakapacker (>= 6.0)
+    react_on_rails_pro (16.7.0.rc.0)
+      addressable
+      async (>= 2.29)
+      connection_pool
+      execjs (~> 2.9)
+      http-2 (>= 1.1.1)
+      httpx (~> 1.5)
+      jwt (>= 3.2.0)
+      rainbow
+      react_on_rails (= 16.7.0.rc.0)
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -433,8 +419,8 @@ DEPENDENCIES
   pry-byebug (~> 3.12)
   puma (~> 6.0)
   rails (~> 7.1)
-  react_on_rails!
-  react_on_rails_pro!
+  react_on_rails (= 16.7.0.rc.0)
+  react_on_rails_pro (= 16.7.0.rc.0)
   rspec-rails (~> 6.1)
   rubocop
   rubocop-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GIT
   branch: upcoming-v16.3.0
   glob: react_on_rails/*.gemspec
   specs:
-    react_on_rails (16.6.0)
+    react_on_rails (16.7.0.rc.0)
       addressable
       connection_pool
       execjs (~> 2.5)
@@ -18,7 +18,7 @@ GIT
   branch: upcoming-v16.3.0
   glob: react_on_rails_pro/*.gemspec
   specs:
-    react_on_rails_pro (16.6.0)
+    react_on_rails_pro (16.7.0.rc.0)
       addressable
       async (>= 2.29)
       connection_pool
@@ -27,7 +27,7 @@ GIT
       httpx (~> 1.5)
       jwt (~> 2.7)
       rainbow
-      react_on_rails (= 16.6.0)
+      react_on_rails (= 16.7.0.rc.0)
 
 GEM
   remote: https://rubygems.org/

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "marked-highlight": "^2.2.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-on-rails-pro": "github:shakacode/react-on-rails-builds#upcoming-v16.3.0&path:react-on-rails-pro",
-    "react-on-rails-pro-node-renderer": "github:shakacode/react-on-rails-builds#upcoming-v16.3.0&path:react-on-rails-pro-node-renderer",
+    "react-on-rails-pro": "16.7.0-rc.0",
+    "react-on-rails-pro-node-renderer": "16.7.0-rc.0",
     "react-on-rails-rsc": "github:shakacode/react_on_rails_rsc#update-rsc-19.0.3-fouc-runtime-chunk-fixes",
     "sanitize-html": "^2.17.3",
     "simple-statistics": "^7.8.9",
@@ -52,7 +52,7 @@
   },
   "pnpm": {
     "overrides": {
-      "react-on-rails": "github:shakacode/react-on-rails-builds#upcoming-v16.3.0&path:react-on-rails",
+      "react-on-rails": "16.7.0-rc.0",
       "shakapacker": "9.5.0"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  react-on-rails: github:shakacode/react-on-rails-builds#upcoming-v16.3.0&path:react-on-rails
+  react-on-rails: 16.7.0-rc.0
   shakapacker: 9.5.0
 
 importers:
@@ -70,11 +70,11 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       react-on-rails-pro:
-        specifier: github:shakacode/react-on-rails-builds#upcoming-v16.3.0&path:react-on-rails-pro
-        version: git+https://git@github.com:shakacode/react-on-rails-builds.git#ed307cb818f39e758873cca3c6ea263dedb24b37&path:react-on-rails-pro(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@https://codeload.github.com/shakacode/react_on_rails_rsc/tar.gz/98cf92f0f6e792c5390640c550977713d7183dc7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4)
+        specifier: 16.7.0-rc.0
+        version: 16.7.0-rc.0(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@https://codeload.github.com/shakacode/react_on_rails_rsc/tar.gz/98cf92f0f6e792c5390640c550977713d7183dc7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4)
       react-on-rails-pro-node-renderer:
-        specifier: github:shakacode/react-on-rails-builds#upcoming-v16.3.0&path:react-on-rails-pro-node-renderer
-        version: git+https://git@github.com:shakacode/react-on-rails-builds.git#ed307cb818f39e758873cca3c6ea263dedb24b37&path:react-on-rails-pro-node-renderer
+        specifier: 16.7.0-rc.0
+        version: 16.7.0-rc.0
       react-on-rails-rsc:
         specifier: github:shakacode/react_on_rails_rsc#update-rsc-19.0.3-fouc-runtime-chunk-fixes
         version: https://codeload.github.com/shakacode/react_on_rails_rsc/tar.gz/98cf92f0f6e792c5390640c550977713d7183dc7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
@@ -1753,6 +1753,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -4009,9 +4010,8 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
-  react-on-rails-pro-node-renderer@git+https://git@github.com:shakacode/react-on-rails-builds.git#ed307cb818f39e758873cca3c6ea263dedb24b37&path:react-on-rails-pro-node-renderer:
-    resolution: {commit: ed307cb818f39e758873cca3c6ea263dedb24b37, path: react-on-rails-pro-node-renderer, repo: git@github.com:shakacode/react-on-rails-builds.git, type: git}
-    version: 16.6.0
+  react-on-rails-pro-node-renderer@16.7.0-rc.0:
+    resolution: {integrity: sha512-kgm8iuoyT1I2DPID0AWTaSjIuVbiW39vTBBouEZ2adxzX2+YKVpuBGQgTaRedTUPcdCkuVTnSNPIgcmkY9FNmw==}
     peerDependencies:
       '@honeybadger-io/js': '>=4.0.0'
       '@sentry/node': '>=5.0.0 <11.0.0'
@@ -4024,9 +4024,9 @@ packages:
       '@sentry/tracing':
         optional: true
 
-  react-on-rails-pro@git+https://git@github.com:shakacode/react-on-rails-builds.git#ed307cb818f39e758873cca3c6ea263dedb24b37&path:react-on-rails-pro:
-    resolution: {commit: ed307cb818f39e758873cca3c6ea263dedb24b37, path: react-on-rails-pro, repo: git@github.com:shakacode/react-on-rails-builds.git, type: git}
-    version: 16.6.0
+  react-on-rails-pro@16.7.0-rc.0:
+    resolution: {integrity: sha512-gy7PgXJZokaDepBVnqPIzINAhxJiBYbkGN0BHu/chRjhW2L7CJO/PC5pLnWnaV6CBu8AJipM+oNBiUpEXUyA6A==}
+    version: 16.7.0-rc.0
     peerDependencies:
       '@tanstack/react-router': '>=1.139.0 <2.0.0'
       react: '>= 16'
@@ -4046,9 +4046,8 @@ packages:
       react-dom: ^19.0.3
       webpack: ^5.59.0
 
-  react-on-rails@git+https://git@github.com:shakacode/react-on-rails-builds.git#ed307cb818f39e758873cca3c6ea263dedb24b37&path:react-on-rails:
-    resolution: {commit: ed307cb818f39e758873cca3c6ea263dedb24b37, path: react-on-rails, repo: git@github.com:shakacode/react-on-rails-builds.git, type: git}
-    version: 16.6.0
+  react-on-rails@16.7.0-rc.0:
+    resolution: {integrity: sha512-81Lu9ToSlunduiPQm+R+C+DJ9irdPDFEN3Jvq8dyI6r5uKc9kgfsTiJkyeULjk613RBAT0apkr08GOyhaSe94A==}
     peerDependencies:
       react: '>= 16'
       react-dom: '>= 16'
@@ -9228,7 +9227,7 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-on-rails-pro-node-renderer@git+https://git@github.com:shakacode/react-on-rails-builds.git#ed307cb818f39e758873cca3c6ea263dedb24b37&path:react-on-rails-pro-node-renderer:
+  react-on-rails-pro-node-renderer@16.7.0-rc.0:
     dependencies:
       '@fastify/formbody': 8.0.2
       '@fastify/multipart': 9.4.0
@@ -9238,11 +9237,11 @@ snapshots:
       lockfile: 1.0.4
       pino: 9.14.0
 
-  react-on-rails-pro@git+https://git@github.com:shakacode/react-on-rails-builds.git#ed307cb818f39e758873cca3c6ea263dedb24b37&path:react-on-rails-pro(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@https://codeload.github.com/shakacode/react_on_rails_rsc/tar.gz/98cf92f0f6e792c5390640c550977713d7183dc7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4):
+  react-on-rails-pro@16.7.0-rc.0(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@https://codeload.github.com/shakacode/react_on_rails_rsc/tar.gz/98cf92f0f6e792c5390640c550977713d7183dc7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      react-on-rails: git+https://git@github.com:shakacode/react-on-rails-builds.git#ed307cb818f39e758873cca3c6ea263dedb24b37&path:react-on-rails(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-on-rails: 16.7.0-rc.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
       react-on-rails-rsc: https://codeload.github.com/shakacode/react_on_rails_rsc/tar.gz/98cf92f0f6e792c5390640c550977713d7183dc7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
 
@@ -9255,7 +9254,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.21)(webpack-cli@5.1.4)
       webpack-sources: 3.3.4
 
-  react-on-rails@git+https://git@github.com:shakacode/react-on-rails-builds.git#ed307cb818f39e758873cca3c6ea263dedb24b37&path:react-on-rails(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-on-rails@16.7.0-rc.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)


### PR DESCRIPTION
Refs shakacode/react_on_rails#3360

## RC test checklist

### Automated
- [ ] `bundle install`
- [ ] `pnpm install`
- [ ] `bundle exec rspec`
- [ ] `pnpm run lint`
- [ ] `pnpm run type-check`
- [ ] `pnpm run build`

### Manual
- [ ] Boot the Rails app locally
- [ ] Verify marketplace RSC pages render server and client content correctly
- [ ] Exercise React on Rails Pro node renderer path
- [ ] Check browser console and server logs for hydration/RSC/runtime errors

## Implementation notes

- Updated Ruby manifests for `react_on_rails` and `react_on_rails_pro` to `16.7.0.rc.0`.
- Updated npm manifest specs for `react-on-rails`, `react-on-rails-pro`, and `react-on-rails-pro-node-renderer` to `16.7.0-rc.0`.
- Left `react-on-rails-rsc` unchanged because it is React-versioned and already points at a 19.x RSC branch.
- Left `pnpm-lock.yaml` unchanged because this remote-only environment cannot run `pnpm install`, and I did not want to invent pnpm resolution metadata, git commits, or integrity data.
- `Gemfile.lock` was updated only with the obvious exact `react_on_rails` / `react_on_rails_pro` version-string replacements requested for this matrix pass; a real `bundle install` should refresh source metadata if needed.

## Test notes

Not run in this environment: local clone/install/test execution is blocked for this repo, and this PR was prepared through GitHub remote file updates only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change, but it upgrades the core React-on-Rails integration on both Ruby and Node sides (including `jwt`), which can affect SSR/RSC rendering and the node-renderer runtime.
> 
> **Overview**
> Updates the app to use `react_on_rails` / `react_on_rails_pro` **16.7.0.rc.0** by switching from git-sourced dependencies to the released RC versions in both `Gemfile.lock` and `pnpm-lock.yaml`.
> 
> As part of the bump, Ruby `jwt` is upgraded to **3.2.0** to satisfy the updated `react_on_rails_pro` requirements, and the pnpm lock is refreshed to resolve `react-on-rails(-pro)` and `react-on-rails-pro-node-renderer` to **16.7.0-rc.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e54ccae106535abb01e87143d89c0429b19dd69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->