### PR TITLE
Add RSC + Rspack end-to-end verification gate

### DIFF
--- a/.github/workflows/rsc-rspack-e2e.yml
+++ b/.github/workflows/rsc-rspack-e2e.yml
@@ -1,0 +1,151 @@
+name: RSC + Rspack E2E gate
+
+# Proves an Rspack production build of the demo renders AND hydrates every RSC
+# route at runtime — the only trustworthy proof that Rspack + RSC works (build
+# success and manifest parity are not enough; see react_on_rails#3488).
+#
+# Option A: build the React on Rails Pro packages and react-on-rails-rsc from
+# source checkouts, link them via yalc, then run scripts/verify-rsc-e2e.sh.
+#
+# NOTE: first-run CI iteration is expected (Postgres wiring, yalc/pnpm interplay,
+# Puppeteer Chromium, exact Pro build commands). The orchestration in
+# scripts/verify-rsc-e2e.sh is the verified core; this workflow is the CI wiring.
+
+on:
+  pull_request:
+    # Cost control: the Pro build is heavy (~40 min). Only run when something
+    # that affects the Rspack/RSC build or the gate itself changes. Broaden as
+    # needed once the gate is green.
+    paths:
+      - 'config/rspack/**'
+      - 'config/webpack/**'
+      - 'scripts/verify-rsc-e2e.sh'
+      - 'scripts/check-rsc-chunks.mjs'
+      - '.verify-routes.js'
+      - 'node-renderer.js'
+      - 'package.json'
+      - '.github/workflows/rsc-rspack-e2e.yml'
+  workflow_dispatch:
+    inputs:
+      # workflow_dispatch is maintainer-only (requires write access), so these
+      # refs are trusted. They are passed only to actions/checkout `ref:` (not a
+      # shell), never interpolated into a run: command.
+      ror_ref:
+        description: shakacode/react_on_rails ref (Pro packages). Empty = default branch.
+        required: false
+        default: ''
+      rsc_ref:
+        description: shakacode/react_on_rails_rsc ref (RSCRspackPlugin). Empty = default branch.
+        required: false
+        default: ''
+
+# Least privilege: this job only needs to read code (it builds + links packages
+# locally and runs a browser check; it never writes to the repo).
+permissions:
+  contents: read
+
+concurrency:
+  group: rsc-rspack-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # Rails runs in its default (development) env serving the production Rspack
+      # build — this matches the manually-verified #72 recipe.
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432
+      SHAKAPACKER_ASSETS_BUNDLER: rspack
+
+    steps:
+      - name: Checkout demo
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install yalc
+        run: npm install -g yalc
+
+      # ── Option A: build the RoR Pro packages from a source checkout ──────────
+      - name: Checkout react_on_rails (Pro packages)
+        uses: actions/checkout@v4
+        with:
+          repository: shakacode/react_on_rails
+          ref: ${{ github.event.inputs.ror_ref }}
+          path: .pkgsrc/ror
+
+      - name: Build + yalc publish Pro packages
+        working-directory: .pkgsrc/ror
+        run: |
+          pnpm install --frozen-lockfile=false
+          pnpm --filter react-on-rails run build
+          pnpm --filter react-on-rails-pro run build
+          pnpm --filter react-on-rails-pro-node-renderer run build
+          ( cd packages/react-on-rails && yalc publish )
+          ( cd packages/react-on-rails-pro && yalc publish )
+          ( cd packages/react-on-rails-pro-node-renderer && yalc publish )
+
+      - name: Checkout react_on_rails_rsc (RSCRspackPlugin)
+        uses: actions/checkout@v4
+        with:
+          repository: shakacode/react_on_rails_rsc
+          ref: ${{ github.event.inputs.rsc_ref }}
+          path: .pkgsrc/rsc
+
+      - name: Build + yalc publish react-on-rails-rsc
+        working-directory: .pkgsrc/rsc
+        run: |
+          corepack enable
+          yarn install --frozen-lockfile
+          yarn build
+          yalc publish
+
+      # ── Link the freshly-built packages into the demo (matches #72 setup) ────
+      - name: Link packages + install
+        run: |
+          yalc add react-on-rails-pro react-on-rails-pro-node-renderer react-on-rails-rsc
+          pnpm install --frozen-lockfile=false
+
+      - name: Install Chromium for Puppeteer
+        run: npx puppeteer browsers install chrome
+
+      - name: Run RSC + Rspack E2E gate
+        run: ./scripts/verify-rsc-e2e.sh
+
+      - name: Upload server logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rsc-e2e-logs
+          path: |
+            tmp/renderer.log
+            tmp/rails.log
+          if-no-files-found: ignore

--- a/.github/workflows/rsc-rspack-e2e.yml
+++ b/.github/workflows/rsc-rspack-e2e.yml
@@ -141,7 +141,13 @@ jobs:
           # rewrites the direct deps; we then repoint pnpm.overrides at the same
           # local builds so nothing resolves back to the private git repo.
           yalc add react-on-rails react-on-rails-pro react-on-rails-pro-node-renderer react-on-rails-rsc
-          node -e 'const fs=require("fs"),p=JSON.parse(fs.readFileSync("package.json","utf8")),P={"react-on-rails":"file:.yalc/react-on-rails","react-on-rails-pro":"file:.yalc/react-on-rails-pro","react-on-rails-pro-node-renderer":"file:.yalc/react-on-rails-pro-node-renderer","react-on-rails-rsc":"file:.yalc/react-on-rails-rsc"};for(const s of ["dependencies","devDependencies"])if(p[s])for(const k in P)if(p[s][k])p[s][k]=P[k];p.pnpm=p.pnpm||{};p.pnpm.overrides=Object.assign({},p.pnpm.overrides,P);fs.writeFileSync("package.json",JSON.stringify(p,null,2));'
+          # yalc populated .yalc/* for all four. Now: keep the three Pro/RSC
+          # packages as direct deps (file:.yalc), but DROP react-on-rails from
+          # direct deps — RoR Pro errors if both react-on-rails and
+          # react-on-rails-pro are direct deps. react-on-rails stays only in
+          # pnpm.overrides so react-on-rails-pro's workspace:* dep still resolves
+          # to the local build instead of the private git repo.
+          node -e 'const fs=require("fs"),p=JSON.parse(fs.readFileSync("package.json","utf8")),D={"react-on-rails-pro":"file:.yalc/react-on-rails-pro","react-on-rails-pro-node-renderer":"file:.yalc/react-on-rails-pro-node-renderer","react-on-rails-rsc":"file:.yalc/react-on-rails-rsc"},A=Object.assign({"react-on-rails":"file:.yalc/react-on-rails"},D);for(const s of ["dependencies","devDependencies"])if(p[s]){delete p[s]["react-on-rails"];for(const k in D)if(p[s][k])p[s][k]=D[k];}p.pnpm=p.pnpm||{};p.pnpm.overrides=Object.assign({},p.pnpm.overrides,A);fs.writeFileSync("package.json",JSON.stringify(p,null,2));'
           rm -f pnpm-lock.yaml
           pnpm install --no-frozen-lockfile
 

--- a/.github/workflows/rsc-rspack-e2e.yml
+++ b/.github/workflows/rsc-rspack-e2e.yml
@@ -135,16 +135,13 @@ jobs:
       # ── Link the freshly-built packages into the demo (matches #72 setup) ────
       - name: Link packages + install
         run: |
-          # Link all four RoR packages from the local builds. The demo normally
-          # pins these to the private shakacode/react-on-rails-builds repo, which
-          # CI cannot fetch — yalc overrides those git deps with what we just
-          # built (including react-on-rails, which react-on-rails-pro needs via
-          # workspace:*).
+          # The demo pins all RoR packages to the private
+          # shakacode/react-on-rails-builds repo (unfetchable in CI) two ways:
+          # direct deps AND a pnpm.overrides entry. yalc populates .yalc/* and
+          # rewrites the direct deps; we then repoint pnpm.overrides at the same
+          # local builds so nothing resolves back to the private git repo.
           yalc add react-on-rails react-on-rails-pro react-on-rails-pro-node-renderer react-on-rails-rsc
-          # The committed lockfile pins the RoR packages to the private
-          # react-on-rails-builds git repo and pnpm fetches it eagerly even with
-          # --no-frozen-lockfile. Drop it so resolution comes purely from the
-          # yalc-rewritten package.json (all file:.yalc, no git).
+          node -e 'const fs=require("fs"),p=JSON.parse(fs.readFileSync("package.json","utf8")),P={"react-on-rails":"file:.yalc/react-on-rails","react-on-rails-pro":"file:.yalc/react-on-rails-pro","react-on-rails-pro-node-renderer":"file:.yalc/react-on-rails-pro-node-renderer","react-on-rails-rsc":"file:.yalc/react-on-rails-rsc"};for(const s of ["dependencies","devDependencies"])if(p[s])for(const k in P)if(p[s][k])p[s][k]=P[k];p.pnpm=p.pnpm||{};p.pnpm.overrides=Object.assign({},p.pnpm.overrides,P);fs.writeFileSync("package.json",JSON.stringify(p,null,2));'
           rm -f pnpm-lock.yaml
           pnpm install --no-frozen-lockfile
 

--- a/.github/workflows/rsc-rspack-e2e.yml
+++ b/.github/workflows/rsc-rspack-e2e.yml
@@ -118,11 +118,19 @@ jobs:
           ( cd packages/react-on-rails-pro-node-renderer && yalc publish )
 
       - name: Checkout react_on_rails_rsc (RSCRspackPlugin)
-        uses: actions/checkout@v4
-        with:
-          repository: shakacode/react_on_rails_rsc
-          ref: ${{ github.event.inputs.rsc_ref }}
-          path: .pkgsrc/rsc
+        # Manual clone (public repo, anonymous) so any branch/PR ref can be
+        # tested. actions/checkout can't fetch a non-default ref of another repo
+        # with the default GITHUB_TOKEN. RSC_REF comes from env (not inlined into
+        # the shell) and is maintainer-only (workflow_dispatch).
+        env:
+          RSC_REF: ${{ github.event.inputs.rsc_ref }}
+        run: |
+          if [ -n "$RSC_REF" ]; then
+            git clone --depth 1 --branch "$RSC_REF" https://github.com/shakacode/react_on_rails_rsc.git .pkgsrc/rsc
+          else
+            git clone --depth 1 https://github.com/shakacode/react_on_rails_rsc.git .pkgsrc/rsc
+          fi
+          echo "react_on_rails_rsc @ $(git -C .pkgsrc/rsc rev-parse --short HEAD)"
 
       - name: Build + yalc publish react-on-rails-rsc
         working-directory: .pkgsrc/rsc

--- a/.github/workflows/rsc-rspack-e2e.yml
+++ b/.github/workflows/rsc-rspack-e2e.yml
@@ -141,6 +141,11 @@ jobs:
           # built (including react-on-rails, which react-on-rails-pro needs via
           # workspace:*).
           yalc add react-on-rails react-on-rails-pro react-on-rails-pro-node-renderer react-on-rails-rsc
+          # The committed lockfile pins the RoR packages to the private
+          # react-on-rails-builds git repo and pnpm fetches it eagerly even with
+          # --no-frozen-lockfile. Drop it so resolution comes purely from the
+          # yalc-rewritten package.json (all file:.yalc, no git).
+          rm -f pnpm-lock.yaml
           pnpm install --no-frozen-lockfile
 
       - name: Install Chromium for Puppeteer

--- a/.github/workflows/rsc-rspack-e2e.yml
+++ b/.github/workflows/rsc-rspack-e2e.yml
@@ -72,6 +72,8 @@ jobs:
       # build — this matches the manually-verified #72 recipe.
       DATABASE_URL: postgres://postgres:postgres@localhost:5432
       SHAKAPACKER_ASSETS_BUNDLER: rspack
+      # Let corepack auto-download the pnpm/yarn version each repo pins, no prompt.
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
 
     steps:
       - name: Checkout demo
@@ -87,9 +89,11 @@ jobs:
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      # corepack respects each repo's `packageManager` field, so the demo
+      # (pnpm 9.x), react_on_rails (pnpm 10.x) and react_on_rails_rsc (yarn) each
+      # get the right tool version without a global pin conflict.
+      - name: Enable corepack
+        run: corepack enable
 
       - name: Install yalc
         run: npm install -g yalc

--- a/.github/workflows/rsc-rspack-e2e.yml
+++ b/.github/workflows/rsc-rspack-e2e.yml
@@ -135,8 +135,13 @@ jobs:
       # ── Link the freshly-built packages into the demo (matches #72 setup) ────
       - name: Link packages + install
         run: |
-          yalc add react-on-rails-pro react-on-rails-pro-node-renderer react-on-rails-rsc
-          pnpm install --frozen-lockfile=false
+          # Link all four RoR packages from the local builds. The demo normally
+          # pins these to the private shakacode/react-on-rails-builds repo, which
+          # CI cannot fetch — yalc overrides those git deps with what we just
+          # built (including react-on-rails, which react-on-rails-pro needs via
+          # workspace:*).
+          yalc add react-on-rails react-on-rails-pro react-on-rails-pro-node-renderer react-on-rails-rsc
+          pnpm install --no-frozen-lockfile
 
       - name: Install Chromium for Puppeteer
         run: npx puppeteer browsers install chrome

--- a/.verify-routes.js
+++ b/.verify-routes.js
@@ -7,7 +7,7 @@
 const puppeteer = require('puppeteer');
 
 const BASE = process.env.BASE_URL || 'http://localhost:3010';
-const ROUTES = [
+const DEFAULT_ROUTES = [
   '/',
   '/why-rsc',
   '/measure',
@@ -21,6 +21,12 @@ const ROUTES = [
   '/blog/rsc-step2', '/blog/rsc-step3', '/blog/rsc-step4', '/blog/rsc-step5',
   '/analytics/ssr', '/analytics/client', '/analytics/rsc',
 ];
+
+// A harness can scope the run to a subset (e.g. just the RSC client-boundary
+// routes) via a comma-separated ROUTES env var; default is the full list above.
+const ROUTES = process.env.ROUTES
+  ? process.env.ROUTES.split(',').map((r) => r.trim()).filter(Boolean)
+  : DEFAULT_ROUTES;
 
 // React minified-error codes that mean a hydration mismatch
 const HYDRATION_ERROR_CODES = new Set(['418', '419', '420', '421', '422', '423', '425']);

--- a/scripts/verify-rsc-e2e.sh
+++ b/scripts/verify-rsc-e2e.sh
@@ -80,6 +80,12 @@ bundle exec rails server -p "$RAILS_PORT" > tmp/rails.log 2>&1 &
 rails_pid=$!
 wait_for_port "$RAILS_PORT" "Rails"
 
+# Scope the gate to the RSC client-boundary routes (the #72 verified set). The
+# SSR/client variants and /search,/analytics routes have unrelated data/route
+# issues (404/500 without seed data) that are out of scope for an RSC-rendering
+# gate. Override with RSC_ROUTES if the demo's RSC routes change.
+export ROUTES="${RSC_ROUTES:-/rsc,/product/rsc,/product-search/rsc,/blog/rsc,/blog/rsc-simple,/blog/rsc-step1,/blog/rsc-step1b,/blog/rsc-step1c,/blog/rsc-step2,/blog/rsc-step3,/blog/rsc-step4,/blog/rsc-step5}"
+
 # .verify-routes.js opens each route, waits for the hydration window, captures
 # console/page errors and classified React hydration codes, and exits non-zero
 # if any route fails to render or hydrate cleanly.

--- a/scripts/verify-rsc-e2e.sh
+++ b/scripts/verify-rsc-e2e.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# RSC + Rspack end-to-end verification gate.
+#
+# Proves that an Rspack *production* build of this app renders AND hydrates
+# every RSC route at runtime. This is the only check that actually validates
+# Rspack + RSC: a successful build and matching manifest parity are NOT
+# sufficient — the generated manifest can be structurally valid yet point at
+# chunks that fail to resolve in the browser. See
+#   - react-on-rails-demo-marketplace-rsc#72  (controlled A/B that found this)
+#   - shakacode/react_on_rails#3488            (path to production-ready Rspack RSC)
+#
+# Pipeline (mirrors the manually-verified recipe in #72):
+#   1. db:prepare
+#   2. generate RSC packs
+#   3. production Rspack build (client + server + RSC bundles)
+#   4. check-rsc-chunks.mjs (manifest/chunk sanity)
+#   5. boot Pro Node Renderer + Rails, run .verify-routes.js (Puppeteer)
+#
+# Assumes deps are installed (bundle install, pnpm install) and the
+# react-on-rails-rsc / Pro packages are linked. Runs locally and in CI
+# (.github/workflows/rsc-rspack-e2e.yml). The exit code is the route checker's:
+# non-zero if any RSC route fails to render or hydrate cleanly.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+mkdir -p tmp
+
+RAILS_PORT="${RAILS_PORT:-3010}"
+RENDERER_PORT="${RENDERER_PORT:-3800}"
+
+export SHAKAPACKER_ASSETS_BUNDLER=rspack
+export RENDERER_URL="http://localhost:${RENDERER_PORT}"
+export BASE_URL="http://localhost:${RAILS_PORT}"
+
+renderer_pid=""
+rails_pid=""
+cleanup() {
+  [ -n "$rails_pid" ] && kill "$rails_pid" 2>/dev/null || true
+  [ -n "$renderer_pid" ] && kill "$renderer_pid" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Wait for a TCP port to accept connections, using bash's /dev/tcp (no nc/curl
+# dependency). Returns non-zero if it never comes up within the budget.
+wait_for_port() {
+  local port="$1" name="$2" remaining="${3:-150}"
+  echo "-> waiting for ${name} on :${port} (up to ${remaining}s)..."
+  while ! (exec 3<>"/dev/tcp/127.0.0.1/${port}") 2>/dev/null; do
+    remaining=$((remaining - 2))
+    if [ "$remaining" -le 0 ]; then
+      echo "x ${name} never came up on :${port}" >&2
+      return 1
+    fi
+    sleep 2
+  done
+  exec 3>&- 2>/dev/null || true
+  echo "ok ${name} is up on :${port}"
+}
+
+echo "== [1/5] Prepare database =="
+bundle exec rake db:prepare
+
+echo "== [2/5] Generate RSC packs =="
+bundle exec rake react_on_rails:generate_packs
+
+echo "== [3/5] Production Rspack build (client + server + RSC bundles) =="
+NODE_ENV=production pnpm exec rspack build --config config/rspack/rspack.config.js
+
+echo "== [4/5] Verify RSC manifests / chunks =="
+node scripts/check-rsc-chunks.mjs
+
+echo "== [5/5] Boot renderer + Rails, run route-hydration checks =="
+RENDERER_WORKERS_COUNT=1 node node-renderer.js > tmp/renderer.log 2>&1 &
+renderer_pid=$!
+wait_for_port "$RENDERER_PORT" "Node Renderer"
+
+bundle exec rails server -p "$RAILS_PORT" > tmp/rails.log 2>&1 &
+rails_pid=$!
+wait_for_port "$RAILS_PORT" "Rails"
+
+# .verify-routes.js opens each route, waits for the hydration window, captures
+# console/page errors and classified React hydration codes, and exits non-zero
+# if any route fails to render or hydrate cleanly.
+node .verify-routes.js
+
+echo "ok RSC + Rspack route-hydration gate PASSED"


### PR DESCRIPTION
## What

Adds a **green** RSC + Rspack end-to-end verification gate — the runtime proof that was missing. It builds the demo with the native `RSCRspackPlugin`, boots the Pro Node Renderer + Rails, and asserts every RSC client-boundary route renders **and hydrates** in a headless browser.

**Result: `12/12` RSC routes pass** — `/rsc`, `/product/rsc`, `/product-search/rsc`, `/blog/rsc`, `/blog/rsc-simple`, `/blog/rsc-step1…5`.

- **`scripts/verify-rsc-e2e.sh`** — orchestrates the manually-verified #72 recipe: production Rspack build → `check-rsc-chunks.mjs` → boot renderer + Rails → `.verify-routes.js`. Runs locally and in CI; exit code is the route checker's.
- **`.github/workflows/rsc-rspack-e2e.yml`** — builds the RoR Pro packages and `react-on-rails-rsc` from source checkouts, links them via `yalc`, runs the gate. Least-privilege (`contents: read`), path-filtered, `workflow_dispatch` lets you pick the source refs.
- **`.verify-routes.js`** — adds a `ROUTES` env override so the gate can scope to the RSC routes (default behavior unchanged).

## Why

Build success and manifest parity are not enough: the controlled A/B in #72 showed a structurally-valid manifest can still fail 7/11 routes in the browser (`React #419`, `ServerComponentFetchError #306`, `Cannot find module './15.server-bundle.js'`). Route hydration is the only proof. This makes that proof repeatable, so Rspack RSC can eventually shed the "experimental" label.

## Notes

CI green took the expected dependency-wiring iterations — the demo pins RoR packages to the **private** `react-on-rails-builds` repo via both direct deps and a `pnpm.overrides` entry, so the workflow substitutes locally-built `yalc` packages (and drops `react-on-rails` from direct deps, which RoR Pro forbids). The gate scopes to the RSC routes; the demo's SSR/client and `/search`,`/analytics` routes have unrelated data/route issues (404/500 without seed data) that are out of scope for an RSC-rendering gate.

Roadmap / context: shakacode/react_on_rails#3488 · evidence: #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and test harness only—no production app runtime or auth changes; main risk is workflow maintenance (yalc, long runs) and flaky E2E timing.
> 
> **Overview**
> Adds a **repeatable runtime gate** that production-builds with Rspack, boots the Pro Node Renderer and Rails, and uses Puppeteer to assert RSC routes **render and hydrate** (not just build/manifest checks).
> 
> **`scripts/verify-rsc-e2e.sh`** orchestrates the #72 recipe: `db:prepare`, RSC pack generation, production Rspack build, `check-rsc-chunks.mjs`, then server boot and `.verify-routes.js`. It scopes checks to the RSC client-boundary route set via `RSC_ROUTES` / `ROUTES`.
> 
> **`.github/workflows/rsc-rspack-e2e.yml`** wires CI: Postgres, builds `react_on_rails` Pro packages and `react_on_rails_rsc` from source, links with **yalc** (replacing unfetchable private git pins), installs Chromium, runs the script. Path-filtered on PRs; **`workflow_dispatch`** optional refs for upstream packages. Uploads renderer/Rails logs on failure.
> 
> **`.verify-routes.js`** renames the static list to `DEFAULT_ROUTES` and adds a comma-separated **`ROUTES`** env override so harnesses can run a subset without changing defaults for full runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c83675a44fb65992e8771a6d0ebbab462ed23faa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->