### PR TITLE
[demo-fleet] Update marketplace-rsc demo dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,15 +17,11 @@ gem 'turbo-rails'
 gem 'stimulus-rails'
 
 # React on Rails
-gem 'react_on_rails', git: 'https://github.com/shakacode/react_on_rails.git',
-                       branch: 'main',
-                       glob: 'react_on_rails/*.gemspec'
-gem 'react_on_rails_pro', git: 'https://github.com/shakacode/react_on_rails.git',
-                            branch: 'main',
-                            glob: 'react_on_rails_pro/*.gemspec'
+gem 'react_on_rails', '17.0.0.rc.0'
+gem 'react_on_rails_pro', '17.0.0.rc.0'
 
 # Shakapacker for webpack integration
-gem 'shakapacker', '~> 9.5'
+gem 'shakapacker', '10.1.0'
 
 # JSON handling
 gem 'jbuilder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,3 @@
-GIT
-  remote: https://github.com/shakacode/react_on_rails.git
-  revision: 6a9fbf938ef6f9db66913fa0c1ae581b4191e2ed
-  branch: main
-  glob: react_on_rails/*.gemspec
-  specs:
-    react_on_rails (16.7.0.rc.2)
-      addressable
-      connection_pool
-      execjs (~> 2.5)
-      rails (>= 5.2)
-      rainbow (~> 3.0)
-      shakapacker (>= 6.0)
-
-GIT
-  remote: https://github.com/shakacode/react_on_rails.git
-  revision: 6a9fbf938ef6f9db66913fa0c1ae581b4191e2ed
-  branch: main
-  glob: react_on_rails_pro/*.gemspec
-  specs:
-    react_on_rails_pro (16.7.0.rc.2)
-      addressable
-      async (>= 2.29)
-      async-http (~> 0.95)
-      execjs (~> 2.9)
-      io-endpoint (~> 0.17.0)
-      jwt (>= 2.5, < 4)
-      rainbow
-      react_on_rails (= 16.7.0.rc.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -128,7 +98,7 @@ GEM
       async (>= 2.0)
     base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (4.1.1)
+    bigdecimal (4.1.2)
     bindex (0.8.1)
     bootsnap (1.19.0)
       msgpack (~> 1.2)
@@ -148,7 +118,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
     connection_pool (2.5.5)
-    console (1.34.3)
+    console (1.35.1)
       fiber-annotation
       fiber-local (~> 1.1)
       json
@@ -159,7 +129,7 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
     drb (2.2.3)
-    erb (6.0.2)
+    erb (6.0.4)
     erubi (1.13.1)
     execjs (2.10.1)
     factory_bot (6.5.6)
@@ -183,9 +153,9 @@ GEM
       railties (>= 6.0.0)
     io-console (0.8.2)
     io-endpoint (0.17.2)
-    io-event (1.15.1)
+    io-event (1.16.1)
     io-stream (0.13.0)
-    irb (1.17.0)
+    irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
@@ -193,7 +163,7 @@ GEM
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.19.3)
+    json (2.19.7)
     jwt (3.2.0)
       base64
     language_server-protocol (3.17.0.5)
@@ -208,16 +178,16 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.2.1)
     matrix (0.4.3)
     method_source (1.1.0)
     metrics (0.15.0)
     mini_mime (1.1.5)
-    minitest (6.0.4)
+    minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -227,21 +197,21 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.2-aarch64-linux-gnu)
+    nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-aarch64-linux-musl)
+    nokogiri (1.19.3-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.2-arm-linux-gnu)
+    nokogiri (1.19.3-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-arm-linux-musl)
+    nokogiri (1.19.3-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.2-arm64-darwin)
+    nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-darwin)
+    nokogiri (1.19.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-musl)
+    nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
     package_json (0.2.0)
     parallel (1.27.0)
@@ -282,7 +252,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
-    rack-proxy (0.7.7)
+    rack-proxy (0.8.2)
       rack
     rack-session (2.1.2)
       base64 (>= 0.1.0)
@@ -323,11 +293,27 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.4.1)
+    rake (13.4.2)
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
       tsort
+    react_on_rails (17.0.0.rc.0)
+      addressable
+      connection_pool
+      execjs (~> 2.5)
+      rails (>= 5.2)
+      rainbow (~> 3.0)
+      shakapacker (>= 6.0)
+    react_on_rails_pro (17.0.0.rc.0)
+      addressable
+      async (>= 2.29)
+      async-http (~> 0.95)
+      execjs (~> 2.9)
+      io-endpoint (~> 0.17.0)
+      jwt (>= 2.5, < 4)
+      rainbow
+      react_on_rails (= 17.0.0.rc.0)
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -382,7 +368,7 @@ GEM
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
     semantic_range (3.1.1)
-    shakapacker (9.5.0)
+    shakapacker (10.1.0)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)
@@ -424,7 +410,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.5)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   aarch64-linux
@@ -451,14 +437,14 @@ DEPENDENCIES
   pry-byebug (~> 3.12)
   puma (~> 6.0)
   rails (~> 7.1)
-  react_on_rails!
-  react_on_rails_pro!
+  react_on_rails (= 17.0.0.rc.0)
+  react_on_rails_pro (= 17.0.0.rc.0)
   rspec-rails (~> 6.1)
   rubocop
   rubocop-rails
   rubocop-rspec
   selenium-webdriver
-  shakapacker (~> 9.5)
+  shakapacker (= 10.1.0)
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/package.json
+++ b/package.json
@@ -43,17 +43,17 @@
     "marked-highlight": "^2.2.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-on-rails-pro": "github:shakacode/react-on-rails-builds#57727588410aefc8fb0dd8b3fb3aa89eb99ff6e3&path:react-on-rails-pro",
-    "react-on-rails-pro-node-renderer": "github:shakacode/react-on-rails-builds#57727588410aefc8fb0dd8b3fb3aa89eb99ff6e3&path:react-on-rails-pro-node-renderer",
-    "react-on-rails-rsc": "file:.yalc/react-on-rails-rsc",
+    "react-on-rails-pro": "17.0.0-rc.0",
+    "react-on-rails-pro-node-renderer": "17.0.0-rc.0",
+    "react-on-rails-rsc": "19.0.5-rc.3",
     "sanitize-html": "^2.17.3",
     "simple-statistics": "^7.8.9",
     "web-vitals": "^4.2.0"
   },
   "pnpm": {
     "overrides": {
-      "react-on-rails": "github:shakacode/react-on-rails-builds#57727588410aefc8fb0dd8b3fb3aa89eb99ff6e3&path:react-on-rails",
-      "shakapacker": "9.5.0"
+      "react-on-rails": "17.0.0-rc.0",
+      "shakapacker": "10.1.0"
     }
   },
   "devDependencies": {
@@ -95,7 +95,7 @@
     "rspack-manifest-plugin": "^5.2.1",
     "sass": "^1.71.0",
     "sass-loader": "^14.1.0",
-    "shakapacker": "^9.5",
+    "shakapacker": "10.1.0",
     "style-loader": "^3.3.0",
     "swc-loader": "^0.2.6",
     "tailwindcss": "^3.4.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  react-on-rails: github:shakacode/react-on-rails-builds#adcff279edd06ad986d0122197abe9e932ed888a&path:react-on-rails
-  shakapacker: 9.5.0
+  react-on-rails: 17.0.0-rc.0
+  shakapacker: 10.1.0
 
 importers:
 
@@ -70,14 +70,14 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       react-on-rails-pro:
-        specifier: github:shakacode/react-on-rails-builds#adcff279edd06ad986d0122197abe9e932ed888a&path:react-on-rails-pro
-        version: git+https://git@github.com:shakacode/react-on-rails-builds.git#adcff279edd06ad986d0122197abe9e932ed888a&path:react-on-rails-pro(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@file:.yalc/react-on-rails-rsc(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4)
+        specifier: 17.0.0-rc.0
+        version: 17.0.0-rc.0(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@19.0.5-rc.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4)
       react-on-rails-pro-node-renderer:
-        specifier: github:shakacode/react-on-rails-builds#adcff279edd06ad986d0122197abe9e932ed888a&path:react-on-rails-pro-node-renderer
-        version: git+https://git@github.com:shakacode/react-on-rails-builds.git#adcff279edd06ad986d0122197abe9e932ed888a&path:react-on-rails-pro-node-renderer
+        specifier: 17.0.0-rc.0
+        version: 17.0.0-rc.0
       react-on-rails-rsc:
-        specifier: file:.yalc/react-on-rails-rsc
-        version: file:.yalc/react-on-rails-rsc(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
+        specifier: 19.0.5-rc.3
+        version: 19.0.5-rc.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
       sanitize-html:
         specifier: ^2.17.3
         version: 2.17.3
@@ -203,8 +203,8 @@ importers:
         specifier: ^14.1.0
         version: 14.2.1(@rspack/core@2.0.3)(sass@1.98.0)(webpack@5.105.4)
       shakapacker:
-        specifier: 9.5.0
-        version: 9.5.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@babel/runtime@7.29.2)(@rspack/cli@2.0.3(@rspack/core@2.0.3))(@rspack/core@2.0.3)(@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.3)(react-refresh@0.14.2))(@swc/core@1.15.21)(babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.105.4))(css-loader@6.11.0(@rspack/core@2.0.3)(webpack@5.105.4))(mini-css-extract-plugin@2.10.1(webpack@5.105.4))(rspack-manifest-plugin@5.2.1(@rspack/core@2.0.3))(sass-loader@14.2.1(@rspack/core@2.0.3)(sass@1.98.0)(webpack@5.105.4))(sass@1.98.0)(swc-loader@0.2.7(@swc/core@1.15.21)(webpack@5.105.4))(terser-webpack-plugin@5.4.0(@swc/core@1.15.21)(webpack@5.105.4))(webpack-assets-manifest@6.5.1(webpack@5.105.4))(webpack-cli@5.1.4)(webpack-dev-server@5.2.3)(webpack@5.105.4)
+        specifier: 10.1.0
+        version: 10.1.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@babel/runtime@7.29.2)(@rspack/cli@2.0.3(@rspack/core@2.0.3))(@rspack/core@2.0.3)(@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.3)(react-refresh@0.14.2))(@swc/core@1.15.21)(babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.105.4))(css-loader@6.11.0(@rspack/core@2.0.3)(webpack@5.105.4))(mini-css-extract-plugin@2.10.1(webpack@5.105.4))(rspack-manifest-plugin@5.2.1(@rspack/core@2.0.3))(sass-loader@14.2.1(@rspack/core@2.0.3)(sass@1.98.0)(webpack@5.105.4))(sass@1.98.0)(swc-loader@0.2.7(@swc/core@1.15.21)(webpack@5.105.4))(terser-webpack-plugin@5.4.0(@swc/core@1.15.21)(webpack@5.105.4))(webpack-assets-manifest@6.5.1(webpack@5.105.4))(webpack-cli@5.1.4)(webpack-dev-server@5.2.3)(webpack@5.105.4)
       style-loader:
         specifier: ^3.3.0
         version: 3.3.4(webpack@5.105.4)
@@ -1869,6 +1869,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -3705,6 +3706,16 @@ packages:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
 
+  pack-config-diff@0.1.0:
+    resolution: {integrity: sha512-gx60G4pnT4GFQ7WECdf7SCq9vdsvBhodLXXzwisy37/t0zkAZ3hMgLCdOGivudF1l0gcLZhIWVYreS89be15QA==}
+    engines: {node: '>=16'}
+    hasBin: true
+    peerDependencies:
+      ts-node: '>=10'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -4125,24 +4136,49 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
-  react-on-rails-pro-node-renderer@git+https://git@github.com:shakacode/react-on-rails-builds.git#adcff279edd06ad986d0122197abe9e932ed888a&path:react-on-rails-pro-node-renderer:
-    resolution: {commit: adcff279edd06ad986d0122197abe9e932ed888a, path: react-on-rails-pro-node-renderer, repo: git@github.com:shakacode/react-on-rails-builds.git, type: git}
-    version: 16.6.0
+  react-on-rails-pro-node-renderer@17.0.0-rc.0:
+    resolution: {integrity: sha512-7UtLwN8oTe9lDTyrfXwepauBH3K0qPK1Lmm3Lv0+3QOg+qHRIIq4Oli3IeWlM+TO38V8/XjtUIi4BjpigOZb6Q==}
     peerDependencies:
+      '@fastify/otel': '>=0.18.0 <1.0.0'
       '@honeybadger-io/js': '>=4.0.0'
+      '@opentelemetry/api': '>=1.9.0 <2.0.0'
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.214.0 <1.0.0'
+      '@opentelemetry/instrumentation': '>=0.214.0 <1.0.0'
+      '@opentelemetry/instrumentation-http': '>=0.214.0 <1.0.0'
+      '@opentelemetry/resources': '>=2.0.0 <3.0.0'
+      '@opentelemetry/sdk-trace-base': '>=2.0.0 <3.0.0'
+      '@opentelemetry/sdk-trace-node': '>=2.0.0 <3.0.0'
+      '@opentelemetry/semantic-conventions': '>=1.36.0 <2.0.0'
       '@sentry/node': '>=5.0.0 <11.0.0'
       '@sentry/tracing': '>=5.0.0'
     peerDependenciesMeta:
+      '@fastify/otel':
+        optional: true
       '@honeybadger-io/js':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/instrumentation-http':
+        optional: true
+      '@opentelemetry/resources':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/sdk-trace-node':
+        optional: true
+      '@opentelemetry/semantic-conventions':
         optional: true
       '@sentry/node':
         optional: true
       '@sentry/tracing':
         optional: true
 
-  react-on-rails-pro@git+https://git@github.com:shakacode/react-on-rails-builds.git#adcff279edd06ad986d0122197abe9e932ed888a&path:react-on-rails-pro:
-    resolution: {commit: adcff279edd06ad986d0122197abe9e932ed888a, path: react-on-rails-pro, repo: git@github.com:shakacode/react-on-rails-builds.git, type: git}
-    version: 16.6.0
+  react-on-rails-pro@17.0.0-rc.0:
+    resolution: {integrity: sha512-/ZO/gPOqlI/ENWoZMSvteMGGi5IWuXJBjY9dj3QHYZIKYeflySlOP+FrErpcOy0TzEZ8IU1gCQYeyJXzBgm2fA==}
     peerDependencies:
       '@tanstack/react-router': '>=1.139.0 <2.0.0'
       react: '>= 16'
@@ -4154,16 +4190,15 @@ packages:
       react-on-rails-rsc:
         optional: true
 
-  react-on-rails-rsc@file:.yalc/react-on-rails-rsc:
-    resolution: {directory: .yalc/react-on-rails-rsc, type: directory}
+  react-on-rails-rsc@19.0.5-rc.3:
+    resolution: {integrity: sha512-lfqsjBM38KlNDE2hnAiGhwiCE/u54oOJd9T3ChhESMj6WJ8ukMKdPb94vygmPvNc3TkOXGC94ZEjYNRHkuAaPg==}
     peerDependencies:
       react: ^19.0.3
       react-dom: ^19.0.3
       webpack: ^5.59.0
 
-  react-on-rails@git+https://git@github.com:shakacode/react-on-rails-builds.git#adcff279edd06ad986d0122197abe9e932ed888a&path:react-on-rails:
-    resolution: {commit: adcff279edd06ad986d0122197abe9e932ed888a, path: react-on-rails, repo: git@github.com:shakacode/react-on-rails-builds.git, type: git}
-    version: 16.6.0
+  react-on-rails@17.0.0-rc.0:
+    resolution: {integrity: sha512-zjAf7E3TjTQXSmg7UY+C6P3eqExYf6IxQeEjNe5Eo/LTgEIbNYpbYRZFfYhr520hdFj0V50E+CWkq9h1lZWl/Q==}
     peerDependencies:
       react: '>= 16'
       react-dom: '>= 16'
@@ -4421,24 +4456,25 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  shakapacker@9.5.0:
-    resolution: {integrity: sha512-pTGHzHCc74CIoXeg8otCoBa8DjGWZUoYVKu9eyWwpdO9Jq6yHxSD9u5Qp36nXjC9jupd9gnfhCY5YHqkJHpfLA==}
-    engines: {node: '>= 20', yarn: '>=1 <5'}
+  shakapacker@10.1.0:
+    resolution: {integrity: sha512-FMo4nXpM21rZyNNhXt5jn/rm40olFF1udWC0BPE9QO9QVY6utJAEv1bkKhM/mXY/k3/nDT8ur8B3ZcEs+HoLFg==}
+    engines: {node: ^20.19.0 || >=22.12.0, yarn: '>=1 <5'}
+    hasBin: true
     peerDependencies:
       '@babel/core': ^7.17.9
       '@babel/plugin-transform-runtime': ^7.17.0
       '@babel/preset-env': ^7.16.11
       '@babel/runtime': ^7.17.9
-      '@rspack/cli': ^1.0.0
-      '@rspack/core': ^1.0.0
-      '@rspack/plugin-react-refresh': ^1.0.0
+      '@rspack/cli': ^1.0.0 || ^2.0.0-0
+      '@rspack/core': ^1.0.0 || ^2.0.0-0
+      '@rspack/plugin-react-refresh': ^1.0.0 || ^2.0.0
       '@swc/core': ^1.3.0
       '@types/babel__core': ^7.0.0
       '@types/webpack': ^5.0.0
       babel-loader: ^8.2.4 || ^9.0.0 || ^10.0.0
-      compression-webpack-plugin: ^9.0.0 || ^10.0.0 || ^11.0.0
+      compression-webpack-plugin: ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0
       css-loader: ^6.8.1 || ^7.0.0
-      esbuild: ^0.14.0 || ^0.15.0 || ^0.16.0 || ^0.17.0 || ^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0
+      esbuild: '>=0.14.0 <1.0.0'
       esbuild-loader: ^2.0.0 || ^3.0.0 || ^4.0.0
       mini-css-extract-plugin: ^2.0.0
       rspack-manifest-plugin: ^5.0.0
@@ -4446,10 +4482,10 @@ packages:
       sass-loader: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
       swc-loader: ^0.1.15 || ^0.2.0
       terser-webpack-plugin: ^5.3.1
-      webpack: ^5.76.0
+      webpack: ^5.101.0
       webpack-assets-manifest: ^5.0.6 || ^6.0.0
-      webpack-cli: ^4.9.2 || ^5.0.0 || ^6.0.0
-      webpack-dev-server: ^4.15.2 || ^5.2.2
+      webpack-cli: ^4.9.2 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      webpack-dev-server: ^5.2.2
       webpack-subresource-integrity: ^5.1.0
     peerDependenciesMeta:
       '@babel/core':
@@ -8948,6 +8984,10 @@ snapshots:
       degenerator: 5.0.1
       netmask: 2.0.2
 
+  pack-config-diff@0.1.0:
+    dependencies:
+      js-yaml: 4.1.1
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -9444,7 +9484,7 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-on-rails-pro-node-renderer@git+https://git@github.com:shakacode/react-on-rails-builds.git#adcff279edd06ad986d0122197abe9e932ed888a&path:react-on-rails-pro-node-renderer:
+  react-on-rails-pro-node-renderer@17.0.0-rc.0:
     dependencies:
       '@fastify/formbody': 8.0.2
       '@fastify/multipart': 9.4.0
@@ -9454,15 +9494,15 @@ snapshots:
       lockfile: 1.0.4
       pino: 9.14.0
 
-  react-on-rails-pro@git+https://git@github.com:shakacode/react-on-rails-builds.git#adcff279edd06ad986d0122197abe9e932ed888a&path:react-on-rails-pro(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@file:.yalc/react-on-rails-rsc(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4):
+  react-on-rails-pro@17.0.0-rc.0(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@19.0.5-rc.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      react-on-rails: git+https://git@github.com:shakacode/react-on-rails-builds.git#adcff279edd06ad986d0122197abe9e932ed888a&path:react-on-rails(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-on-rails: 17.0.0-rc.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
-      react-on-rails-rsc: file:.yalc/react-on-rails-rsc(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
+      react-on-rails-rsc: 19.0.5-rc.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
 
-  react-on-rails-rsc@file:.yalc/react-on-rails-rsc(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4):
+  react-on-rails-rsc@19.0.5-rc.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
@@ -9471,7 +9511,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.21)(webpack-cli@5.1.4)
       webpack-sources: 3.3.4
 
-  react-on-rails@git+https://git@github.com:shakacode/react-on-rails-builds.git#adcff279edd06ad986d0122197abe9e932ed888a&path:react-on-rails(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-on-rails@17.0.0-rc.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -9758,9 +9798,10 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shakapacker@9.5.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@babel/runtime@7.29.2)(@rspack/cli@2.0.3(@rspack/core@2.0.3))(@rspack/core@2.0.3)(@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.3)(react-refresh@0.14.2))(@swc/core@1.15.21)(babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.105.4))(css-loader@6.11.0(@rspack/core@2.0.3)(webpack@5.105.4))(mini-css-extract-plugin@2.10.1(webpack@5.105.4))(rspack-manifest-plugin@5.2.1(@rspack/core@2.0.3))(sass-loader@14.2.1(@rspack/core@2.0.3)(sass@1.98.0)(webpack@5.105.4))(sass@1.98.0)(swc-loader@0.2.7(@swc/core@1.15.21)(webpack@5.105.4))(terser-webpack-plugin@5.4.0(@swc/core@1.15.21)(webpack@5.105.4))(webpack-assets-manifest@6.5.1(webpack@5.105.4))(webpack-cli@5.1.4)(webpack-dev-server@5.2.3)(webpack@5.105.4):
+  shakapacker@10.1.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@babel/runtime@7.29.2)(@rspack/cli@2.0.3(@rspack/core@2.0.3))(@rspack/core@2.0.3)(@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.3)(react-refresh@0.14.2))(@swc/core@1.15.21)(babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.105.4))(css-loader@6.11.0(@rspack/core@2.0.3)(webpack@5.105.4))(mini-css-extract-plugin@2.10.1(webpack@5.105.4))(rspack-manifest-plugin@5.2.1(@rspack/core@2.0.3))(sass-loader@14.2.1(@rspack/core@2.0.3)(sass@1.98.0)(webpack@5.105.4))(sass@1.98.0)(swc-loader@0.2.7(@swc/core@1.15.21)(webpack@5.105.4))(terser-webpack-plugin@5.4.0(@swc/core@1.15.21)(webpack@5.105.4))(webpack-assets-manifest@6.5.1(webpack@5.105.4))(webpack-cli@5.1.4)(webpack-dev-server@5.2.3)(webpack@5.105.4):
     dependencies:
       js-yaml: 4.1.1
+      pack-config-diff: 0.1.0
       path-complete-extname: 1.0.0
       webpack-merge: 5.10.0
       yargs: 17.7.2
@@ -9784,6 +9825,8 @@ snapshots:
       webpack-assets-manifest: 6.5.1(webpack@5.105.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.4)
       webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.4)
+    transitivePeerDependencies:
+      - ts-node
 
   shallow-clone@3.0.1:
     dependencies:

--- a/script/demo-fleet-verify
+++ b/script/demo-fleet-verify
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bundle exec rake
+pnpm lint:rsc
+bundle exec rake react_on_rails:generate_packs
+RAILS_ENV=production NODE_ENV=production SECRET_KEY_BASE=dummy_secret_key_base_for_demo_fleet pnpm build:production
+pnpm verify:rsc


### PR DESCRIPTION
## Summary

- Updates the Marketplace RSC demo to the current React on Rails 17 RC dependency set.
- Pins `react_on_rails` / `react_on_rails_pro` to `17.0.0.rc.0` and the npm packages to `17.0.0-rc.0`.
- Updates `react-on-rails-rsc` to `19.0.5-rc.3` and `shakapacker` to `10.1.0`.
- Adds `script/demo-fleet-verify` so the release gate can be rerun from this repo.

## Why

This is the first pilot output from the ShakaStack demo-fleet update/release-gate control plane. It exercises the dependency update flow against `react-on-rails-demo-marketplace-rsc` and records the repo-local verification command set.

## Validation

Freshly run from `/tmp/demo-fleet-pilot-v4/marketplace-rsc` on `demo-fleet/release-20260601-marketplace-rsc`:

- `script/demo-fleet-verify`
  - `bundle exec rake`
  - `pnpm lint:rsc`
  - `bundle exec rake react_on_rails:generate_packs`
  - production `pnpm build:production`
  - `pnpm verify:rsc`

The production webpack build emitted existing asset-size warnings, but the release gate completed successfully through `verify:rsc`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major-version bumps on the core RoR + Shakapacker + RSC toolchain (RC releases) can break builds, pack generation, or RSC verification even though application code is unchanged.
> 
> **Overview**
> Moves the Marketplace RSC demo off **git/yalc-linked** React on Rails and Shakapacker builds onto **published RC pins** aligned with the React on Rails 17 stack.
> 
> **Ruby:** `react_on_rails` and `react_on_rails_pro` are pinned to **`17.0.0.rc.0`** (replacing the Shakacode `main` git sources), and **`shakapacker`** is pinned to **`10.1.0`** (from ~9.5). `Gemfile.lock` drops the GIT sections and picks up transitive bumps (e.g. `rack-proxy`, `nokogiri`).
> 
> **JavaScript:** npm deps and `pnpm` overrides now use **`17.0.0-rc.0`** for `react-on-rails`, `react-on-rails-pro`, and the node renderer; **`react-on-rails-rsc`** moves from `.yalc` to **`19.0.5-rc.3`**; **`shakapacker`** is **`10.1.0`** in dependencies and devDependencies. The lockfile reflects registry packages and Shakapacker 10’s added **`pack-config-diff`** dependency.
> 
> **Release gate:** Adds **`script/demo-fleet-verify`**, a single entrypoint that runs `rake`, `pnpm lint:rsc`, `react_on_rails:generate_packs`, production `pnpm build:production`, and `pnpm verify:rsc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6b3780247e3c43376029d8337b7d4ae0baef00e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->