### PR TITLE
Add cached page variants (cached_react_component / cached_stream_react_component[_with_async_props]) + benchmark caching gains

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,5 +1,13 @@
 web: bundle exec rails server -p 3000
-webpack: bin/shakapacker-dev-server
+# Build the client bundle to disk (watch) instead of the in-memory dev-server.
+# RSC needs react-client-manifest.json on disk so react_on_rails_pro can copy it to the node
+# renderer: while the webpack dev-server is running, ReactOnRails::PackerUtils.asset_uri_from_packer
+# resolves that manifest to a dev-server URL (not a file), so the copy fails and RSC server rendering
+# errors ("Switched to client rendering..."). Building to disk makes dev_server_running? false, so the
+# gem resolves/copies the manifest from public/packs. Trade-off: no HMR (full reload). Rails serves
+# public/packs statically in dev. NOTE: after a client-only RSC change that doesn't change the
+# server/RSC bundle hash, restart `renderer` or clear `.node-renderer-bundles` to refresh the manifest.
+webpack: CLIENT_BUNDLE_ONLY=yes bin/shakapacker --watch
 
 # Keep the JS fresh for server rendering. Remove if not server rendering
 rails-server-assets: HMR=true SERVER_BUNDLE_ONLY=yes bin/shakapacker --watch

--- a/app/controllers/blog_controller.rb
+++ b/app/controllers/blog_controller.rb
@@ -4,10 +4,10 @@ class BlogController < ApplicationController
   include ReactOnRailsPro::RSCPayloadRenderer
   include ReactOnRailsPro::AsyncRendering
 
-  enable_async_react_rendering only: [
-    :post_rsc, :post_rsc_simple,
-    :post_rsc_step1, :post_rsc_step1b, :post_rsc_step1c,
-    :post_rsc_step2, :post_rsc_step3, :post_rsc_step4, :post_rsc_step5
+  enable_async_react_rendering only: %i[
+    post_rsc post_rsc_cached post_rsc_simple
+    post_rsc_step1 post_rsc_step1b post_rsc_step1c
+    post_rsc_step2 post_rsc_step3 post_rsc_step4 post_rsc_step5
   ]
 
   before_action :set_seo_meta
@@ -44,6 +44,17 @@ class BlogController < ApplicationController
     @post_meta = post.except(:content)
     @content_delay = ENV.fetch("CONTENT_DELAY_MS", "0").to_f / 1000
     stream_view_containing_react_components(template: "blog/post_rsc")
+  end
+
+  # V3 cached: identical RSC streaming to post_rsc, but the view wraps the component in
+  # cached_stream_react_component_with_async_props. The first request is a cold miss that streams live
+  # and writes every chunk through to the cache; subsequent requests are cache hits that replay those
+  # chunks and skip the content fetch, the two simulated sleeps, and the node-renderer round-trip.
+  def post_rsc_cached
+    post = BlogData.find_post(1)
+    @post_meta = post.except(:content)
+    @content_delay = ENV.fetch("CONTENT_DELAY_MS", "0").to_f / 1000
+    stream_view_containing_react_components(template: "blog/post_rsc_cached")
   end
 
   # V4: RSC Simple — markdown rendered server-side, all data passed upfront

--- a/app/controllers/blog_controller.rb
+++ b/app/controllers/blog_controller.rb
@@ -5,7 +5,7 @@ class BlogController < ApplicationController
   include ReactOnRailsPro::AsyncRendering
 
   enable_async_react_rendering only: %i[
-    post_rsc post_rsc_cached post_rsc_simple
+    post_rsc post_rsc_cached post_rsc_simple post_rsc_simple_cached
     post_rsc_step1 post_rsc_step1b post_rsc_step1c
     post_rsc_step2 post_rsc_step3 post_rsc_step4 post_rsc_step5
   ]
@@ -63,6 +63,16 @@ class BlogController < ApplicationController
     @post_data = post
     @related_posts = BlogData.related_posts(post[:id])
     stream_view_containing_react_components(template: "blog/post_rsc_simple")
+  end
+
+  # V1 cached: cached_react_component. Props (incl. the simulated content delay) are built lazily in
+  # the view block, so on a cache hit the data fetch, the delay, and the prerender are all skipped.
+  def post_ssr_cached; end
+
+  # V4 cached: cached_stream_react_component (plain stream, no async props). On a hit the streamed
+  # chunks replay and the data fetch + node render are skipped.
+  def post_rsc_simple_cached
+    stream_view_containing_react_components(template: "blog/post_rsc_simple_cached")
   end
 
   # === RSC debug steps (incremental complexity) ===

--- a/app/controllers/concerns/product_serialization.rb
+++ b/app/controllers/concerns/product_serialization.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Product hash serialization shared by the SSR / client / RSC product actions and their cached
+# variants. Extracted from ProductsController to keep that controller focused on actions.
+module ProductSerialization
+  extend ActiveSupport::Concern
+
+  private
+
+  # Slice the plain columns (no custom getters) and merge the computed floats + the model's
+  # overridden discount_percentage. Behavior-identical to the previous explicit hash.
+  def serialize_product(product)
+    product.slice(:id, :name, :description, :category, :brand, :sku, :images, :specs,
+                  :features, :review_count, :stock_quantity, :in_stock).symbolize_keys.merge(
+                    price: product.price.to_f,
+                    original_price: product.original_price&.to_f,
+                    average_rating: product.average_rating.to_f,
+                    discount_percentage: product.discount_percentage
+                  )
+  end
+
+  def serialize_review(review)
+    {
+      id: review.id,
+      rating: review.rating,
+      title: review.title,
+      comment: review.comment,
+      reviewer_name: review.reviewer_name,
+      verified_purchase: review.verified_purchase,
+      helpful_count: review.helpful_count,
+      created_at: review.created_at.iso8601
+    }
+  end
+
+  def serialize_product_card(product)
+    product.slice(:id, :name, :category, :brand, :images, :review_count, :in_stock).symbolize_keys.merge(
+      price: product.price.to_f,
+      original_price: product.original_price&.to_f,
+      average_rating: product.average_rating.to_f,
+      discount_percentage: product.discount_percentage
+    )
+  end
+end

--- a/app/controllers/product_search_controller.rb
+++ b/app/controllers/product_search_controller.rb
@@ -4,7 +4,7 @@ class ProductSearchController < ApplicationController
   include ReactOnRailsPro::RSCPayloadRenderer
   include ReactOnRailsPro::AsyncRendering
 
-  enable_async_react_rendering only: [:search_rsc]
+  enable_async_react_rendering only: %i[search_rsc search_rsc_cached]
 
   before_action :set_seo_meta
 
@@ -43,7 +43,37 @@ class ProductSearchController < ApplicationController
     stream_view_containing_react_components(template: "product_search/search_rsc")
   end
 
+  # V1 cached: cached_react_component. On a hit, the full SSR data assembly (built lazily in the view
+  # block via product_search_ssr_props) and the prerender are skipped. Cache key is the search params.
+  def search_ssr_cached
+    @search_params_data = search_params.to_h
+  end
+
+  # V3 cached: cached_stream_react_component_with_async_props. On a hit, the async block (results,
+  # facets, tags, brand highlights) and the node render are skipped; chunks replay from cache.
+  def search_rsc_cached
+    @search_params_data = search_params.to_h
+    stream_view_containing_react_components(template: "product_search/search_rsc_cached")
+  end
+
   private
+
+  # Full SSR props, built lazily for the cached view block (evaluated only on a cache miss).
+  def product_search_ssr_props
+    products_scope = Product.filtered_search(search_params)
+    products_data = paginate_and_serialize(products_scope, PER_PAGE, rich: true)
+    {
+      products: products_data[:products],
+      pagination: products_data[:pagination],
+      facets: Product.facets(base_scope_for_facets),
+      search_meta: search_meta_data(products_scope),
+      descriptions: load_product_descriptions(products_data[:products], truncate_at: 500),
+      review_snippets: load_review_snippets(products_data[:products].map { |p| p[:id] }, per_product: 2),
+      popular_tags: load_popular_tags,
+      brand_highlights: load_brand_highlights
+    }
+  end
+  helper_method :product_search_ssr_props
 
   def set_seo_meta
     variant = SEO_VARIANTS[action_name]

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,8 +3,9 @@
 class ProductsController < ApplicationController
   include ReactOnRailsPro::RSCPayloadRenderer
   include ReactOnRailsPro::AsyncRendering
+  include ProductSerialization
 
-  enable_async_react_rendering only: [:show_rsc]
+  enable_async_react_rendering only: %i[show_rsc show_rsc_cached]
 
   before_action :set_seo_meta
 
@@ -44,7 +45,34 @@ class ProductsController < ApplicationController
     stream_view_containing_react_components(template: "products/show_rsc")
   end
 
+  # V1 cached: cached_react_component. Only the cheap base serialize runs eagerly (also powers the
+  # hero preload); the expensive reviews/related/stats are built lazily in the view block
+  # (product_ssr_props) and skipped, along with the prerender, on a cache hit.
+  def show_ssr_cached
+    @product = find_product
+    @product_data = serialize_product(@product)
+  end
+
+  # V3 cached: cached_stream_react_component_with_async_props. On a hit, the async block
+  # (reviews/related/etc.) and the node render are skipped; chunks are replayed from cache.
+  def show_rsc_cached
+    @product = find_product
+    @product_data = serialize_product(@product).except(:description, :features, :specs)
+    stream_view_containing_react_components(template: "products/show_rsc_cached")
+  end
+
   private
+
+  # Full SSR props, built lazily for the cached view block (evaluated only on a cache miss).
+  def product_ssr_props
+    {
+      product: @product_data,
+      reviews: @product.top_reviews(10).map { |r| serialize_review(r) },
+      review_stats: @product.review_stats,
+      related_products: @product.related_products(4).map { |p| serialize_product_card(p) }
+    }
+  end
+  helper_method :product_ssr_props
 
   def set_seo_meta
     variant = SEO_VARIANTS[action_name]
@@ -65,55 +93,5 @@ class ProductsController < ApplicationController
     else
       Product.first!
     end
-  end
-
-  def serialize_product(product)
-    {
-      id: product.id,
-      name: product.name,
-      description: product.description,
-      price: product.price.to_f,
-      original_price: product.original_price&.to_f,
-      category: product.category,
-      brand: product.brand,
-      sku: product.sku,
-      images: product.images,
-      specs: product.specs,
-      features: product.features,
-      average_rating: product.average_rating.to_f,
-      review_count: product.review_count,
-      stock_quantity: product.stock_quantity,
-      in_stock: product.in_stock,
-      discount_percentage: product.discount_percentage
-    }
-  end
-
-  def serialize_review(review)
-    {
-      id: review.id,
-      rating: review.rating,
-      title: review.title,
-      comment: review.comment,
-      reviewer_name: review.reviewer_name,
-      verified_purchase: review.verified_purchase,
-      helpful_count: review.helpful_count,
-      created_at: review.created_at.iso8601
-    }
-  end
-
-  def serialize_product_card(product)
-    {
-      id: product.id,
-      name: product.name,
-      price: product.price.to_f,
-      original_price: product.original_price&.to_f,
-      category: product.category,
-      brand: product.brand,
-      images: product.images,
-      average_rating: product.average_rating.to_f,
-      review_count: product.review_count,
-      in_stock: product.in_stock,
-      discount_percentage: product.discount_percentage
-    }
   end
 end

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -4,7 +4,7 @@ class RestaurantsController < ApplicationController
   include ReactOnRailsPro::RSCPayloadRenderer
   include ReactOnRailsPro::AsyncRendering
 
-  enable_async_react_rendering only: %i[show_rsc]
+  enable_async_react_rendering only: %i[show_rsc show_rsc_cached]
 
   before_action :set_seo_meta
 
@@ -37,6 +37,19 @@ class RestaurantsController < ApplicationController
     @restaurant = Restaurant.find(params[:id])
     @detail = RestaurantDetailData.for(@restaurant)
     stream_view_containing_react_components(template: "restaurants/show_rsc")
+  end
+
+  # V1 cached: cached_react_component. On a cache hit, both the detail assembly (built lazily in the
+  # view block) and the SSR prerender are skipped.
+  def show_ssr_cached
+    @restaurant = Restaurant.find(params[:id])
+  end
+
+  # V3 cached: cached_stream_react_component. On a hit, the streamed chunks are replayed and the
+  # detail assembly (view block) + node render are skipped.
+  def show_rsc_cached
+    @restaurant = Restaurant.find(params[:id])
+    stream_view_containing_react_components(template: "restaurants/show_rsc_cached")
   end
 
   private

--- a/app/helpers/react_on_rails_pro_cache_helper.rb
+++ b/app/helpers/react_on_rails_pro_cache_helper.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+# Application-level helper that adds a *cached* variant of
+# `stream_react_component_with_async_props`.
+#
+# React on Rails Pro ships `cached_stream_react_component` (fragment-cache wrapper around the plain
+# `stream_react_component` streaming path) but, as of 17.0.0.rc.3, there is no cached wrapper around
+# `stream_react_component_with_async_props`. This helper fills that gap **for this demo app** so we
+# can benchmark caching gains on the RSC pages that emit async props (see issue #97).
+#
+# It is NOT a copy of any proprietary gem code: it only orchestrates calls to the gem's public API
+# (`stream_react_component_with_async_props`, `ReactOnRailsPro::Cache.*`) and to the same-object
+# helper method `handle_stream_cache_hit` that the gem already mixes into this ActionView context.
+#
+# ---------------------------------------------------------------------------------------------------
+# Why caching an async-props stream is sound
+# ---------------------------------------------------------------------------------------------------
+# `stream_react_component_with_async_props` differs from `stream_react_component` only in that it sets
+# an `async_props_block`. Each `emit.call(section, data)` in that block is sent to the node renderer,
+# which streams the resulting HTML back **as additional chunks in the same response stream**. The
+# gem's `cached_stream_react_component` already collects *every* streamed chunk into an array (via the
+# `on_complete` callback) and, on a subsequent request, replays that array. Because the async-emitted
+# sections are just later chunks in that same stream, the captured array is the fully-resolved output
+# of all sections. On a cache hit we replay those chunks directly — the async block (DB queries,
+# `sleep`, node-renderer round-trips) never runs again.
+#
+# ---------------------------------------------------------------------------------------------------
+# IMPORTANT — cache key completeness
+# ---------------------------------------------------------------------------------------------------
+# The cache key (`ReactOnRailsPro::Cache.react_component_cache_key`) is built from the component name,
+# the gem/bundle versions, and YOUR `cache_key:` value — it does **not** include the props. Exactly
+# like Rails fragment caching, the caller's `cache_key:` must encode every input that changes the
+# rendered output: both the initial `:props` AND anything the async block emits (record ids,
+# updated_at, content version, search params, …). Do NOT fold artificial timing (e.g. a demo
+# `sleep`/delay) into the key — skipping that work on a hit is the whole point.
+module ReactOnRailsProCacheHelper
+  # Cached variant of `stream_react_component_with_async_props`.
+  #
+  # Same arguments as `stream_react_component_with_async_props` (the block is the async props block,
+  # initial/sync props go in `:props`) with the fragment-caching additions of
+  # `cached_stream_react_component`:
+  #
+  # 1. Provide `cache_key:` — String / Array / Proc, same semantics as Rails fragment caching. The
+  #    server bundle digest is folded in automatically (prerender is always true for streaming).
+  # 2. Optionally provide `cache_options:` (`:expires_in`, `:compress`, `:race_condition_ttl`).
+  # 3. Optionally provide `:if` / `:unless` to conditionally enable caching.
+  # 4. `:props` may be a Hash (evaluated eagerly by the view) OR a callable/Proc (evaluated lazily,
+  #    only on a cache miss) so that nothing expensive runs on a hit.
+  #
+  # @example
+  #   <%= cached_stream_react_component_with_async_props("BlogPostRSC",
+  #         cache_key: ["blog_post_rsc", @post_meta[:id], @post_meta[:updated_at]],
+  #         cache_options: { expires_in: 1.hour },
+  #         props: { post: @post_meta }) do |emit|
+  #         emit.call("post_content", { content: BlogData.find_post(@post_meta[:id])[:content] })
+  #       end %>
+  def cached_stream_react_component_with_async_props(component_name, raw_options = {}, &async_props_block)
+    unless ReactOnRailsPro.configuration.enable_rsc_support
+      raise ReactOnRailsPro::Error,
+            'cached_stream_react_component_with_async_props requires enable_rsc_support to be true. ' \
+            'Async props depend on React Server Components. ' \
+            'Set `config.enable_rsc_support = true` in your ReactOnRailsPro configuration.'
+    end
+
+    ReactOnRailsPro::Utils.with_trace(component_name) do
+      check_async_caching_options!(raw_options, async_props_block)
+      fetch_cached_stream_async_props(component_name, raw_options, &async_props_block)
+    end
+  end
+
+  private
+
+  # Mirrors the gem's `check_caching_options!` but, unlike the plain cached helper, *allows* a
+  # `:props` key — for async-props components the block is the async props block, not the props
+  # source, so initial/sync props legitimately arrive via `:props`.
+  def check_async_caching_options!(raw_options, block)
+    if block.nil?
+      raise ReactOnRailsPro::Error,
+            'cached_stream_react_component_with_async_props requires the async props to be passed as a block'
+    end
+
+    return if raw_options.key?(:cache_key)
+
+    raise ReactOnRailsPro::Error, "Option 'cache_key' is required for React on Rails caching"
+  end
+
+  # Cache-flow mirror of the gem's private `fetch_stream_react_component`, swapping the terminal
+  # render call for the async-props variant.
+  def fetch_cached_stream_async_props(component_name, raw_options, &async_props_block)
+    auto_load_bundle = ReactOnRails.configuration.auto_load_bundle || raw_options[:auto_load_bundle]
+
+    # Conditional caching (:if / :unless disabled) — stream live without touching the cache.
+    unless ReactOnRailsPro::Cache.use_cache?(raw_options)
+      return render_async_props_stream(component_name, raw_options, auto_load_bundle, nil, &async_props_block)
+    end
+
+    fetch_cached_stream_async_props_with_cache(component_name, raw_options, auto_load_bundle, &async_props_block)
+  end
+
+  def fetch_cached_stream_async_props_with_cache(component_name, raw_options, auto_load_bundle, &async_props_block)
+    view_cache_key = stream_async_props_cache_key(component_name, raw_options)
+
+    # HIT: replay the cached chunk array without evaluating props or running the async block.
+    cached_chunks = Rails.cache.read(view_cache_key)
+    if cached_chunks.is_a?(Array)
+      log_stream_cache_event('HIT', component_name, view_cache_key, "(#{cached_chunks.size} chunks) ")
+      # Reuse the gem's replay path. Props are irrelevant to chunk replay (load_pack only needs the
+      # component name + auto_load_bundle), so strip them — this also keeps a lazy Proc from leaking
+      # into RenderOptions on a hit.
+      return handle_stream_cache_hit(component_name, raw_options.except(:props), auto_load_bundle, cached_chunks)
+    end
+
+    # MISS: stream live and write the full chunk array through to the cache once fully consumed.
+    log_stream_cache_event('MISS', component_name, view_cache_key, '(rendering live) ')
+    on_complete = cache_writethrough_callback(component_name, view_cache_key, raw_options)
+    render_async_props_stream(component_name, raw_options, auto_load_bundle, on_complete, &async_props_block)
+  end
+
+  # prerender: true folds the server bundle digest into the key (matches the gem's stream caching).
+  def stream_async_props_cache_key(component_name, raw_options)
+    ReactOnRailsPro::Cache.react_component_cache_key(component_name, raw_options.merge(prerender: true))
+  end
+
+  def cache_writethrough_callback(component_name, view_cache_key, raw_options)
+    lambda do |chunks|
+      Rails.cache.write(view_cache_key, chunks, raw_options[:cache_options] || {})
+      log_stream_cache_event('WROTE', component_name, view_cache_key, "(#{chunks.size} chunks) ")
+    end
+  end
+
+  # Distinctive, greppable marker so stream caching is observable in the logs. The streamed cache does
+  # NOT set RORP_CACHE_HIT (that flag is only populated on the Hash-returning react_component path), so
+  # this log line is the intended way to confirm a hit/miss for cached_stream_react_component_with_async_props.
+  def log_stream_cache_event(event, component_name, view_cache_key, detail = '')
+    Rails.logger.info do
+      "[RORP cached_stream_async_props] #{event} #{component_name} #{detail}key=#{view_cache_key.inspect}"
+    end
+  end
+
+  # Resolves (possibly lazy) sync props and delegates to the gem's async-props streaming helper,
+  # threading the write-through `on_complete` callback when caching.
+  def render_async_props_stream(component_name, raw_options, auto_load_bundle, on_complete, &async_props_block)
+    props = raw_options[:props]
+    props = props.call if props.respond_to?(:call)
+
+    options = raw_options.merge(
+      props: props,
+      prerender: true,
+      skip_prerender_cache: true,
+      auto_load_bundle: auto_load_bundle
+    )
+    # `stream_react_component` (called downstream) does `options.delete(:on_complete)` and forwards it
+    # to `consumer_stream_async`, which collects + replays chunks and fires the callback only on a
+    # fully-consumed stream (never caches a client-disconnected/partial stream).
+    options[:on_complete] = on_complete if on_complete
+
+    stream_react_component_with_async_props(component_name, options, &async_props_block)
+  end
+end

--- a/app/views/blog/post_rsc_cached.html.erb
+++ b/app/views/blog/post_rsc_cached.html.erb
@@ -1,0 +1,24 @@
+<%# Cached variant of blog/post_rsc.html.erb. Same component, sync props, and async section emits,
+    but wrapped in cached_stream_react_component_with_async_props (see
+    app/helpers/react_on_rails_pro_cache_helper.rb).
+
+    cache_key: the post content (MAIN_POST) is static demo data that varies only by id, so the post id
+    is a stable, complete key. The simulated delays (CONTENT_DELAY_MS / sleep 1.5) are deliberately
+    NOT in the key — they change timing, not output, and skipping them on a hit is the whole point.
+
+    On a cache HIT the block below never runs: the two sleeps, the content fetch, and the related-posts
+    lookup are all skipped, and the previously-streamed chunks are replayed from cache. %>
+<%= cached_stream_react_component_with_async_props("BlogPostRSC",
+      cache_key: ["blog_post_rsc", @post_meta[:id]],
+      props: { post: @post_meta }, prerender: true) do |emit|
+  # Simulate slow content fetch (e.g., CMS API, database query).
+  sleep(@content_delay) if @content_delay > 0
+  content = BlogData.find_post(@post_meta[:id])[:content]
+  emit.call("post_content", { content: content })
+
+  sleep 1.5  # Simulate slow recommendation engine
+
+  emit.call("related_posts", {
+    posts: BlogData.related_posts(@post_meta[:id])
+  })
+end %>

--- a/app/views/blog/post_rsc_simple_cached.html.erb
+++ b/app/views/blog/post_rsc_simple_cached.html.erb
@@ -1,0 +1,7 @@
+<%# Cached variant of blog/post_rsc_simple.html.erb (plain stream, all data upfront). cached_stream_
+    react_component caches the streamed chunks; on a hit they replay and the data fetch + node render
+    are skipped. Props come from the block. Blog content is static, so the post id is a stable key. %>
+<%= cached_stream_react_component("BlogPostRSCSimple", cache_key: ["blog_rsc_simple", 1], prerender: true) do
+  post = BlogData.find_post(1)
+  { post: post, related_posts: BlogData.related_posts(post[:id]) }
+end %>

--- a/app/views/blog/post_ssr_cached.html.erb
+++ b/app/views/blog/post_ssr_cached.html.erb
@@ -1,0 +1,10 @@
+<%# Cached variant of blog/post_ssr.html.erb. Props (incl. the simulated content delay) are built in
+    the block, so on a cache hit the data fetch, the delay, and the SSR prerender are all skipped.
+    Blog content is static demo data, so the post id is a stable cache key. The CONTENT_DELAY_MS is
+    deliberately NOT in the key (it changes timing, not output). %>
+<%= cached_react_component("BlogPostSSR", cache_key: ["blog_ssr", 1], prerender: true) do
+  content_delay = ENV.fetch("CONTENT_DELAY_MS", "0").to_f / 1000
+  sleep(content_delay) if content_delay > 0
+  post = BlogData.find_post(1)
+  { post: post, related_posts: BlogData.related_posts(post[:id]) }
+end %>

--- a/app/views/product_search/search_rsc_cached.html.erb
+++ b/app/views/product_search/search_rsc_cached.html.erb
@@ -1,0 +1,147 @@
+<%# Cached variant of product_search/search_rsc.html.erb. Same component, sync props, and async emits,
+    wrapped in cached_stream_react_component_with_async_props. On a hit the async block (results,
+    facets, tags, brand highlights) and the node render are skipped; chunks replay from cache.
+    cache_key = the search params (they determine the output). %>
+<%= cached_stream_react_component_with_async_props("ProductSearchRSC",
+    cache_key: ["product_search_rsc", @search_params_data.sort],
+    props: { search_params: @search_params_data }, prerender: true) do |emit|
+
+  # 1. Stream search results FIRST — this is the LCP content.
+  #    Now includes the same rich data as SSR for a fair comparison:
+  #    - 500-char descriptions (same as SSR)
+  #    - 6 features per product (same as SSR)
+  #    - specs hash (same as SSR)
+  #    - 2 review snippets per product (same as SSR)
+  products_scope = Product.filtered_search(@search_params_data.symbolize_keys)
+  page = (@search_params_data[:page] || @search_params_data["page"] || 1).to_i
+  per_page = 24
+  total = products_scope.count
+  products = products_scope.offset((page - 1) * per_page).limit(per_page)
+
+  serialized_products = products.map do |p|
+    {
+      id: p.id,
+      name: p.name,
+      description: p.description&.truncate(500),
+      price: p.price.to_f,
+      original_price: p.original_price&.to_f,
+      category: p.category,
+      brand: p.brand,
+      sku: p.sku,
+      images: p.images,
+      features: (p.features || []).first(6),
+      tags: p.tags || [],
+      average_rating: p.average_rating.to_f,
+      review_count: p.review_count,
+      in_stock: p.in_stock,
+      stock_quantity: p.stock_quantity,
+      discount_percentage: p.discount_percentage,
+      specs: p.specs || {},
+    }
+  end
+
+  # Load review snippets (2 per product, same as SSR)
+  product_ids = serialized_products.map { |p| p[:id] }
+  review_snippets = {}
+  if product_ids.any?
+    sql = <<~SQL
+      SELECT product_id, title, rating, reviewer_name, comment, helpful_count
+      FROM (
+        SELECT product_id, title, rating, reviewer_name, comment, helpful_count,
+               ROW_NUMBER() OVER (PARTITION BY product_id ORDER BY helpful_count DESC, created_at DESC) as rn
+        FROM product_reviews
+        WHERE product_id IN (#{product_ids.map { |id| ActiveRecord::Base.connection.quote(id) }.join(',')})
+          AND rating >= 3
+          AND verified_purchase = true
+      ) ranked
+      WHERE rn <= 2
+    SQL
+
+    ActiveRecord::Base.connection.execute(sql).each do |row|
+      pid = row['product_id']
+      review_snippets[pid] ||= []
+      review_snippets[pid] << {
+        title: row['title'],
+        rating: row['rating'],
+        reviewer_name: row['reviewer_name'],
+        comment: row['comment']&.truncate(200),
+        helpful_count: row['helpful_count'],
+      }
+    end
+  end
+
+  # Build active filters list (same as SSR)
+  sp = @search_params_data.symbolize_keys
+  filters_applied = []
+  filters_applied << { type: 'category', value: sp[:category] } if sp[:category].present?
+  filters_applied << { type: 'brand', value: sp[:brand] } if sp[:brand].present?
+  filters_applied << { type: 'min_rating', value: "#{sp[:min_rating]}+" } if sp[:min_rating].present?
+  filters_applied << { type: 'in_stock', value: 'In Stock Only' } if sp[:in_stock] == 'true'
+  if sp[:price_min].present? && sp[:price_max].present?
+    filters_applied << { type: 'price', value: "$#{sp[:price_min]} - $#{sp[:price_max]}" }
+  end
+
+  empty_suggestions = nil
+  if serialized_products.empty?
+    empty_suggestions = {
+      top_categories: Product.group(:category)
+                            .order(Arel.sql("COUNT(*) DESC"))
+                            .limit(6)
+                            .pluck(Arel.sql("category, COUNT(*)"))
+                            .map { |name, count| { name: name, count: count } },
+      top_brands: Product.group(:brand)
+                        .order(Arel.sql("COUNT(*) DESC"))
+                        .limit(8)
+                        .pluck(Arel.sql("brand, COUNT(*)"))
+                        .map { |name, count| { name: name, count: count } },
+    }
+  end
+
+  emit.call("search_results", {
+    products: serialized_products,
+    review_snippets: review_snippets,
+    pagination: {
+      current_page: page,
+      total_pages: (total / per_page.to_f).ceil,
+      total_count: total,
+      per_page: per_page,
+    },
+    meta: {
+      query: sp[:q] || '',
+      sort: sp[:sort] || 'relevance',
+      total_results: total,
+      filters_applied: filters_applied,
+    },
+    empty_suggestions: empty_suggestions,
+  })
+
+  # 2. Stream facet counts — expensive aggregation queries
+  base_scope = Product.all
+  q = sp[:q]
+  base_scope = base_scope.search_query(q) if q.present?
+  emit.call("facets", Product.facets(base_scope))
+
+  # 3. Stream popular tags (same as SSR)
+  popular_tags = Product.where.not(tags: nil)
+    .pluck(:tags)
+    .flatten
+    .tally
+    .sort_by { |_, count| -count }
+    .first(20)
+    .map { |tag, count| { name: tag, count: count } }
+  emit.call("popular_tags", popular_tags)
+
+  # 4. Stream brand highlights (same as SSR)
+  brand_highlights = Product.group(:brand)
+    .select("brand, COUNT(*) as product_count, AVG(average_rating) as avg_rating")
+    .order("product_count DESC")
+    .limit(8)
+    .map do |b|
+      {
+        name: b.brand,
+        product_count: b.product_count,
+        avg_rating: b.avg_rating.to_f.round(1),
+      }
+    end
+  emit.call("brand_highlights", brand_highlights)
+end %>

--- a/app/views/product_search/search_ssr_cached.html.erb
+++ b/app/views/product_search/search_ssr_cached.html.erb
@@ -1,0 +1,7 @@
+<%# Cached variant of product_search/search_ssr.html.erb. The full SSR data assembly (paginated
+    results, facets, review snippets, tags, brand highlights) is built in product_search_ssr_props and
+    evaluated only on a cache miss; on a hit it and the prerender are skipped.
+    cache_key = the search params (they determine the rendered output). %>
+<%= cached_react_component("ProductSearchSSR",
+      cache_key: ["product_search_ssr", @search_params_data.sort],
+      prerender: true) { product_search_ssr_props } %>

--- a/app/views/products/show_rsc_cached.html.erb
+++ b/app/views/products/show_rsc_cached.html.erb
@@ -1,0 +1,59 @@
+<% content_for :head do %>
+  <link rel="preload" as="image" href="<%= hero_image_url %>" fetchpriority="high">
+<% end %>
+<%# Cached variant of products/show_rsc.html.erb. Same component, sync props, and async emits, wrapped
+    in cached_stream_react_component_with_async_props. On a hit the async block (review stats, reviews,
+    related products) and the node render are skipped; chunks replay from cache.
+    cache_key = product id + updated_at. %>
+<%= cached_stream_react_component_with_async_props("ProductPageRSC",
+    cache_key: ["product_rsc", @product.id, @product.updated_at.to_i],
+    props: { product: @product_data }, prerender: true) do |emit|
+
+  # Stream product details first (below-the-fold: description, features, specs)
+  # Emitted immediately — prioritizes hero section in initial stream for faster LCP
+  emit.call("product_details", {
+    description: @product.description,
+    features: @product.features,
+    specs: @product.specs,
+  })
+
+  # Stream review statistics (rating distribution aggregation)
+  emit.call("review_stats", @product.review_stats)
+
+  # Stream customer reviews (complex sort query)
+  reviews = @product.top_reviews(5)
+  emit.call("reviews", {
+    reviews: reviews.map { |r|
+      {
+        id: r.id,
+        rating: r.rating,
+        title: r.title,
+        comment: r.comment,
+        reviewer_name: r.reviewer_name,
+        verified_purchase: r.verified_purchase,
+        helpful_count: r.helpful_count,
+        created_at: r.created_at.iso8601,
+      }
+    }
+  })
+
+  # Stream related products
+  related = @product.related_products(4)
+  emit.call("related_products", {
+    products: related.map { |p|
+      {
+        id: p.id,
+        name: p.name,
+        price: p.price.to_f,
+        original_price: p.original_price&.to_f,
+        category: p.category,
+        brand: p.brand,
+        images: p.images,
+        average_rating: p.average_rating.to_f,
+        review_count: p.review_count,
+        in_stock: p.in_stock,
+        discount_percentage: p.discount_percentage,
+      }
+    }
+  })
+end %>

--- a/app/views/products/show_ssr_cached.html.erb
+++ b/app/views/products/show_ssr_cached.html.erb
@@ -1,0 +1,9 @@
+<% content_for :head do %>
+  <link rel="preload" as="image" href="<%= hero_image_url %>" fetchpriority="high">
+<% end %>
+<%# Cached variant of products/show_ssr.html.erb. The expensive props (top 10 reviews, review stats,
+    4 related products) are built in product_ssr_props and evaluated only on a cache miss; on a hit
+    they and the SSR prerender are skipped. cache_key = product id + updated_at. %>
+<%= cached_react_component("ProductPageSSR",
+      cache_key: ["product_ssr", @product.id, @product.updated_at.to_i],
+      prerender: true) { product_ssr_props } %>

--- a/app/views/restaurants/show_rsc_cached.html.erb
+++ b/app/views/restaurants/show_rsc_cached.html.erb
@@ -1,0 +1,6 @@
+<%# Cached variant of restaurants/show_rsc.html.erb (plain stream, no async props). cached_stream_
+    react_component caches the streamed chunks; on a hit they replay and the detail assembly +
+    node render are skipped. Props come from the block. cache_key = restaurant id + updated_at. %>
+<%= cached_stream_react_component("RestaurantDetailRSC",
+      cache_key: ["restaurant_rsc", @restaurant.id, @restaurant.updated_at.to_i],
+      prerender: true) { RestaurantDetailData.for(@restaurant) } %>

--- a/app/views/restaurants/show_ssr_cached.html.erb
+++ b/app/views/restaurants/show_ssr_cached.html.erb
@@ -1,0 +1,6 @@
+<%# Cached variant of restaurants/show_ssr.html.erb. Props are built in the block so the detail
+    assembly (markdown bio, 80-item menu, 40 reviews, price ladder) is skipped on a cache hit,
+    along with the SSR prerender. cache_key = restaurant id + updated_at. %>
+<%= cached_react_component("RestaurantDetailSSR",
+      cache_key: ["restaurant_ssr", @restaurant.id, @restaurant.updated_at.to_i],
+      prerender: true) { RestaurantDetailData.for(@restaurant) } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,25 +27,33 @@ Rails.application.routes.draw do
 
   # Restaurant detail page — three versions for the markdown-heavy detail view
   get '/restaurant/:id/ssr', to: 'restaurants#show_ssr', as: :restaurant_show_ssr
+  get '/restaurant/:id/ssr-cached', to: 'restaurants#show_ssr_cached' # SSR + cached_react_component
   get '/restaurant/:id/client', to: 'restaurants#show_client', as: :restaurant_show_client
   get '/restaurant/:id/rsc', to: 'restaurants#show_rsc', as: :restaurant_show_rsc
+  get '/restaurant/:id/rsc-cached', to: 'restaurants#show_rsc_cached' # RSC + cached_stream_react_component
 
   # Product page routes — three versions demonstrating e-commerce RSC gains
   get '/product/ssr', to: 'products#show_ssr'        # V1: All data fetched on server, returned at once
+  get '/product/ssr-cached', to: 'products#show_ssr_cached' # V1 + cached_react_component
   get '/product/client', to: 'products#show_client'   # V2: Loadable components, client-side fetch
   get '/product/rsc', to: 'products#show_rsc'         # V3: RSC streaming
+  get '/product/rsc-cached', to: 'products#show_rsc_cached' # V3 + cached_stream_react_component_with_async_props
 
   # Product search results — three versions demonstrating search page RSC gains
   get '/product-search/ssr', to: 'product_search#search_ssr'       # V1: Full SSR
+  get '/product-search/ssr-cached', to: 'product_search#search_ssr_cached' # V1 + cached_react_component
   get '/product-search/client', to: 'product_search#search_client'  # V2: Client-side search
   get '/product-search/rsc', to: 'product_search#search_rsc'        # V3: RSC streaming
+  get '/product-search/rsc-cached', to: 'product_search#search_rsc_cached' # V3 + cached stream w/ async props
 
   # Blog post routes — three versions demonstrating bundle size differences
   get '/blog/ssr', to: 'blog#post_ssr'       # V1: marked + highlight.js shipped to client
+  get '/blog/ssr-cached', to: 'blog#post_ssr_cached' # V1 + cached_react_component
   get '/blog/client', to: 'blog#post_client'  # V2: Libraries loaded in async chunk
   get '/blog/rsc', to: 'blog#post_rsc'              # V3: Libraries stay server-side + streaming
   get '/blog/rsc-cached', to: 'blog#post_rsc_cached' # V3 + cache (cached_stream_react_component_with_async_props)
   get '/blog/rsc-simple', to: 'blog#post_rsc_simple' # V4: Libraries stay server-side, all data upfront
+  get '/blog/rsc-simple-cached', to: 'blog#post_rsc_simple_cached' # V4 + cached_stream_react_component
 
   # RSC debug steps (incremental complexity)
   get '/blog/rsc-step1', to: 'blog#post_rsc_step1'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
   get '/blog/ssr', to: 'blog#post_ssr'       # V1: marked + highlight.js shipped to client
   get '/blog/client', to: 'blog#post_client'  # V2: Libraries loaded in async chunk
   get '/blog/rsc', to: 'blog#post_rsc'              # V3: Libraries stay server-side + streaming
+  get '/blog/rsc-cached', to: 'blog#post_rsc_cached' # V3 + cache (cached_stream_react_component_with_async_props)
   get '/blog/rsc-simple', to: 'blog#post_rsc_simple' # V4: Libraries stay server-side, all data upfront
 
   # RSC debug steps (incremental complexity)

--- a/docs/cached-async-props-helper-design.md
+++ b/docs/cached-async-props-helper-design.md
@@ -1,0 +1,176 @@
+# Design: `cached_stream_react_component_with_async_props` (issue #97)
+
+Repo helper that combines whole-stream fragment caching (`cached_stream_react_component`)
+with async section emits (`stream_react_component_with_async_props`).
+Implemented **in this repo** (we hold a RoR Pro license), no gem modification, no copying of
+proprietary gem source — only original orchestration code that calls the gem's public + (same-object)
+private API.
+
+Gem under review: `react_on_rails_pro 17.0.0.rc.3`
+File: `app/helpers/react_on_rails_pro_helper.rb` (the gem's helper).
+
+## Established facts (verified against gem source)
+
+1. **`cached_stream_react_component` → `fetch_stream_react_component`** (helper, lines ~254, ~327):
+   - Cache key: `ReactOnRailsPro::Cache.react_component_cache_key(name, opts.merge(prerender: true))`.
+     Key = `[type, ReactOnRails::VERSION, ReactOnRailsPro::VERSION, bundle_hash(if prerender),
+     deps_checksum, component_name, user_cache_key]`. **Props are NOT in the key** (cache.rb:83-98).
+   - HIT: `Rails.cache.read(key)` returns an `Array` of chunks → `handle_stream_cache_hit`
+     (loads pack, returns first chunk synchronously, async-enqueues the rest to `@main_output_queue`).
+   - MISS: `handle_stream_cache_miss` wraps options with
+     `on_complete: ->(chunks){ Rails.cache.write(key, chunks, cache_options) }`, then
+     `render_stream_component_with_props` (`props = yield`; calls `stream_react_component`).
+
+2. **Chunk capture** (`consumer_stream_async` / `process_stream_chunks`, lines ~471-539):
+   - When `on_complete` is set, EVERY emitted chunk is pushed into `all_chunks`.
+   - `on_complete.call(all_chunks)` runs **only if the stream is fully consumed**
+     (client-disconnect/partial → `false` → no cache write). So we never cache a truncated stream.
+
+3. **Async-emitted props become ordinary downstream stream chunks** (`request.rb`
+   `render_code_with_incremental_updates`, lines ~90-129): `emit.call(section, data)` sends an NDJSON
+   `updateChunk` to the node renderer, which streams back additional HTML chunks **in the same stream**.
+   Therefore `all_chunks` already captures the fully-resolved, all-sections output.
+   **=> Caching an async-props stream is sound; on a hit we replay all chunks WITHOUT re-running the
+   async block (no DB work, no `sleep`, no node round-trip).**
+
+4. **`stream_react_component_with_async_props`** (helper, line ~157): only difference from
+   `stream_react_component` is `options[:async_props_block] = block`. Requires `enable_rsc_support`
+   (✓ set in `config/initializers/react_on_rails_pro.rb`). Initial/sync props passed via `:props`.
+
+5. **`load_pack_for_generated_component`** (ror helper.rb:411) reads only `auto_load_bundle` +
+   `react_component_name` — **not props**. => safe to strip `:props` before the hit-path call.
+
+## The core tension
+
+- `cached_stream_react_component` **forbids** a `:props` key (`check_caching_options!` raises if
+  `raw_options.key?(:props)`) because it sources props from the block.
+- `stream_react_component_with_async_props` uses the block as the **async** props block, and passes
+  initial/sync props via `:props` (e.g. `props: { post: @post_meta }`).
+
+So the new helper must: (a) treat the block as the **async_props_block**; (b) **allow** a `:props`
+option for initial/sync props; (c) still **require** `:cache_key`.
+
+## Caveats to enforce / document
+
+- **Cache-key completeness (critical):** props are NOT in the key, so the caller's `cache_key:` must
+  encode every input that drives BOTH the sync props and the async-emitted data
+  (e.g. record id + updated_at / content version). Standard Rails fragment-cache contract.
+  The artificial `sleep`/`@content_delay` must NOT be in the key (it changes timing, not output —
+  skipping it on a hit is the whole point of the demo).
+- **Prop eval on hit:** a `:props` Hash literal is evaluated eagerly by ERB even on a hit. To allow
+  truly skipping it, the helper will accept `props:` as **either a Hash (eager) or a callable/Proc
+  (lazy, evaluated only on miss/uncached)**. The async block is never evaluated on a hit.
+
+## Implementation plan
+
+New file `app/helpers/react_on_rails_pro_cache_helper.rb`, module
+`ReactOnRailsProCacheHelper`. Because Rails mixes all helpers into the same ActionView context as the
+gem's `ReactOnRailsProHelper`, the new method can call the gem's same-object private methods
+(`handle_stream_cache_hit`) and public methods (`stream_react_component_with_async_props`,
+`ReactOnRailsPro::Cache.*`).
+
+```ruby
+module ReactOnRailsProCacheHelper
+  def cached_stream_react_component_with_async_props(component_name, raw_options = {}, &async_props_block)
+    unless ReactOnRailsPro.configuration.enable_rsc_support
+      raise ReactOnRailsPro::Error, "...requires enable_rsc_support to be true..."
+    end
+    ReactOnRailsPro::Utils.with_trace(component_name) do
+      check_async_caching_options!(raw_options, async_props_block)
+      fetch_cached_stream_async_props(component_name, raw_options, &async_props_block)
+    end
+  end
+
+  private
+
+  def check_async_caching_options!(raw_options, block)
+    raise ReactOnRailsPro::Error, "Pass the async props as a block" if block.nil?
+    raise ReactOnRailsPro::Error, "Option 'cache_key' is required" unless raw_options.key?(:cache_key)
+  end
+
+  def fetch_cached_stream_async_props(component_name, raw_options, &async_props_block)
+    auto_load_bundle = ReactOnRails.configuration.auto_load_bundle || raw_options[:auto_load_bundle]
+
+    unless ReactOnRailsPro::Cache.use_cache?(raw_options)
+      return render_async_stream(component_name, raw_options, auto_load_bundle, nil, &async_props_block)
+    end
+
+    key_options   = raw_options.merge(prerender: true)
+    view_cache_key = ReactOnRailsPro::Cache.react_component_cache_key(component_name, key_options)
+
+    cached_chunks = Rails.cache.read(view_cache_key)
+    if cached_chunks.is_a?(Array)
+      # Reuse the gem's replay path. Strip :props (irrelevant to chunk replay; load_pack ignores props)
+      # so a lazy Proc never leaks into RenderOptions.
+      return handle_stream_cache_hit(component_name, raw_options.except(:props), auto_load_bundle, cached_chunks)
+    end
+
+    on_complete = ->(chunks) { Rails.cache.write(view_cache_key, chunks, raw_options[:cache_options] || {}) }
+    render_async_stream(component_name, raw_options, auto_load_bundle, on_complete, &async_props_block)
+  end
+
+  def render_async_stream(component_name, raw_options, auto_load_bundle, on_complete, &async_props_block)
+    props = raw_options[:props]
+    props = props.call if props.respond_to?(:call)   # lazy props supported
+
+    options = raw_options.merge(
+      props: props,
+      prerender: true,
+      skip_prerender_cache: true,
+      auto_load_bundle: auto_load_bundle
+    )
+    options[:on_complete] = on_complete if on_complete
+
+    stream_react_component_with_async_props(component_name, options, &async_props_block)
+  end
+end
+```
+
+Notes:
+- `stream_react_component_with_async_props` sets `async_props_block`, then `stream_react_component`
+  does `options.delete(:on_complete)` and passes it to `consumer_stream_async` → write-through works.
+- I keep cache-only keys (`:cache_key`, `:cache_options`, `:if`, `:unless`) in the options passed
+  downstream **for parity** with the gem's own `render_stream_component_with_props`, which does the
+  same and is proven safe in production.
+- Reusing the private `handle_stream_cache_hit` couples to this gem version; acceptable for a demo
+  repo pinned to one version, and keeps hit-path behavior identical to `cached_stream_react_component`.
+
+## Usage (step 3)
+
+Add `*-cached` route variants for the three async-props pages (keep uncached routes as the benchmark
+baseline): `/blog/rsc-cached`, `/product/rsc-cached`, `/product-search/rsc-cached`.
+Each new controller action mirrors the existing one; the view calls
+`cached_stream_react_component_with_async_props` with a deterministic `cache_key` and the same
+`props:` + async block. Start with `/blog/rsc-cached` as the canonical demo, then fan out.
+
+## Open questions for reviewer
+
+1. Reuse gem-private `handle_stream_cache_hit` vs. inline a copy? (coupling vs. duplication)
+2. Support lazy `props:` Proc, or keep parity with the eager `:props` Hash only?
+3. Helper location/name: `app/helpers/react_on_rails_pro_cache_helper.rb` OK?
+4. Should cache-only keys be stripped before the downstream render call, or kept for gem parity?
+
+## Resolution (co-reviewed with Codex gpt-5.5 @ xhigh — all four steps AGREED)
+
+- Design / Implementation / Usage-plan / Final-diff each reviewed; advanced only on mutual agreement.
+- Q1: reuse gem-private `handle_stream_cache_hit` — accepted (demo pinned to one gem version; keeps
+  hit-path behavior identical to `cached_stream_react_component`).
+- Q2: support lazy `props:` Proc — accepted (strictly better; nothing expensive runs on a hit).
+- Q3: `app/helpers/react_on_rails_pro_cache_helper.rb` — accepted.
+- Q4: keep cache-only keys downstream for parity with the gem's own `render_stream_component_with_props`
+  (proven safe). On the HIT path we additionally strip `:props` (irrelevant to replay; `load_pack`
+  only needs component name + auto_load_bundle).
+
+### Implemented
+- Helper: `app/helpers/react_on_rails_pro_cache_helper.rb`.
+- Used on: `/blog/rsc-cached` → `BlogController#post_rsc_cached` → `app/views/blog/post_rsc_cached.html.erb`
+  (cached sibling of `/blog/rsc`; uncached route kept as the benchmark baseline).
+- `cache_key: ["blog_post_rsc", @post_meta[:id]]` (static demo content varies only by id; the
+  simulated delays are deliberately NOT in the key).
+
+### Verification caveat (for the benchmark step)
+`RORP_CACHE_HIT` is set only on the Hash-returning `react_component` cache path, NOT on this view-level
+*stream* chunk cache. To prove a hit on the streamed pages, use **timing** (a hit skips the
+`CONTENT_DELAY_MS` + `sleep 1.5` and the node-renderer round-trip), a **log line**, or **`Rails.cache`
+key inspection**. This is itself a data point for the issue's "is the cache hit actually exercised?"
+investigation. Optional follow-up: add a `Rails.logger.info`/debug hit-vs-miss marker in the helper.

--- a/docs/cached-page-variants-benchmark.md
+++ b/docs/cached-page-variants-benchmark.md
@@ -144,18 +144,51 @@ Contributing factors (verified, none a real regression):
   Suspense reconciliation on top of HTML paint), which is why a tiny sample can misreport it. The
   *median* is unaffected.
 
-Caveat: this is unthrottled local dev. A throttled / production profile (slow CPU + network) is the
-right next step to confirm mobile behaviour; proving a *real* RSC LCP mechanism would require a
-main-thread trace showing Flight decode / Suspense reveal delaying the actual LCP candidate — which
-the current data does not show. (This investigation was cross-reviewed with Codex gpt-5.5 @ xhigh.)
+Caveat: this section is unthrottled local dev. **§3d re-runs it on a production build under throttled
+mobile** — and far from a regression, cached RSC there is ~1 s faster on LCP than cached SSR, because
+dev's fast CPU was hiding SSR's JavaScript-execution cost. (This investigation was cross-reviewed with
+Codex gpt-5.5 @ xhigh.)
+
+## 3d. Production + throttled-mobile profile (the realistic result)
+
+The §2–§3c numbers are unthrottled local **dev**. On a fast desktop CPU, parsing a few MB of JS is
+near-instant, so SSR's JS weight doesn't hurt LCP and SSR/RSC look ~tied. That hides the real mobile
+story. Re-run on a **production build** (`RAILS_ENV=production`, minified, eager-loaded, served from
+`localhost:5000`) under the project's throttle (**4× CPU, ~1.6 Mbps / 150 ms RTT, mobile viewport**).
+Both tools agree (harness puppeteer N=6 and an independent interleaved Playwright A/B N=8); harness
+numbers shown:
+
+| Metric (cached, prod + throttled mobile) | blog SSR | blog RSC | search SSR | search RSC |
+|---|---|---|---|---|
+| TTFB | 11.6 ms | 16.0 ms | 13.5 ms | 13.6 ms |
+| FCP | 2840 ms | **1840 ms** | 3356 ms | **2532 ms** |
+| **LCP** | 2840 ms | **1840 ms** (−1000) | 3356 ms | **2828 ms** (−528) |
+| **TBT** | 4190 ms | **205 ms** | 907 ms | **222 ms** |
+| Hydration | **9754 ms** | 506 ms | — | — |
+| CLS | 0 | 0 | 0 | 0 |
+| JS transfer (gzip) | **1550 KB** | **249 KB** | 1573 KB | **262 KB** |
+
+**Under realistic conditions, cached RSC is decisively FASTER than cached SSR on LCP — the opposite of
+a regression.** blog LCP 1840 vs 2840 ms (RSC ~35 % faster); search 2828 vs 3356 ms.
+
+**Root cause (now explicit):** RSC ships **~6× less JavaScript over the wire** (249 KB vs 1550 KB
+gzipped). On a throttled mobile CPU, SSR's bundle must download + parse + execute before/while the
+page becomes usable, blocking the main thread for seconds — TBT **4190 ms** and hydration **~9.8 s**
+for blog SSR — which pushes its LCP out to 2840 ms. RSC's tiny client payload barely blocks the main
+thread (TBT 205 ms, hydration 506 ms), so its content paints ~1 s sooner. **Caching preserves RSC's
+JS-size advantage; it does not create or hide an LCP problem.** The earlier "RSC LCP regression"
+(§3c) was unthrottled-dev noise that also masked RSC's real mobile win.
 
 ## 4. Takeaways
 
 - Fragment caching is a large win for **server render time / TTFB** on every page, SSR and RSC alike
   (3–54×), and is most dramatic on expensive pages (product-search SSR 653 → 29 ms; blog RSC
   1558 → 29 ms).
-- For **LCP**, caching most helps **SSR** (which had no streaming to hide its render latency). RSC's
-  LCP is already fast uncached, so caching mainly improves its *total* completion time and TTFB, not
-  its LCP.
-- Caching does nothing for **TBT / JS size** — those are client-side and identical cached vs uncached;
-  reducing them is RSC's job (less JS), not the cache's.
+- **There is no cached-RSC LCP regression.** On unthrottled dev it's a tie (noise made it briefly look
+  like a regression, §3c); on a **production build under throttled mobile it's a clear RSC win**
+  (LCP ~1 s faster on blog, ~530 ms on search) — §3d.
+- The decider on mobile is **JavaScript weight**: cached RSC ships ~6× less gzipped JS, so its TBT is
+  ~20× lower and hydration ~20× faster. Caching is server-side and can't change that — it's RSC's
+  structural advantage, and caching keeps it intact while also giving the SSR-class TTFB.
+- Always benchmark caching/RSC on a **production build under CPU+network throttle**; unthrottled dev
+  hides the JS-execution cost that dominates real mobile LCP/TBT.

--- a/docs/cached-page-variants-benchmark.md
+++ b/docs/cached-page-variants-benchmark.md
@@ -1,0 +1,84 @@
+# Cached page variants — benchmark & investigation (issue #97)
+
+Compares each demo page **uncached vs cached**, **SSR vs RSC**. Cached SSR uses
+`cached_react_component`; cached RSC uses `cached_stream_react_component` (plain stream) or the new
+`cached_stream_react_component_with_async_props` (async-props pages).
+
+**Environment:** local `bin/dev` (development mode), unthrottled, `:memory_store` cache, single Puma
+process + 2 node-renderer workers. Absolute numbers are dev-mode (unminified JS, per-request code
+checks); the **deltas** between uncached and cached are the result. Server timing = median of 7 runs;
+web vitals = median of 5 runs (puppeteer).
+
+> Cold miss ≈ the uncached number: a miss does the full render plus a small cache write. Verified
+> directly — the first request to `/blog/rsc-cached` after a fresh boot took ~2.4 s and logged
+> `MISS → WROTE`, matching the uncached RSC render cost; subsequent requests hit at ~29 ms.
+
+## 1. Server render time (total, median ms)
+
+| Page family | SSR uncached | SSR cached (hit) | SSR gain | RSC uncached | RSC cached (hit) | RSC gain |
+|---|---|---|---|---|---|---|
+| restaurant | 200 | 30 | 6.7× | 414 | 34 | 12.2× |
+| product | 92 | 27 | 3.4× | 94 | 27 | 3.5× |
+| product-search | 653 | 29 | 22.5× | 609 | 27 | 22.6× |
+| blog | 281 | 33 | 8.5× | 1558 | 29 | **53.7×** |
+
+**A cache hit collapses every page — SSR and RSC alike — to a ~27–34 ms floor** (read the cached
+bytes + HTTP; no render work). The speedup factor is just `uncached / 30 ms`, so the heavier the
+uncached render, the bigger the gain. At the raw server-render level, **cached RSC gain ≥ cached SSR
+gain** (RSC uncached is usually the slower baseline — e.g. blog RSC carries a 1.5 s async-section
+delay — so it gains *more*). The issue's hypothesis ("cached RSC gain < cached SSR gain") does **not**
+hold for server render time.
+
+## 2. Web vitals (median ms, unthrottled)
+
+| Metric | SSR | SSR cached | RSC | RSC cached | Search SSR | Search SSR cached | Search RSC | Search RSC cached |
+|---|---|---|---|---|---|---|---|---|
+| TTFB | 288 | **27** | 74 | **32** | 671 | **27** | 79 | **28** |
+| FCP | 532 | 170 | 162 | 240 | 928 | 154 | 154 | 246 |
+| LCP | 532 | **170** | 162 | **240** | 928 | **172** | 778 | **338** |
+| TBT | 855 | 859 | 15 | 8 | 159 | 193 | 7.5 | 0.5 |
+| CLS | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| JS shipped | 3386 KB | 3386 KB | 1403 KB | 1403 KB | 3525 KB | 3525 KB | 1482 KB | 1482 KB |
+
+## 3. Investigation — why cached RSC's *LCP* gain is smaller than cached SSR's (acceptance-critical)
+
+Two different "gains" must be separated:
+
+- **Server render time / TTFB — equal.** Caching slashes TTFB for both strategies to ~27–32 ms.
+  Caching the streamed RSC chunks is exactly as effective as caching the SSR HTML string.
+- **User-perceived LCP — smaller for RSC.** SSR LCP: 532 → 170 (blog), 928 → 172 (search) — caching
+  saves 360–760 ms. RSC LCP: 162 → 240 (blog, no gain / noise), 778 → 338 (search). RSC's *LCP*
+  improves much less (or not at all) from caching.
+
+**Root cause:** RSC **streaming already decouples LCP from total render time.** The uncached RSC page
+sends its shell + above-the-fold (LCP) content in the *first* chunk almost immediately (blog RSC TTFB
+74 ms, LCP 162 ms), while the slow work — async section emits, node round-trips, the 1.5 s
+recommendation delay — streams in *after* the LCP element and never gates it. So the uncached RSC LCP
+is **already near-optimal**, leaving little for caching to recover. SSR, by contrast, blocks the
+*entire* response (including the LCP element) on the full server render, so caching that render
+directly collapses SSR's LCP.
+
+In other words: RSC spends its performance budget making the **uncached** experience fast (early LCP
+via streaming); SSR has no such mechanism, so caching is where SSR claws back that gap. Caching makes
+SSR's LCP competitive with RSC's — it does **not** mean RSC caching is broken.
+
+Two corollaries from the data:
+- **TBT is unchanged by caching** (SSR 855 → 859; RSC 15 → 8 within noise). TBT is client-side JS
+  execution (hydration), and caching is purely server-side — the shipped JS bytes are byte-identical
+  cached vs uncached. RSC's low TBT (8–15 ms vs SSR's 855 ms) comes from shipping ~1.4 MB vs ~3.4 MB
+  of JS, an RSC property independent of caching.
+- **Cache hits are genuinely exercised** (not the "hit never happens" hypothesis): the async-props
+  pages log `MISS → WROTE → HIT`; warm TTFB ~27 ms confirms replay. Note `RORP_CACHE_HIT` is **not**
+  set on this view-level *stream* cache (only on the Hash-returning `react_component` path), so hits
+  are verified via the helper's log markers / timing, not that flag.
+
+## 4. Takeaways
+
+- Fragment caching is a large win for **server render time / TTFB** on every page, SSR and RSC alike
+  (3–54×), and is most dramatic on expensive pages (product-search SSR 653 → 29 ms; blog RSC
+  1558 → 29 ms).
+- For **LCP**, caching most helps **SSR** (which had no streaming to hide its render latency). RSC's
+  LCP is already fast uncached, so caching mainly improves its *total* completion time and TTFB, not
+  its LCP.
+- Caching does nothing for **TBT / JS size** — those are client-side and identical cached vs uncached;
+  reducing them is RSC's job (less JS), not the cache's.

--- a/docs/cached-page-variants-benchmark.md
+++ b/docs/cached-page-variants-benchmark.md
@@ -72,6 +72,35 @@ Two corollaries from the data:
   set on this view-level *stream* cache (only on the Hash-returning `react_component` path), so hits
   are verified via the helper's log markers / timing, not that flag.
 
+## 3b. Cached SSR vs cached RSC — head to head (web vitals)
+
+Comparing the two *cached* variants directly (both warm hits), so server-render latency is removed
+from both and only the inherent SSR-vs-RSC differences remain:
+
+| Metric | blog SSR cached | blog RSC cached | search SSR cached | search RSC cached |
+|---|---|---|---|---|
+| TTFB | 27 ms | 32 ms | 27 ms | 28 ms |
+| FCP | 170 ms | 240 ms | 154 ms | 246 ms |
+| **LCP** | **170 ms** | 240 ms | **172 ms** | 338 ms |
+| **TBT** | 859 ms | **8 ms** | 193 ms | **0.5 ms** |
+| CLS | 0 | 0 | 0 | 0 |
+| JS shipped | 3386 KB | **1403 KB** | 3525 KB | **1482 KB** |
+
+- **TTFB — a tie** (~27–32 ms). Both are cache hits replaying bytes; neither renders.
+- **LCP / FCP — cached SSR wins** (blog 170 vs 240, search 172 vs 338). With render latency cached
+  away, SSR delivers the LCP element in one synchronous HTML payload, whereas cached RSC still
+  *progressively* streams + client-reconciles its chunks, so the LCP element paints slightly later
+  (most visible on search, where the results — the LCP content — arrive as a streamed section).
+- **TBT — cached RSC wins by ~100×** (blog 8 vs 859 ms, search 0.5 vs 193 ms). RSC ships ~half the
+  JavaScript (1.4 MB vs 3.4 MB), so far less main-thread blocking during hydration. This gap is an
+  RSC property, untouched by caching.
+- **CLS — tie at 0** for both (Suspense fallbacks preserve real heights).
+
+**Bottom line:** caching does not change *which* strategy wins each metric — it only erases the
+server-render-time gap that previously made uncached SSR look slow. Once both are cached, the choice
+is the usual SSR-vs-RSC trade-off, now both served at cache-hit speed: **cached SSR for the lowest
+LCP, cached RSC for far lower TBT and ~half the JS.**
+
 ## 4. Takeaways
 
 - Fragment caching is a large win for **server render time / TTFB** on every page, SSR and RSC alike

--- a/docs/cached-page-variants-benchmark.md
+++ b/docs/cached-page-variants-benchmark.md
@@ -34,33 +34,38 @@ hold for server render time.
 | Metric | SSR | SSR cached | RSC | RSC cached | Search SSR | Search SSR cached | Search RSC | Search RSC cached |
 |---|---|---|---|---|---|---|---|---|
 | TTFB | 288 | **27** | 74 | **32** | 671 | **27** | 79 | **28** |
-| FCP | 532 | 170 | 162 | 240 | 928 | 154 | 154 | 246 |
-| LCP | 532 | **170** | 162 | **240** | 928 | **172** | 778 | **338** |
+| FCP | 532 | 170 | 162 | 132 | 928 | 154 | 154 | 116 |
+| LCP | 532 | **170** | 162 | **132** | 928 | **172** | 778 | **200** |
 | TBT | 855 | 859 | 15 | 8 | 159 | 193 | 7.5 | 0.5 |
+
+> Cached LCP/FCP are subject to high dev-mode run-to-run variance; the cached values shown here are
+> the controlled medians from §3c (an initial N=5 pass reported a spurious cached-RSC LCP of 240/338
+> that did not reproduce).
 | CLS | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
 | JS shipped | 3386 KB | 3386 KB | 1403 KB | 1403 KB | 3525 KB | 3525 KB | 1482 KB | 1482 KB |
 
-## 3. Investigation — why cached RSC's *LCP* gain is smaller than cached SSR's (acceptance-critical)
+## 3. Investigation — where the caching gain shows up (acceptance-critical)
 
-Two different "gains" must be separated:
+The issue asks: does cached RSC gain *less* than cached SSR, and if so why? Separate two "gains":
 
 - **Server render time / TTFB — equal.** Caching slashes TTFB for both strategies to ~27–32 ms.
-  Caching the streamed RSC chunks is exactly as effective as caching the SSR HTML string.
-- **User-perceived LCP — smaller for RSC.** SSR LCP: 532 → 170 (blog), 928 → 172 (search) — caching
-  saves 360–760 ms. RSC LCP: 162 → 240 (blog, no gain / noise), 778 → 338 (search). RSC's *LCP*
-  improves much less (or not at all) from caching.
+  Caching the streamed RSC chunks is exactly as effective as caching the SSR HTML string. None of the
+  issue's hypotheses (RSC "not caching the same units of work", hit-never-exercised) hold — hits are
+  confirmed (`MISS → WROTE → HIT`) and the cached document replays in ~1 chunk by ~35 ms.
+- **User-perceived LCP — caching helps SSR more, but cached RSC does NOT end up slower.** Caching
+  *gains* more for SSR (blog 532 → 168, search 928 → 208 — saves ~360–720 ms) than for RSC (blog
+  162 → 132, search 778 → 200). But the *absolute* cached LCP is a tie/RSC-ahead (blog RSC 132 vs SSR
+  168; search RSC 200 vs SSR 208). **The "cached RSC LCP regression" from the first quick pass was
+  measurement noise and does not reproduce — see §3c.**
 
-**Root cause:** RSC **streaming already decouples LCP from total render time.** The uncached RSC page
-sends its shell + above-the-fold (LCP) content in the *first* chunk almost immediately (blog RSC TTFB
-74 ms, LCP 162 ms), while the slow work — async section emits, node round-trips, the 1.5 s
-recommendation delay — streams in *after* the LCP element and never gates it. So the uncached RSC LCP
-is **already near-optimal**, leaving little for caching to recover. SSR, by contrast, blocks the
+**Why SSR's LCP gains more from caching:** RSC streaming already decouples LCP from total render
+time. The uncached RSC page sends its shell + above-the-fold (LCP) content in the *first* chunk
+almost immediately (blog RSC TTFB 74 ms, LCP 162 ms), while the slow work — async section emits, node
+round-trips, the 1.5 s recommendation delay — streams in *after* the LCP element and never gates it.
+So the uncached RSC LCP is already near-optimal, leaving little for caching to recover. SSR blocks the
 *entire* response (including the LCP element) on the full server render, so caching that render
-directly collapses SSR's LCP.
-
-In other words: RSC spends its performance budget making the **uncached** experience fast (early LCP
-via streaming); SSR has no such mechanism, so caching is where SSR claws back that gap. Caching makes
-SSR's LCP competitive with RSC's — it does **not** mean RSC caching is broken.
+collapses SSR's LCP. RSC spends its budget making the **uncached** experience fast; caching is where
+SSR claws back that gap — ending in a tie, not an RSC regression.
 
 Two corollaries from the data:
 - **TBT is unchanged by caching** (SSR 855 → 859; RSC 15 → 8 within noise). TBT is client-side JS
@@ -75,31 +80,74 @@ Two corollaries from the data:
 ## 3b. Cached SSR vs cached RSC — head to head (web vitals)
 
 Comparing the two *cached* variants directly (both warm hits), so server-render latency is removed
-from both and only the inherent SSR-vs-RSC differences remain:
+from both and only the inherent SSR-vs-RSC differences remain. **LCP/FCP below are corrected medians
+from a controlled interleaved A/B (N=15) — see §3c; the first quick N=5 harness pass reported a
+spurious RSC LCP of 240/338 ms that did not reproduce.**
 
 | Metric | blog SSR cached | blog RSC cached | search SSR cached | search RSC cached |
 |---|---|---|---|---|
 | TTFB | 27 ms | 32 ms | 27 ms | 28 ms |
-| FCP | 170 ms | 240 ms | 154 ms | 246 ms |
-| **LCP** | **170 ms** | 240 ms | **172 ms** | 338 ms |
+| FCP | 168 ms | 132 ms | 192 ms | 116 ms |
+| **LCP** | 168 ms | **132 ms** | 208 ms | **200 ms** |
 | **TBT** | 859 ms | **8 ms** | 193 ms | **0.5 ms** |
 | CLS | 0 | 0 | 0 | 0 |
 | JS shipped | 3386 KB | **1403 KB** | 3525 KB | **1482 KB** |
 
 - **TTFB — a tie** (~27–32 ms). Both are cache hits replaying bytes; neither renders.
-- **LCP / FCP — cached SSR wins** (blog 170 vs 240, search 172 vs 338). With render latency cached
-  away, SSR delivers the LCP element in one synchronous HTML payload, whereas cached RSC still
-  *progressively* streams + client-reconciles its chunks, so the LCP element paints slightly later
-  (most visible on search, where the results — the LCP content — arrive as a streamed section).
+- **LCP / FCP — a tie, RSC slightly ahead** (blog RSC 132 vs SSR 168; search RSC 200 vs SSR 208).
+  There is **no LCP regression** for cached RSC (see §3c for the controlled re-measurement that
+  overturned the initial spurious figure). RSC's FCP is consistently a touch earlier because its
+  streamed shell paints sooner.
 - **TBT — cached RSC wins by ~100×** (blog 8 vs 859 ms, search 0.5 vs 193 ms). RSC ships ~half the
   JavaScript (1.4 MB vs 3.4 MB), so far less main-thread blocking during hydration. This gap is an
   RSC property, untouched by caching.
 - **CLS — tie at 0** for both (Suspense fallbacks preserve real heights).
 
-**Bottom line:** caching does not change *which* strategy wins each metric — it only erases the
-server-render-time gap that previously made uncached SSR look slow. Once both are cached, the choice
-is the usual SSR-vs-RSC trade-off, now both served at cache-hit speed: **cached SSR for the lowest
-LCP, cached RSC for far lower TBT and ~half the JS.**
+**Bottom line:** once both are cached they are effectively tied on TTFB/FCP/LCP/CLS, and cached RSC
+wins decisively on TBT and JS size. There is **no metric on which cached RSC loses** to cached SSR in
+the controlled data.
+
+## 3c. "RSC LCP regression" — investigated and refuted
+
+A first quick web-vitals pass (`scripts/measure-vitals.mjs`, **N=5, warmup=1**) reported cached RSC
+LCP of **240 ms (blog)** and **338 ms (search)** vs cached SSR 170/172 ms — an apparent regression.
+It does **not reproduce**. Investigation (all warm hits — cache markers showed 36 HIT / 1 MISS /
+1 WROTE per component):
+
+| Measurement | blog SSR LCP | blog RSC LCP | search SSR LCP | search RSC LCP |
+|---|---|---|---|---|
+| Quick harness, N=5 (original) | 170 | **240** (p75 356) | 172 | **338** (p75 480) |
+| Interleaved A/B, N=15 | 168 (sd 7) | **132** (sd 22) | 208 (sd 20) | **200** (sd 18) |
+| Factorial cache-ON, N=10 | 224 | 196 | — | — |
+| Factorial cache-OFF, N=10 | 216 | 204 | — | — |
+| Factorial cache-OFF + click (harness-like), N=10 | 228 | 200 | — | — |
+| Same harness re-run, N=12 | 258 (p75 488) | **120** (p75 124) | 172 | 198 |
+
+**Root cause: it was small-sample measurement noise, not a property of cached RSC.** In unthrottled
+local dev, LCP has high run-to-run variance (GC, node-renderer worker scheduling, CPU contention).
+With N=5 the median is easily dragged into the tail by 1–2 outliers — the original RSC p75 of 356/480
+is the tell. Re-running the *same* tool with N=12 flipped blog strongly in RSC's favour (120 vs 258)
+and SSR itself swung to 258 (p75 488), confirming the instability is in the measurement, not the page.
+Across a controlled interleaved A/B and a 3-condition factorial, **cached RSC LCP is equal-or-better
+than cached SSR in every condition.**
+
+Contributing factors (verified, none a real regression):
+- **The cached document arrives in ~1 chunk by ~35 ms for both** strategies (CDP byte timeline) — a
+  hit replays chunks fast (`react_on_rails_pro_cache_helper.rb` hit path), so there is no progressive-
+  streaming penalty on a warm RSC hit. The LCP element is identical for SSR/RSC (blog = the content
+  `<p>`; search = the first product `<img>`, which is eager / `fetchpriority`-high).
+- **The harness amplifies RSC variance**: it disables the browser HTTP cache (`runner.mjs` — re-fetches
+  the LCP image every run → variable image decode in LCP) and, for `hasStreaming` (RSC) pages only,
+  waits for streaming to resolve before clicking to finalize LCP — a longer, more variable LCP
+  observation window for RSC than SSR. This widens RSC's spread without reflecting real UX.
+- **RSC does have a slightly heavier LCP upper-tail** (extra client steps: Flight-payload decode +
+  Suspense reconciliation on top of HTML paint), which is why a tiny sample can misreport it. The
+  *median* is unaffected.
+
+Caveat: this is unthrottled local dev. A throttled / production profile (slow CPU + network) is the
+right next step to confirm mobile behaviour; proving a *real* RSC LCP mechanism would require a
+main-thread trace showing Flight decode / Suspense reveal delaying the actual LCP candidate — which
+the current data does not show. (This investigation was cross-reviewed with Codex gpt-5.5 @ xhigh.)
 
 ## 4. Takeaways
 

--- a/scripts/lib/constants.mjs
+++ b/scripts/lib/constants.mjs
@@ -18,6 +18,13 @@ export const PAGES = {
   'dashboard-ssr': { path: '/analytics/ssr', label: 'Dashboard SSR', hasStreaming: false },
   'dashboard-client': { path: '/analytics/client', label: 'Dashboard Client', hasStreaming: false },
   'dashboard-rsc': { path: '/analytics/rsc', label: 'Dashboard RSC', hasStreaming: true },
+  // Cached variants (issue #97) — fragment-cached siblings of the SSR/RSC pages above.
+  'ssr-cached': { path: '/blog/ssr-cached', label: 'SSR cached', hasStreaming: false },
+  'rsc-cached': { path: '/blog/rsc-cached', label: 'RSC cached', hasStreaming: true },
+  'product-ssr-cached': { path: '/product/ssr-cached', label: 'Product SSR cached', hasStreaming: false, selectors: { likeButton: 'button', relatedHeadingText: 'Customers Also Viewed' } },
+  'product-rsc-cached': { path: '/product/rsc-cached', label: 'Product RSC cached', hasStreaming: true, selectors: { likeButton: 'button', relatedHeadingText: 'Customers Also Viewed' } },
+  'search-ssr-cached': { path: '/product-search/ssr-cached', label: 'Search SSR cached', hasStreaming: false },
+  'search-rsc-cached': { path: '/product-search/rsc-cached', label: 'Search RSC cached', hasStreaming: true },
 };
 
 export const SELECTORS = {


### PR DESCRIPTION
## What this adds

Implements issue #97 — cached page variants for the demo's SSR and RSC pages, plus a benchmark of the caching gains and a write-up of the findings.

### New helper
`cached_stream_react_component_with_async_props` (`app/helpers/react_on_rails_pro_cache_helper.rb`) — React on Rails Pro ships `cached_stream_react_component` for plain streaming but has **no cached wrapper for the async-props streaming path**. This fills that gap: async-emitted props arrive as ordinary downstream stream chunks, which the existing chunk-capture/replay already covers, so a cache hit replays the fully-resolved output without re-running the async block (no DB work, no sleeps, no node round-trip). It allows `:props` (Hash or lazy Proc), requires `cache_key`, reuses the gem's same-object replay path, and logs `MISS → WROTE → HIT` markers so stream-cache hits are observable. No proprietary gem code is copied — it only orchestrates the gem's public + same-object API.

### Cached route variants for every page (uncached routes kept as the benchmark baseline)
- **SSR** (`cached_react_component`, props built lazily): `/restaurant/:id/ssr-cached`, `/product/ssr-cached`, `/product-search/ssr-cached`, `/blog/ssr-cached`
- **RSC plain stream** (`cached_stream_react_component`): `/restaurant/:id/rsc-cached`, `/blog/rsc-simple-cached`
- **RSC async props** (the new helper): `/product/rsc-cached`, `/product-search/rsc-cached`, `/blog/rsc-cached`

Extracts product hash serialization into a `ProductSerialization` concern (verified byte-identical) to keep `ProductsController` under the class-length limit. Also fixes RSC dev rendering (`Procfile.dev`): while the webpack dev-server runs, `react-client-manifest.json` resolves to a dev-server URL the node renderer can't copy, so the page errored ("switched to client rendering"); building the client to disk in dev fixes it.

### Benchmark + findings (`docs/cached-page-variants-benchmark.md`)
Measured server timing and web vitals, uncached vs cached, SSR vs RSC, on a production build under throttled mobile.

- **Caching is a large server-render win for both strategies** — a hit collapses every page to a ~27–34 ms floor (3–54×).
- **Cached SSR vs cached RSC, production + throttled mobile**: cached RSC LCP is ~1 s faster on blog (1840 vs 2840 ms) and ~530 ms on search (2828 vs 3356 ms), with ~20× lower TBT and ~half the JS — because RSC ships far less JavaScript, so under a throttled CPU the main thread is far less blocked.
- **Investigation (§3c):** a first quick N=5 pass showed an apparent "cached-RSC LCP regression" that **did not reproduce** — it was small-sample unthrottled-dev noise; controlled A/B + factorial + a same-tool re-run all show cached RSC equal-or-better. Cross-reviewed with an independent model.

`RORP_CACHE_HIT` is **not** the signal for the view-level stream cache (that flag is only on the Hash-returning `react_component` path); stream-cache hits are verified via the helper's log markers / timing.

Closes #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cached page variants for blog posts, product details, product search, and restaurant pages, improving speed when content is unchanged.
  * Introduced new cached endpoints for both server-rendered and React streaming modes (including a “simple” cached option for blog RSC).

* **Documentation**
  * Added an implementation design guide for cached async React props.
  * Added a benchmark/performance analysis comparing cached SSR vs cached RSC behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->