### PR TITLE
Document staging deploy variable requirement + how to check live SHA

### DIFF
--- a/.controlplane/README.md
+++ b/.controlplane/README.md
@@ -165,6 +165,37 @@ a protected GitHub Environment named `production`, require reviewers, enable
 prevent self-review, and store `CPLN_TOKEN_PRODUCTION` as an environment secret
 rather than a repository secret.
 
+> **These repository variables must actually be created, not just documented.**
+> The staging wrapper's `validate-branch` preflight exits early when
+> `CPLN_ORG_STAGING` or `STAGING_APP_NAME` is missing, so the deploy never runs
+> and staging silently keeps serving the previously deployed image. A merge to
+> `main` looks fine in the PR, but staging stays stale. This was the root cause
+> of #88 (the variables were documented here but never set in repo settings).
+>
+> Verify the variables exist with:
+>
+> ```bash
+> gh variable list
+> # expected:
+> # CPLN_ORG_STAGING   shakacode-open-source-examples-staging
+> # STAGING_APP_NAME   react-server-components-demo
+> ```
+
+#### Confirming which commit staging is running
+
+The most reliable source is the GitHub Actions history: the newest **successful**
+"Deploy Staging to Control Plane" run deployed the commit it ran on.
+
+```bash
+gh run list --workflow=cpflow-deploy-staging.yml --status success \
+  --limit 1 --json headSha,createdAt,displayTitle
+```
+
+If that SHA lags `origin/main`, staging is behind: check the most recent run for
+a failed `validate-branch` (missing variables) or a failed build/deploy. An
+in-app footer SHA (tracked separately) makes the running commit visible at a
+glance without leaving the site.
+
 Validate generated wrapper changes locally with:
 
 ```bash


### PR DESCRIPTION
## Summary

- Documents that the staging deploy repository variables (`CPLN_ORG_STAGING`, `STAGING_APP_NAME`) must actually be **created** in repo settings, not merely documented — the staging wrapper's `validate-branch` preflight exits early when they're missing, so staging silently keeps serving the previously deployed image (the root cause of #88). Adds a `gh run list` recipe for confirming which commit staging is actually running.
- Note: merging this PR documents the fix but does not resolve #88 on its own — the variables still need to be set in GitHub repo settings.

## Demo surfaces affected

- [ ] Landing page / navigation
- [ ] Restaurant search comparison
- [ ] Blog comparison
- [ ] Product page comparison
- [ ] Product search comparison
- [ ] Analytics / dashboard
- [x] Deployment / Control Plane
- [x] Docs / contributor experience

## Test plan

- Docs-only change to `.controlplane/README.md`; verified the Markdown renders and the `gh variable list` / `gh run list` commands are accurate.

## Screenshots or metrics

- Not applicable

## Checklist

- [x] I kept the SSR, client, and RSC comparison honest, or documented why a route intentionally diverges
- [x] I updated docs, routes, or contributor guidance for any new user-facing entry point
- [x] I called out deploy, seed, or benchmark impacts when relevant

Refs #88

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `.controlplane/README.md` with no runtime or deploy behavior changes.
> 
> **Overview**
> **Expands Control Plane staging deploy docs** so operators don't hit silent stale staging when GitHub repo variables are missing.
> 
> Adds a prominent callout that `CPLN_ORG_STAGING` and `STAGING_APP_NAME` must be **created** in repository settings—not only listed in the table—because the staging wrapper's `validate-branch` step exits early without them and staging keeps the old image (root cause of #88). Includes `gh variable list` to verify values.
> 
> Adds a **"Confirming which commit staging is running"** section with `gh run list` against `cpflow-deploy-staging.yml` to read the latest successful deploy SHA, plus guidance when that SHA lags `origin/main` (failed preflight vs build/deploy). Notes an optional in-app footer SHA as a separate convenience.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79d82f769ee9ce33bdafcf930962bcc3c2dae728. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added warnings and verification instructions for required GitHub repository variables in the Control Plane deployment guide
  * Provided commands to list and confirm variable configuration
  * Included diagnostic steps to identify currently deployed commits and troubleshoot staging deployment lag

<!-- end of auto-generated comment: release notes by coderabbit.ai -->