### PR TITLE
Footer: show deployed git commit SHA (#89)

### DIFF
--- a/.controlplane/Dockerfile
+++ b/.controlplane/Dockerfile
@@ -94,6 +94,13 @@ ENV RAILS_ENV=production \
     RAILS_LOG_TO_STDOUT=true \
     PORT=3000
 
+# Deployed git commit SHA. cpflow's `build-image --commit=<sha>` passes this as a
+# build-arg (the image dockerignores `.git`, so there's no other runtime source);
+# promoting it to ENV lets BuildMetadata surface it in the footer. Declared last
+# so a new SHA only rebuilds these trivial metadata layers.
+ARG GIT_COMMIT
+ENV GIT_COMMIT=${GIT_COMMIT}
+
 EXPOSE 3000
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,21 @@
 class ApplicationController < ActionController::Base
   around_action :apply_db_delay
 
+  helper_method :deployed_commit_sha, :deployed_commit_short_sha, :deployed_commit_url
+
   private
+
+  def deployed_commit_sha
+    BuildMetadata.commit_sha
+  end
+
+  def deployed_commit_short_sha
+    BuildMetadata.short_commit_sha
+  end
+
+  def deployed_commit_url
+    BuildMetadata.commit_url
+  end
 
   def apply_db_delay
     delay_ms = params[:delay].to_i

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,6 +19,10 @@ module ApplicationHelper
   CANONICAL_HOST = "https://rsc.reactonrails.com"
   OG_IMAGE_PATH = "/og-image.png"
 
+  # Canonical GitHub repo. Single source of truth for the footer/nav source
+  # links (config/routes.rb) and the deployed-commit URL (BuildMetadata).
+  GITHUB_REPO_URL = "https://github.com/shakacode/react-server-components-marketplace-demo"
+
   DEFAULT_TITLE =
     "React Server Components for Ruby on Rails — Live Demo & Benchmarks"
   DEFAULT_DESCRIPTION =

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -122,8 +122,19 @@
     <footer class="border-t border-slate-200 bg-white">
       <div class="mx-auto flex max-w-7xl flex-col gap-3 px-4 py-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
         <p>Explore the code, compare the rendering strategies, and open a PR when you improve the demo.</p>
-        <div class="flex flex-wrap gap-4">
+        <div class="flex flex-wrap items-center gap-4">
           <%= link_to 'GitHub repo', source_code_path, class: 'transition hover:text-slate-900' %>
+          <%# Deployed commit SHA — only rendered when a SHA is known (omitted in local dev without git). %>
+          <% if deployed_commit_short_sha.present? %>
+            <% if deployed_commit_url.present? %>
+              <%= link_to "commit #{deployed_commit_short_sha}", deployed_commit_url,
+                    target: '_blank', rel: 'noreferrer noopener',
+                    class: 'font-mono text-xs text-slate-400 transition hover:text-slate-900',
+                    title: "Deployed commit #{deployed_commit_sha}" %>
+            <% else %>
+              <code class="font-mono text-xs text-slate-400" title="Deployed commit <%= deployed_commit_sha %>">commit <%= deployed_commit_short_sha %></code>
+            <% end %>
+          <% end %>
           <%= link_to 'Contributor guide', contributing_guide_path, class: 'transition hover:text-slate-900' %>
           <%= link_to 'Forum', 'https://forum.shakacode.com/c/reactjs', class: 'transition hover:text-slate-900' %>
           <%= link_to 'ShakaCode', 'https://www.shakacode.com', class: 'transition hover:text-slate-900' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   rsc_payload_route
-  repository_url = 'https://github.com/shakacode/react-server-components-marketplace-demo'
+  repository_url = ApplicationHelper::GITHUB_REPO_URL
   contributing_url = "#{repository_url}/blob/main/CONTRIBUTING.md"
   issues_url = "#{repository_url}/issues"
 

--- a/lib/build_metadata.rb
+++ b/lib/build_metadata.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "open3"
+
+# Resolves the git commit SHA of the running build so views can show "what's
+# actually deployed" (see the footer badge in the application layout).
+#
+# Resolution order:
+#   1. A commit env var injected at build/deploy time. Control Plane's cpflow
+#      passes `--build-arg GIT_COMMIT=<sha>`, which the Dockerfile promotes to a
+#      runtime ENV. The other keys cover common PaaS providers.
+#   2. `git rev-parse HEAD` for local development (the deployed image dockerignores
+#      `.git`, so this only ever resolves on a developer machine).
+#   3. nil — render nothing rather than guess.
+module BuildMetadata
+  COMMIT_ENV_KEYS = %w[
+    GIT_COMMIT
+    SOURCE_VERSION
+    HEROKU_SLUG_COMMIT
+    RENDER_GIT_COMMIT
+    VERCEL_GIT_COMMIT_SHA
+  ].freeze
+  COMMIT_SHA_PATTERN = /\A[0-9a-f]{7,40}\z/i
+
+  module_function
+
+  def commit_sha
+    return @commit_sha if instance_variable_defined?(:@commit_sha)
+
+    @commit_sha = env_commit_sha || local_git_commit_sha
+  end
+
+  def short_commit_sha
+    commit_sha&.first(7)
+  end
+
+  def commit_url
+    sha = commit_sha
+    return unless sha&.match?(COMMIT_SHA_PATTERN)
+
+    "#{github_repo_url}/commit/#{sha}"
+  end
+
+  def env_commit_sha
+    COMMIT_ENV_KEYS.filter_map { |key| valid_commit_sha(ENV[key].presence) }.first
+  end
+
+  def local_git_commit_sha
+    return unless Rails.root.join(".git").exist?
+
+    stdout, status = Open3.capture2("git", "-C", Rails.root.to_s, "rev-parse", "HEAD")
+    return unless status.success?
+
+    valid_commit_sha(stdout.strip.presence)
+  rescue Errno::ENOENT, StandardError
+    nil
+  end
+
+  def github_repo_url
+    ApplicationHelper::GITHUB_REPO_URL
+  end
+
+  def valid_commit_sha(value)
+    return unless value&.match?(COMMIT_SHA_PATTERN)
+
+    value
+  end
+
+  # Test/console helper: clears the memoized SHA so a changed env is picked up.
+  def reset!
+    remove_instance_variable(:@commit_sha) if instance_variable_defined?(:@commit_sha)
+  end
+end


### PR DESCRIPTION
## What

Show the **deployed git commit SHA** as a subtle badge in the site footer, linking to that exact commit on GitHub. Makes it obvious at a glance what's actually running — and surfaces deploy lag (#88).

![footer badge]: `GitHub repo · commit b097d1d · Contributor guide · …`

## How

- **`lib/build_metadata.rb`** — resolves the SHA from a build/deploy env var (`GIT_COMMIT` + common PaaS keys), falling back to `git rev-parse HEAD` for local dev, and `nil` otherwise. Validated against a SHA pattern + memoized.
- **`ApplicationController`** — exposes `deployed_commit_sha` / `_short_sha` / `_url` via `helper_method`.
- **`ApplicationHelper::GITHUB_REPO_URL`** — single source of truth for the repo URL; `config/routes.rb` now references it instead of a duplicated literal.
- **`application.html.erb`** — renders the badge only when a SHA is present (local dev without git just omits it). Styled to match the sibling footer links (`font-mono text-xs text-slate-400 hover:text-slate-900`).
- **`.controlplane/Dockerfile`** — `ARG`/`ENV GIT_COMMIT` in the production stage.

### Why no workflow change was needed

The staging deploy already runs `cpflow build-image --commit=${{ github.sha }}` (via `control-plane-flow@v5.0.4`), which passes `--build-arg GIT_COMMIT=<sha>` to `docker build`. The only missing link was the Dockerfile declaring `ARG GIT_COMMIT` + `ENV GIT_COMMIT` so the running container can read it. Review apps get it for free via the same build action.

## Verification

Booted the app via `rails runner` and confirmed:
- Local-git fallback resolves the working-tree HEAD; `commit_url` builds `…/commit/<sha>`.
- Env-injected `GIT_COMMIT` takes precedence; a garbage value is rejected and falls back to git.
- Footer fragment renders an `<a>` to the commit when a SHA is present, and **nothing** when it's absent.

(Repo has no rspec/CI-lint harness, and local rubocop is broken by an unrelated `prism/translation/parser34` load error.)

## Acceptance criteria

- [x] Port `BuildMetadata` + the 3 `helper_method`s.
- [x] Add `ApplicationHelper::GITHUB_REPO_URL`; DRY `routes.rb`.
- [x] Footer badge in `application.html.erb`, slate-styled, conditional on a present SHA.
- [x] `GIT_COMMIT` injected via Dockerfile `ARG`/`ENV` in the cpflow build.
- [x] Local dev shows the working-tree SHA; renders nothing if neither env nor `.git` is available.
- [ ] Staging footer shows the live SHA — verify after deploy.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only metadata and Dockerfile env wiring; no auth, data, or request-handling changes.
> 
> **Overview**
> Adds a **deployed commit** indicator in the site footer so visitors can see which git revision is running and jump to it on GitHub.
> 
> A new **`BuildMetadata`** module resolves the SHA from deploy-time env vars (`GIT_COMMIT` and common PaaS keys), with local **`git rev-parse`** fallback and pattern validation; invalid or missing values hide the badge. **`ApplicationController`** exposes `deployed_commit_*` helpers to the layout, which renders a monospace **commit** link (or plain text when no URL) only when a SHA is known.
> 
> **`ApplicationHelper::GITHUB_REPO_URL`** centralizes the repo URL; **`routes.rb`** uses it instead of a duplicated string. The production **Dockerfile** adds **`ARG`/`ENV GIT_COMMIT`** at the end of the image so cpflow’s existing `--build-arg` wiring reaches the running container (`.git` is not in the image).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddfebb624a8102e8994d04858446f01769ad7a76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->