### PR TITLE
Update react-on-rails-rsc to 19.0.5-rc.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-dom": "^19.0.0",
     "react-on-rails-pro": "17.0.0-rc.0",
     "react-on-rails-pro-node-renderer": "17.0.0-rc.0",
-    "react-on-rails-rsc": "19.0.5-rc.5",
+    "react-on-rails-rsc": "19.0.5-rc.6",
     "sanitize-html": "^2.17.3",
     "simple-statistics": "^7.8.9",
     "web-vitals": "^4.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,13 +72,13 @@ importers:
         version: 19.2.4(react@19.2.4)
       react-on-rails-pro:
         specifier: 17.0.0-rc.0
-        version: 17.0.0-rc.0(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@19.0.5-rc.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4)
+        version: 17.0.0-rc.0(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@19.0.5-rc.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4)
       react-on-rails-pro-node-renderer:
         specifier: 17.0.0-rc.0
         version: 17.0.0-rc.0
       react-on-rails-rsc:
-        specifier: 19.0.5-rc.5
-        version: 19.0.5-rc.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
+        specifier: 19.0.5-rc.6
+        version: 19.0.5-rc.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
       sanitize-html:
         specifier: ^2.17.3
         version: 2.17.3
@@ -4190,8 +4190,8 @@ packages:
       react-on-rails-rsc:
         optional: true
 
-  react-on-rails-rsc@19.0.5-rc.5:
-    resolution: {integrity: sha512-NTe3g34iR0ya8XFUpwbqE37ff4x5YGZEGowWGbY4o/wqNPykICDH5Nsd7MjqUSwun5NYqI92FHKHSEhpHgPq2A==}
+  react-on-rails-rsc@19.0.5-rc.6:
+    resolution: {integrity: sha512-BCnSJ4lzLP6lqegQlr5smJW/54NAEwnQy1OMLBYUwXYKXEozuLlGH/GzLf0F0nR69fDmKyUL51fzcg6Khm4AkA==}
     peerDependencies:
       react: ^19.0.4
       react-dom: ^19.0.4
@@ -9494,15 +9494,15 @@ snapshots:
       lockfile: 1.0.4
       pino: 9.14.0
 
-  react-on-rails-pro@17.0.0-rc.0(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@19.0.5-rc.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4):
+  react-on-rails-pro@17.0.0-rc.0(react-dom@19.2.4(react@19.2.4))(react-on-rails-rsc@19.0.5-rc.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-on-rails: 17.0.0-rc.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
-      react-on-rails-rsc: 19.0.5-rc.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
+      react-on-rails-rsc: 19.0.5-rc.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
 
-  react-on-rails-rsc@19.0.5-rc.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4):
+  react-on-rails-rsc@19.0.5-rc.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.4):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2


### PR DESCRIPTION
## Summary
- Update `react-on-rails-rsc` to `19.0.5-rc.6`.
- Refresh `pnpm-lock.yaml` to the published rc.6 package integrity.

## Verification
- `npm view react-on-rails-rsc@19.0.5-rc.6 version dist.integrity dist.shasum --json --prefer-online`
- `npm pack react-on-rails-rsc@19.0.5-rc.6 --pack-destination /tmp/ror-rsc-registry-pack-rc6 --prefer-online`
- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run lint:rsc`
- `pnpm run verify:rsc`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with lockfile refresh; no app logic changes, though RSC/webpack integration could shift with the upstream rc package.
> 
> **Overview**
> Bumps **`react-on-rails-rsc`** from **`19.0.5-rc.5`** to **`19.0.5-rc.6`** in `package.json` and updates **`pnpm-lock.yaml`** so the lockfile points at the new tarball (integrity hash and nested references under `react-on-rails-pro`).
> 
> No application or config changes beyond the version pin; behavior should match whatever shipped in that rc release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a35f89ab2238d214e76e7193df39c26ca2064db2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->