### PR TITLE
Update React on Rails to 17.0.0.rc.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,8 @@ gem 'turbo-rails'
 gem 'stimulus-rails'
 
 # React on Rails
-gem 'react_on_rails', '17.0.0.rc.2'
-gem 'react_on_rails_pro', '17.0.0.rc.2'
+gem 'react_on_rails', '17.0.0.rc.3'
+gem 'react_on_rails_pro', '17.0.0.rc.3'
 
 # Shakapacker for webpack integration
 gem 'shakapacker', '10.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,14 +298,14 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
-    react_on_rails (17.0.0.rc.2)
+    react_on_rails (17.0.0.rc.3)
       addressable
       connection_pool
       execjs (~> 2.5)
       rails (>= 5.2)
       rainbow (~> 3.0)
       shakapacker (>= 6.0)
-    react_on_rails_pro (17.0.0.rc.2)
+    react_on_rails_pro (17.0.0.rc.3)
       addressable
       async (>= 2.29)
       async-http (~> 0.95)
@@ -313,7 +313,7 @@ GEM
       io-endpoint (~> 0.17.0)
       jwt (>= 2.5, < 4)
       rainbow
-      react_on_rails (= 17.0.0.rc.2)
+      react_on_rails (= 17.0.0.rc.3)
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -437,8 +437,8 @@ DEPENDENCIES
   pry-byebug (~> 3.12)
   puma (~> 6.0)
   rails (~> 7.1)
-  react_on_rails (= 17.0.0.rc.2)
-  react_on_rails_pro (= 17.0.0.rc.2)
+  react_on_rails (= 17.0.0.rc.3)
+  react_on_rails_pro (= 17.0.0.rc.3)
   rspec-rails (~> 6.1)
   rubocop
   rubocop-rails

--- a/app/services/blog_data.rb
+++ b/app/services/blog_data.rb
@@ -42,8 +42,8 @@ Before starting the migration, ensure your project meets these requirements:
 
 ```ruby
 # Gemfile
-gem 'react_on_rails', '17.0.0.rc.2'
-gem 'react_on_rails_pro', '17.0.0.rc.2'
+gem 'react_on_rails', '17.0.0.rc.3'
+gem 'react_on_rails_pro', '17.0.0.rc.3'
 ```
 
 ```json
@@ -52,8 +52,8 @@ gem 'react_on_rails_pro', '17.0.0.rc.2'
   "dependencies": {
     "react": "19.0.4",
     "react-dom": "19.0.4",
-    "react-on-rails-pro": "17.0.0-rc.2",
-    "react-on-rails-pro-node-renderer": "17.0.0-rc.2",
+    "react-on-rails-pro": "17.0.0-rc.3",
+    "react-on-rails-pro-node-renderer": "17.0.0-rc.3",
     "react-on-rails-rsc": "19.0.5-rc.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "marked-highlight": "^2.2.3",
     "react": "19.0.4",
     "react-dom": "19.0.4",
-    "react-on-rails-pro": "17.0.0-rc.2",
-    "react-on-rails-pro-node-renderer": "17.0.0-rc.2",
+    "react-on-rails-pro": "17.0.0-rc.3",
+    "react-on-rails-pro-node-renderer": "17.0.0-rc.3",
     "react-on-rails-rsc": "19.0.5-rc.7",
     "sanitize-html": "^2.17.3",
     "simple-statistics": "^7.8.9",
@@ -53,7 +53,7 @@
   "pnpm": {
     "overrides": {
       "@ungap/structured-clone": "1.3.1",
-      "react-on-rails": "17.0.0-rc.2",
+      "react-on-rails": "17.0.0-rc.3",
       "shakapacker": "10.1.0"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@ungap/structured-clone': 1.3.1
-  react-on-rails: 17.0.0-rc.2
+  react-on-rails: 17.0.0-rc.3
   shakapacker: 10.1.0
 
 importers:
@@ -71,11 +71,11 @@ importers:
         specifier: 19.0.4
         version: 19.0.4(react@19.0.4)
       react-on-rails-pro:
-        specifier: 17.0.0-rc.2
-        version: 17.0.0-rc.2(react-dom@19.0.4(react@19.0.4))(react-on-rails-rsc@19.0.5-rc.7(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(webpack@5.105.4))(react@19.0.4)
+        specifier: 17.0.0-rc.3
+        version: 17.0.0-rc.3(react-dom@19.0.4(react@19.0.4))(react-on-rails-rsc@19.0.5-rc.7(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(webpack@5.105.4))(react@19.0.4)
       react-on-rails-pro-node-renderer:
-        specifier: 17.0.0-rc.2
-        version: 17.0.0-rc.2
+        specifier: 17.0.0-rc.3
+        version: 17.0.0-rc.3
       react-on-rails-rsc:
         specifier: 19.0.5-rc.7
         version: 19.0.5-rc.7(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(webpack@5.105.4)
@@ -4136,8 +4136,8 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
-  react-on-rails-pro-node-renderer@17.0.0-rc.2:
-    resolution: {integrity: sha512-5dGh259JpGVIaSkTNHz2RLruSahKynGOW/hj8I70AzgE+LnM3hZuXc3WveCjzZl8vQShpGlxgRQxPoOZh9fyQQ==}
+  react-on-rails-pro-node-renderer@17.0.0-rc.3:
+    resolution: {integrity: sha512-Red3GaNEF33XhjtfCSkYAM4+GEoiCEjP0Yt1eknH5LmWqVnO1NMqWoFhtBfxaVr/K++qTVYY5yV28iNh6gTqzg==}
     peerDependencies:
       '@fastify/otel': '>=0.18.0 <1.0.0'
       '@honeybadger-io/js': '>=4.0.0'
@@ -4177,8 +4177,8 @@ packages:
       '@sentry/tracing':
         optional: true
 
-  react-on-rails-pro@17.0.0-rc.2:
-    resolution: {integrity: sha512-gfB6qUEOQ8ANHFKqQahyS/0NfagdyZ1JgNMVK9O+t863GiMZPnVZa2YVoi/NjHmV6HaRQ3JnODQM3GHbP9s4aQ==}
+  react-on-rails-pro@17.0.0-rc.3:
+    resolution: {integrity: sha512-DzBHKrDX+bHY2ojnNjH5cNxFXmwIncaL3SQL1SCVibU+G2I32IV8gKB3cUTZgNhMY3p1Onsgjt/cVt0x6+Cqhw==}
     peerDependencies:
       '@tanstack/react-router': '>=1.139.0 <2.0.0'
       ioredis: '>= 5'
@@ -4200,8 +4200,8 @@ packages:
       react-dom: ^19.0.4
       webpack: ^5.59.0
 
-  react-on-rails@17.0.0-rc.2:
-    resolution: {integrity: sha512-Ix3v9k7p/K6lI7fHl/NivIlu/pr3USGdGYANKMltkOluGsshQnUL9Cz7Oj6/LI8l8Rmp9IJwN5QdigMr+Ssqjg==}
+  react-on-rails@17.0.0-rc.3:
+    resolution: {integrity: sha512-VpLWgVt4mE6ETo1mGj5yLCL/sEK+SPYIut7nVqx10HY0F/P1IQodEWm18IYQ5ZBBxdAngvSsOArjypVUcFLP0w==}
     peerDependencies:
       react: '>= 16'
       react-dom: '>= 16'
@@ -9487,7 +9487,7 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-on-rails-pro-node-renderer@17.0.0-rc.2:
+  react-on-rails-pro-node-renderer@17.0.0-rc.3:
     dependencies:
       '@fastify/formbody': 8.0.2
       '@fastify/multipart': 9.4.0
@@ -9497,11 +9497,11 @@ snapshots:
       lockfile: 1.0.4
       pino: 9.14.0
 
-  react-on-rails-pro@17.0.0-rc.2(react-dom@19.0.4(react@19.0.4))(react-on-rails-rsc@19.0.5-rc.7(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(webpack@5.105.4))(react@19.0.4):
+  react-on-rails-pro@17.0.0-rc.3(react-dom@19.0.4(react@19.0.4))(react-on-rails-rsc@19.0.5-rc.7(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(webpack@5.105.4))(react@19.0.4):
     dependencies:
       react: 19.0.4
       react-dom: 19.0.4(react@19.0.4)
-      react-on-rails: 17.0.0-rc.2(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
+      react-on-rails: 17.0.0-rc.3(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
     optionalDependencies:
       react-on-rails-rsc: 19.0.5-rc.7(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(webpack@5.105.4)
 
@@ -9514,7 +9514,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.21)(webpack-cli@5.1.4)
       webpack-sources: 3.3.4
 
-  react-on-rails@17.0.0-rc.2(react-dom@19.0.4(react@19.0.4))(react@19.0.4):
+  react-on-rails@17.0.0-rc.3(react-dom@19.0.4(react@19.0.4))(react@19.0.4):
     dependencies:
       react: 19.0.4
       react-dom: 19.0.4(react@19.0.4)


### PR DESCRIPTION
## Summary

- Update React on Rails Ruby gems from `17.0.0.rc.2` to `17.0.0.rc.3`.
- Update React on Rails Pro npm packages from `17.0.0-rc.2` to `17.0.0-rc.3`.
- Refresh the rendered RSC migration prerequisite snippet so app copy matches the consumed RC.

## Demo surfaces affected

- [ ] Landing page / navigation
- [ ] Restaurant search comparison
- [ ] Blog comparison
- [ ] Product page comparison
- [ ] Product search comparison
- [ ] Analytics / dashboard
- [ ] Deployment / Control Plane
- [x] Docs / contributor experience

## RC Test Report

Tracker: shakacode/react_on_rails#3823

Target versions consumed:

- `react_on_rails` gem: `17.0.0.rc.3`
- `react_on_rails_pro` gem: `17.0.0.rc.3`
- `react-on-rails` pnpm override: `17.0.0-rc.3`
- `react-on-rails-pro`: `17.0.0-rc.3`
- `react-on-rails-pro-node-renderer`: `17.0.0-rc.3`

Validation run:

- `bundle update react_on_rails react_on_rails_pro` -> passed; lockfile narrowed to only the two React on Rails gem versions.
- `bundle install` -> passed.
- `pnpm install` -> passed; pnpm reported existing peer warnings for `css-loader`/`sass-loader` with `@rspack/core@2.0.3`.
- `script/demo-fleet-verify` -> passed:
  - `bundle exec rake` -> passed, 0 RSpec examples found.
  - `pnpm lint:rsc` -> passed, no heavy-lib import contamination detected.
  - `bundle exec rake react_on_rails:generate_packs` -> passed.
  - `RAILS_ENV=production NODE_ENV=production SECRET_KEY_BASE=dummy_secret_key_base_for_demo_fleet pnpm build:production` -> passed; webpack emitted existing asset-size warnings for markdown/client entrypoints.
  - `pnpm verify:rsc` -> passed, 12 RSC entry packs checked with no heavy-lib chunks reachable.
- `pnpm type-check` -> passed.
- `git diff --check` -> passed.

Additional local checks attempted:

- `pnpm lint` -> failed before linting because the repo has no ESLint configuration file.
- `bundle exec rubocop` -> failed in the existing RuboCop/prism setup with `cannot load such file -- prism/translation/parser34`, plus pending-cop configuration warnings.

## Screenshots or metrics

- Not applicable; dependency-only RC uptake plus rendered prerequisite version copy.

## Checklist

- [x] I kept the SSR, client, and RSC comparison honest, or documented why a route intentionally diverges
- [x] I updated docs, routes, or contributor guidance for any new user-facing entry point
- [x] I called out deploy, seed, or benchmark impacts when relevant

Labels: none. This is a focused dependency bump; the repository's path-based RSC/Rspack gate is expected to run because `package.json` changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No application logic changes—only pinned dependency versions and documentation strings; risk is limited to potential behavior differences in the new RC release.
> 
> **Overview**
> Bumps the React on Rails stack from **`17.0.0.rc.2`** to **`17.0.0.rc.3`** across Ruby gems, npm packages, and lockfiles.
> 
> **Ruby:** `react_on_rails` and `react_on_rails_pro` in `Gemfile` / `Gemfile.lock`.
> 
> **JavaScript:** `react-on-rails-pro`, `react-on-rails-pro-node-renderer`, and the pnpm `react-on-rails` override in `package.json` / `pnpm-lock.yaml`.
> 
> **Docs copy:** The embedded RSC migration prerequisites in `app/services/blog_data.rb` are updated so the in-app blog snippet matches the versions the demo actually consumes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 650220de3ee53e493e9bb7b7d73a9dd0e5562c90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->