### PR TITLE
Clarify review app security guidance

### DIFF
--- a/.controlplane/README.md
+++ b/.controlplane/README.md
@@ -95,12 +95,18 @@ automatically redeploy the review app. `+review-app-delete` deletes the review
 app, and deletion also runs when the PR closes. Stale review apps are cleaned up
 nightly by `.github/workflows/cpflow-cleanup-stale-review-apps.yml`.
 
+In public repositories, generated review-app deploys skip fork PR heads because
+Docker builds use repository secrets. If a forked change needs a review app,
+first move the reviewed change to a trusted branch in this repository. Review
+apps still run pull request code, so same-repository PRs can read any secret
+mounted into the workload.
+
 Configure these GitHub repository secrets before enabling review app deploys:
 
 | Name | Required | Notes |
 | --- | --- | --- |
-| `CPLN_TOKEN_STAGING` | Yes | Control Plane service-account token for `shakacode-open-source-examples-staging`. |
-| `DOCKER_BUILD_SSH_KEY` | Yes for this repo | SSH key that can read the private `shakacode/react-on-rails-builds` dependency during Docker builds. |
+| `CPLN_TOKEN_STAGING` | Yes | Staging/review Control Plane service-account token for `shakacode-open-source-examples-staging`; it must not access production resources. |
+| `DOCKER_BUILD_SSH_KEY` | Yes for this repo | Read-only, revocable deploy key that can read the private `shakacode/react-on-rails-builds` dependency during Docker builds. Do not use a personal SSH key. |
 | `DOCKER_BUILD_EXTRA_ARGS` | Optional | Newline-delimited extra Docker build tokens if the build needs additional `--build-arg` or `--secret` values. |
 
 No review-app repository variables are required while
@@ -118,6 +124,13 @@ SECRET_KEY_BASE
 RENDERER_PASSWORD
 REACT_ON_RAILS_PRO_LICENSE
 ```
+
+Because these values are mounted into workloads that run pull request code, keep
+this dictionary review-safe: use a disposable database, review-only renderer
+credentials, and a Pro license value that is acceptable for review-app exposure.
+Do not point review apps at production or long-lived staging secret
+dictionaries. `cpln://secret/...` protects the value in Control Plane
+configuration, but the value is readable by app code after it is mounted.
 
 Because `DATABASE_URL` points at an external database secret, review app deletion
 does not run `rails db:drop`. Add a per-review-app database template before

--- a/.controlplane/README.md
+++ b/.controlplane/README.md
@@ -95,11 +95,13 @@ automatically redeploy the review app. `+review-app-delete` deletes the review
 app, and deletion also runs when the PR closes. Stale review apps are cleaned up
 nightly by `.github/workflows/cpflow-cleanup-stale-review-apps.yml`.
 
-In public repositories, generated review-app deploys skip fork PR heads because
-Docker builds use repository secrets. If a forked change needs a review app,
-first move the reviewed change to a trusted branch in this repository. Review
-apps still run pull request code, so same-repository PRs can read any secret
-mounted into the workload.
+In public repositories, automatic pull request review-app deploys skip fork PR
+heads because Docker builds use repository secrets. Manual comment or dispatch
+deploys from trusted maintainers can still run PR code, so do not deploy a fork
+PR unless the reviewed change has first been moved to a trusted branch in this
+repository or the wrapper has an explicit fork guard. Review apps still run pull
+request code, so same-repository PRs can read any secret mounted into the
+workload.
 
 Configure these GitHub repository secrets before enabling review app deploys:
 

--- a/.controlplane/templates/app.yml
+++ b/.controlplane/templates/app.yml
@@ -22,6 +22,9 @@ spec:
       value: '2'
     - name: RENDERER_URL
       value: http://localhost:3800
+    # Review apps run pull request code. Values mounted through cpln://secret
+    # become readable by that code after the workload starts, so this dictionary
+    # must contain review-safe database, renderer, and license values.
     - name: SECRET_KEY_BASE
       value: cpln://secret/react-server-components-demo-secrets.SECRET_KEY_BASE
     - name: DATABASE_URL

--- a/.github/cpflow-help.md
+++ b/.github/cpflow-help.md
@@ -23,10 +23,22 @@ For the normal generated review-app path, GitHub needs one repository secret:
 | --- | --- | --- |
 | `CPLN_TOKEN_STAGING` | Repository secret | Control Plane service-account token for the staging/review org. |
 
+For public repositories, use a staging/review token that cannot access
+production Control Plane resources. Generated review-app deploys skip fork PR
+heads because Docker builds use repository secrets. If a forked change needs a
+review app, first move the reviewed change to a trusted branch in this
+repository.
+
 No repository variables are required for the standard review-app path when
 `.controlplane/controlplane.yml` has exactly one review app entry with
 `match_if_app_name_starts_with: true`. cpflow infers the review-app prefix and
 staging org from that config.
+
+Review apps run pull request code. Any value mounted through
+`cpln://secret/...` can be read by that code after the workload starts, so keep
+review-app secret dictionaries limited to disposable databases, review-only
+renderer credentials, and license values that are acceptable for review-app
+exposure.
 
 Optional overrides exist for forks, clones, and unusual apps:
 
@@ -119,7 +131,7 @@ Most apps do not need these:
 | Name | Notes |
 | --- | --- |
 | `DOCKER_BUILD_EXTRA_ARGS` | Newline-delimited extra Docker build tokens. |
-| `DOCKER_BUILD_SSH_KEY` | Private SSH key for Docker builds that fetch private dependencies. |
+| `DOCKER_BUILD_SSH_KEY` | Read-only, revocable deploy key for Docker builds that fetch private dependencies. Do not use a personal SSH key. |
 | `DOCKER_BUILD_SSH_KNOWN_HOSTS` | SSH known_hosts entries when SSH build hosts are not GitHub.com. |
 | `REVIEW_APP_DEPLOYING_ICON_URL` | Cosmetic custom image URL for the animated deploying icon. Set to `none` to use the text fallback icon. |
 | `STAGING_APP_BRANCH` | Custom staging branch. The branch must also appear in `cpflow-deploy-staging.yml`'s push filter. |

--- a/.github/cpflow-help.md
+++ b/.github/cpflow-help.md
@@ -24,10 +24,11 @@ For the normal generated review-app path, GitHub needs one repository secret:
 | `CPLN_TOKEN_STAGING` | Repository secret | Control Plane service-account token for the staging/review org. |
 
 For public repositories, use a staging/review token that cannot access
-production Control Plane resources. Generated review-app deploys skip fork PR
-heads because Docker builds use repository secrets. If a forked change needs a
-review app, first move the reviewed change to a trusted branch in this
-repository.
+production Control Plane resources. Automatic pull request deploys skip fork PR
+heads because Docker builds use repository secrets. Manual comment or dispatch
+deploys from trusted maintainers can still run PR code, so do not deploy a fork
+PR unless the reviewed change has first been moved to a trusted branch in this
+repository or the wrapper has an explicit fork guard.
 
 No repository variables are required for the standard review-app path when
 `.controlplane/controlplane.yml` has exactly one review app entry with


### PR DESCRIPTION
## Summary

- document review-app security expectations for the marketplace RSC demo
- clarify that mounted `cpln://secret/...` values are readable by deployed PR code
- recommend review-safe database, renderer, Pro license, Control Plane token, and SSH deploy-key values

## Verification

- `git diff --check`

Note: local commands print mise trust warnings for this temporary worktree's `mise.toml`, but `git diff --check` exited successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and template comments only; no changes to deployment behavior, secrets, or workflows.
> 
> **Overview**
> This PR **documents review-app security expectations** for the Control Plane Flow demo—no runtime or workflow logic changes.
> 
> **`.controlplane/README.md`** and **`.github/cpflow-help.md`** now explain that review workloads execute **pull request code**, so mounted `cpln://secret/...` values are readable by that code after startup. Operators are told to use **review-safe** secret dictionaries (disposable DB, review-only renderer creds, acceptable Pro license exposure) and **not** production or long-lived staging secrets. **`CPLN_TOKEN_STAGING`** must be scoped to staging/review only; **`DOCKER_BUILD_SSH_KEY`** should be a read-only revocable deploy key, not a personal SSH key.
> 
> **Fork and public-repo behavior** is spelled out: automatic PR deploys skip fork heads (builds need repo secrets); manual deploys from trusted maintainers can still run untrusted PR code—deploy only from trusted branches or with an explicit fork guard.
> 
> **`.controlplane/templates/app.yml`** adds an inline comment above the secret env vars reinforcing that the shared dictionary must stay review-safe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fb6b5c425c1ebb071e0c42ae3b591f97abf1934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->