### PR TITLE
[codex] Add starter reciprocal link

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for local setup, demo guardrails, deplo
 
 - React 19 Server Components: https://react.dev/blog/2024/12/19/react-19
 - react-on-rails: https://github.com/shakacode/react_on_rails
+- React on Rails Starter with TanStack: https://github.com/shakacode/react-on-rails-starter-tanstack - a companion Rails 8 starter for building production apps with React on Rails Pro and TanStack.
 - Web Vitals: https://web.dev/vitals/
 - Streaming HTML: https://web.dev/rendering-on-the-web/
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for local setup, demo guardrails, deplo
 
 - React 19 Server Components: https://react.dev/blog/2024/12/19/react-19
 - react-on-rails: https://github.com/shakacode/react_on_rails
-- React on Rails Starter with TanStack: https://github.com/shakacode/react-on-rails-starter-tanstack - a companion Rails 8 starter for building production apps with React on Rails Pro and TanStack.
+- See also: react-on-rails-starter-tanstack: https://github.com/shakacode/react-on-rails-starter-tanstack - a companion Rails 8 starter for building production apps with React on Rails Pro and TanStack.
 - Web Vitals: https://web.dev/vitals/
 - Streaming HTML: https://web.dev/rendering-on-the-web/
 


### PR DESCRIPTION
## Summary
- Add a related resource link from the Marketplace RSC demo README to the React on Rails Starter with TanStack.

## Validation
- git diff --check
- grep -n https://github.com/shakacode/react-on-rails-starter-tanstack README.md

Refs shakacode/react-on-rails-starter-tanstack#32

@justin808

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime or application impact.
> 
> **Overview**
> Adds a **Related Resources** entry in `README.md` pointing readers to the **react-on-rails-starter-tanstack** companion repo (Rails 8 + React on Rails Pro + TanStack), positioned alongside the existing react-on-rails link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7411c8b4a04fe195d0fde2fd4d8fdb73b7282fc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->