### PR TITLE
Experiment: per-component CSS code-splitting under SSR vs RSC (repro for react_on_rails#4049)

### DIFF
--- a/app/controllers/css_demo_controller.rb
+++ b/app/controllers/css_demo_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# CSS code-splitting experiment (does each page download only the CSS its components need?).
+# Three rendering shapes per page, sharing the same big CSS Modules (cssShared/cssA/cssB):
+#   *_ssr        - SSR via react_component (client component → per-component CSS in the client pack)
+#   *_rsc_server - RSC streamed, CSS imported by SERVER components (CSS lives in the RSC/server bundle)
+#   *_rsc_client - RSC streamed, CSS imported by nested 'use client' leaves (RSC client-reference CSS)
+# Page One uses Shared + A; Page Two uses Shared + B — so cssShared is shared, cssA/cssB are per-page.
+class CssDemoController < ApplicationController
+  include ReactOnRailsPro::RSCPayloadRenderer
+  include ReactOnRailsPro::AsyncRendering
+
+  enable_async_react_rendering only: %i[one_rsc_server two_rsc_server one_rsc_client two_rsc_client]
+
+  def one_ssr; end
+  def two_ssr; end
+
+  def one_rsc_server
+    stream_view_containing_react_components(template: 'css_demo/one_rsc_server')
+  end
+
+  def two_rsc_server
+    stream_view_containing_react_components(template: 'css_demo/two_rsc_server')
+  end
+
+  def one_rsc_client
+    stream_view_containing_react_components(template: 'css_demo/one_rsc_client')
+  end
+
+  def two_rsc_client
+    stream_view_containing_react_components(template: 'css_demo/two_rsc_client')
+  end
+end

--- a/app/controllers/css_demo_controller.rb
+++ b/app/controllers/css_demo_controller.rb
@@ -15,6 +15,14 @@ class CssDemoController < ApplicationController
   def one_ssr; end
   def two_ssr; end
 
+  # FIX for the server-component-CSS gap: a pure server component's CSS lives only in the
+  # RSC/server bundle and never reaches the browser, so the streamed markup renders unstyled.
+  # The fix links the page's exact CSS set (page one = cssShared + cssA) from a client-built
+  # carrier pack via `append_stylesheet_pack_tag` — done at the TOP of the rsc-server view
+  # templates (a view-helper; not available on the controller), exactly like the gem's own
+  # `load_pack_for_generated_component` appends during the template render. Rails renders the
+  # view before the layout, so the <link> lands in the layout's `stylesheet_pack_tag` in the
+  # <head> (flushed before the streamed body paints → no FOUC). Scoped per route, no over-fetch.
   def one_rsc_server
     stream_view_containing_react_components(template: 'css_demo/one_rsc_server')
   end

--- a/app/javascript/components/css-demo/CssBlockA.tsx
+++ b/app/javascript/components/css-demo/CssBlockA.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import './cssA.css';
+
+export default function CssBlockA() {
+  return (
+    <div className="cssA_marker" data-cssdemo="cssA">
+      <span className="cssA_sentinel" />
+      <span className="cssA_box0">CSS-DEMO block A (cssA.css)</span>
+    </div>
+  );
+}

--- a/app/javascript/components/css-demo/CssBlockAClient.tsx
+++ b/app/javascript/components/css-demo/CssBlockAClient.tsx
@@ -1,0 +1,12 @@
+'use client';
+import React from 'react';
+import './cssA.css';
+
+export default function CssBlockAClient() {
+  return (
+    <div className="cssA_marker" data-cssdemo="cssA">
+      <span className="cssA_sentinel" />
+      <span className="cssA_box0">CSS-DEMO block A client (cssA.css)</span>
+    </div>
+  );
+}

--- a/app/javascript/components/css-demo/CssBlockB.tsx
+++ b/app/javascript/components/css-demo/CssBlockB.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import './cssB.css';
+
+export default function CssBlockB() {
+  return (
+    <div className="cssB_marker" data-cssdemo="cssB">
+      <span className="cssB_sentinel" />
+      <span className="cssB_box0">CSS-DEMO block B (cssB.css)</span>
+    </div>
+  );
+}

--- a/app/javascript/components/css-demo/CssBlockBClient.tsx
+++ b/app/javascript/components/css-demo/CssBlockBClient.tsx
@@ -1,0 +1,12 @@
+'use client';
+import React from 'react';
+import './cssB.css';
+
+export default function CssBlockBClient() {
+  return (
+    <div className="cssB_marker" data-cssdemo="cssB">
+      <span className="cssB_sentinel" />
+      <span className="cssB_box0">CSS-DEMO block B client (cssB.css)</span>
+    </div>
+  );
+}

--- a/app/javascript/components/css-demo/CssPageOne.tsx
+++ b/app/javascript/components/css-demo/CssPageOne.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import CssShared from './CssShared';
+import CssBlockA from './CssBlockA';
+
+export default function CssPageOne() {
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>CSS Demo — Page One (Shared + A)</h1>
+      <CssShared />
+      <CssBlockA />
+    </main>
+  );
+}

--- a/app/javascript/components/css-demo/CssPageOneClientCss.tsx
+++ b/app/javascript/components/css-demo/CssPageOneClientCss.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import CssSharedClient from './CssSharedClient';
+import CssBlockAClient from './CssBlockAClient';
+
+export default function CssPageOneClientCss() {
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>CSS Demo — Page One (Shared + A, client-CSS)</h1>
+      <CssSharedClient />
+      <CssBlockAClient />
+    </main>
+  );
+}

--- a/app/javascript/components/css-demo/CssPageTwo.tsx
+++ b/app/javascript/components/css-demo/CssPageTwo.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import CssShared from './CssShared';
+import CssBlockB from './CssBlockB';
+
+export default function CssPageTwo() {
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>CSS Demo — Page Two (Shared + B)</h1>
+      <CssShared />
+      <CssBlockB />
+    </main>
+  );
+}

--- a/app/javascript/components/css-demo/CssPageTwoClientCss.tsx
+++ b/app/javascript/components/css-demo/CssPageTwoClientCss.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import CssSharedClient from './CssSharedClient';
+import CssBlockBClient from './CssBlockBClient';
+
+export default function CssPageTwoClientCss() {
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>CSS Demo — Page Two (Shared + B, client-CSS)</h1>
+      <CssSharedClient />
+      <CssBlockBClient />
+    </main>
+  );
+}

--- a/app/javascript/components/css-demo/CssShared.tsx
+++ b/app/javascript/components/css-demo/CssShared.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import './cssShared.css';
+
+export default function CssShared() {
+  return (
+    <div className="cssShared_marker" data-cssdemo="cssShared">
+      <span className="cssShared_sentinel" />
+      <span className="cssShared_box0">CSS-DEMO shared block (cssShared.css)</span>
+    </div>
+  );
+}

--- a/app/javascript/components/css-demo/CssSharedClient.tsx
+++ b/app/javascript/components/css-demo/CssSharedClient.tsx
@@ -1,0 +1,12 @@
+'use client';
+import React from 'react';
+import './cssShared.css';
+
+export default function CssSharedClient() {
+  return (
+    <div className="cssShared_marker" data-cssdemo="cssShared">
+      <span className="cssShared_sentinel" />
+      <span className="cssShared_box0">CSS-DEMO shared block client (cssShared.css)</span>
+    </div>
+  );
+}

--- a/app/javascript/components/css-demo/cssA.css
+++ b/app/javascript/components/css-demo/cssA.css
@@ -1,0 +1,11643 @@
+/* cssA ~300KB */
+.cssA_sentinel::after { content: "SENTINEL_CSSA"; }
+.cssA_marker { outline-style: solid; outline-width: 11px; outline-color: hsl(187,80%,40%); }
+.cssA_box0 {
+  --cssA-v-0: 0;
+  color: hsl(0, 0%, 30%);
+  background-color: hsl(180, 0%, 70%);
+  border: 1px solid hsl(90, 50%, 50%);
+  margin: 0px 0px 0px 0px;
+  padding: 0px 0px;
+  border-radius: 0px 0px;
+  box-shadow: 0px 0px 0px rgba(0, 0, 0, 0.1);
+  transform: rotate(0deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box1 {
+  --cssA-v-1: 7919;
+  color: hsl(37, 13%, 37%);
+  background-color: hsl(217, 13%, 63%);
+  border: 2px solid hsl(127, 50%, 50%);
+  margin: 1px 3px 5px 7px;
+  padding: 1px 2px;
+  border-radius: 1px 2px;
+  box-shadow: 1px 1px 1px rgba(1, 2, 3, 0.2);
+  transform: rotate(1deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box2 {
+  --cssA-v-2: 15838;
+  color: hsl(74, 26%, 44%);
+  background-color: hsl(254, 26%, 56%);
+  border: 3px solid hsl(164, 50%, 50%);
+  margin: 2px 6px 10px 14px;
+  padding: 2px 4px;
+  border-radius: 2px 4px;
+  box-shadow: 2px 2px 2px rgba(2, 4, 6, 0.3);
+  transform: rotate(2deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box3 {
+  --cssA-v-3: 23757;
+  color: hsl(111, 39%, 51%);
+  background-color: hsl(291, 39%, 49%);
+  border: 4px solid hsl(201, 50%, 50%);
+  margin: 3px 9px 15px 3px;
+  padding: 3px 6px;
+  border-radius: 3px 6px;
+  box-shadow: 3px 3px 3px rgba(3, 6, 9, 0.4);
+  transform: rotate(3deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box4 {
+  --cssA-v-4: 31676;
+  color: hsl(148, 52%, 58%);
+  background-color: hsl(328, 52%, 42%);
+  border: 5px solid hsl(238, 50%, 50%);
+  margin: 4px 12px 20px 10px;
+  padding: 4px 8px;
+  border-radius: 4px 8px;
+  box-shadow: 4px 4px 4px rgba(4, 8, 12, 0.5);
+  transform: rotate(4deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box5 {
+  --cssA-v-5: 39595;
+  color: hsl(185, 65%, 65%);
+  background-color: hsl(5, 65%, 35%);
+  border: 1px solid hsl(275, 50%, 50%);
+  margin: 5px 15px 0px 17px;
+  padding: 5px 10px;
+  border-radius: 5px 1px;
+  box-shadow: 0px 5px 5px rgba(5, 10, 15, 0.6);
+  transform: rotate(5deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box6 {
+  --cssA-v-6: 47514;
+  color: hsl(222, 78%, 72%);
+  background-color: hsl(42, 78%, 28%);
+  border: 2px solid hsl(312, 50%, 50%);
+  margin: 6px 18px 5px 6px;
+  padding: 6px 12px;
+  border-radius: 6px 3px;
+  box-shadow: 1px 6px 6px rgba(6, 12, 18, 0.7);
+  transform: rotate(6deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box7 {
+  --cssA-v-7: 55433;
+  color: hsl(259, 91%, 79%);
+  background-color: hsl(79, 91%, 21%);
+  border: 3px solid hsl(349, 50%, 50%);
+  margin: 7px 21px 10px 13px;
+  padding: 7px 14px;
+  border-radius: 7px 5px;
+  box-shadow: 2px 0px 7px rgba(7, 14, 21, 0.8);
+  transform: rotate(7deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box8 {
+  --cssA-v-8: 63352;
+  color: hsl(296, 4%, 36%);
+  background-color: hsl(116, 4%, 64%);
+  border: 4px solid hsl(26, 50%, 50%);
+  margin: 8px 24px 15px 2px;
+  padding: 8px 16px;
+  border-radius: 8px 7px;
+  box-shadow: 3px 1px 8px rgba(8, 16, 24, 0.9);
+  transform: rotate(8deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box9 {
+  --cssA-v-9: 71271;
+  color: hsl(333, 17%, 43%);
+  background-color: hsl(153, 17%, 57%);
+  border: 5px solid hsl(63, 50%, 50%);
+  margin: 9px 27px 20px 9px;
+  padding: 9px 18px;
+  border-radius: 9px 0px;
+  box-shadow: 4px 2px 0px rgba(9, 18, 27, 0.1);
+  transform: rotate(9deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box10 {
+  --cssA-v-10: 79190;
+  color: hsl(10, 30%, 50%);
+  background-color: hsl(190, 30%, 50%);
+  border: 1px solid hsl(100, 50%, 50%);
+  margin: 10px 0px 0px 16px;
+  padding: 10px 20px;
+  border-radius: 10px 2px;
+  box-shadow: 0px 3px 1px rgba(10, 20, 30, 0.2);
+  transform: rotate(10deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box11 {
+  --cssA-v-11: 87109;
+  color: hsl(47, 43%, 57%);
+  background-color: hsl(227, 43%, 43%);
+  border: 2px solid hsl(137, 50%, 50%);
+  margin: 11px 3px 5px 5px;
+  padding: 11px 0px;
+  border-radius: 11px 4px;
+  box-shadow: 1px 4px 2px rgba(11, 22, 33, 0.3);
+  transform: rotate(11deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box12 {
+  --cssA-v-12: 95028;
+  color: hsl(84, 56%, 64%);
+  background-color: hsl(264, 56%, 36%);
+  border: 3px solid hsl(174, 50%, 50%);
+  margin: 12px 6px 10px 12px;
+  padding: 12px 2px;
+  border-radius: 0px 6px;
+  box-shadow: 2px 5px 3px rgba(12, 24, 36, 0.4);
+  transform: rotate(12deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box13 {
+  --cssA-v-13: 102947;
+  color: hsl(121, 69%, 71%);
+  background-color: hsl(301, 69%, 29%);
+  border: 4px solid hsl(211, 50%, 50%);
+  margin: 13px 9px 15px 1px;
+  padding: 13px 4px;
+  border-radius: 1px 8px;
+  box-shadow: 3px 6px 4px rgba(13, 26, 39, 0.5);
+  transform: rotate(13deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box14 {
+  --cssA-v-14: 110866;
+  color: hsl(158, 82%, 78%);
+  background-color: hsl(338, 82%, 22%);
+  border: 5px solid hsl(248, 50%, 50%);
+  margin: 14px 12px 20px 8px;
+  padding: 14px 6px;
+  border-radius: 2px 1px;
+  box-shadow: 4px 0px 5px rgba(14, 28, 42, 0.6);
+  transform: rotate(14deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box15 {
+  --cssA-v-15: 118785;
+  color: hsl(195, 95%, 35%);
+  background-color: hsl(15, 95%, 65%);
+  border: 1px solid hsl(285, 50%, 50%);
+  margin: 15px 15px 0px 15px;
+  padding: 0px 8px;
+  border-radius: 3px 3px;
+  box-shadow: 0px 1px 6px rgba(15, 30, 45, 0.7);
+  transform: rotate(15deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box16 {
+  --cssA-v-16: 126704;
+  color: hsl(232, 8%, 42%);
+  background-color: hsl(52, 8%, 58%);
+  border: 2px solid hsl(322, 50%, 50%);
+  margin: 16px 18px 5px 4px;
+  padding: 1px 10px;
+  border-radius: 4px 5px;
+  box-shadow: 1px 2px 7px rgba(16, 32, 48, 0.8);
+  transform: rotate(16deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box17 {
+  --cssA-v-17: 134623;
+  color: hsl(269, 21%, 49%);
+  background-color: hsl(89, 21%, 51%);
+  border: 3px solid hsl(359, 50%, 50%);
+  margin: 17px 21px 10px 11px;
+  padding: 2px 12px;
+  border-radius: 5px 7px;
+  box-shadow: 2px 3px 8px rgba(17, 34, 51, 0.9);
+  transform: rotate(17deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box18 {
+  --cssA-v-18: 142542;
+  color: hsl(306, 34%, 56%);
+  background-color: hsl(126, 34%, 44%);
+  border: 4px solid hsl(36, 50%, 50%);
+  margin: 18px 24px 15px 0px;
+  padding: 3px 14px;
+  border-radius: 6px 0px;
+  box-shadow: 3px 4px 0px rgba(18, 36, 54, 0.1);
+  transform: rotate(18deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box19 {
+  --cssA-v-19: 150461;
+  color: hsl(343, 47%, 63%);
+  background-color: hsl(163, 47%, 37%);
+  border: 5px solid hsl(73, 50%, 50%);
+  margin: 19px 27px 20px 7px;
+  padding: 4px 16px;
+  border-radius: 7px 2px;
+  box-shadow: 4px 5px 1px rgba(19, 38, 57, 0.2);
+  transform: rotate(19deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box20 {
+  --cssA-v-20: 158380;
+  color: hsl(20, 60%, 70%);
+  background-color: hsl(200, 60%, 30%);
+  border: 1px solid hsl(110, 50%, 50%);
+  margin: 0px 0px 0px 14px;
+  padding: 5px 18px;
+  border-radius: 8px 4px;
+  box-shadow: 0px 6px 2px rgba(20, 40, 60, 0.3);
+  transform: rotate(20deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box21 {
+  --cssA-v-21: 166299;
+  color: hsl(57, 73%, 77%);
+  background-color: hsl(237, 73%, 23%);
+  border: 2px solid hsl(147, 50%, 50%);
+  margin: 1px 3px 5px 3px;
+  padding: 6px 20px;
+  border-radius: 9px 6px;
+  box-shadow: 1px 0px 3px rgba(21, 42, 63, 0.4);
+  transform: rotate(21deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box22 {
+  --cssA-v-22: 174218;
+  color: hsl(94, 86%, 34%);
+  background-color: hsl(274, 86%, 66%);
+  border: 3px solid hsl(184, 50%, 50%);
+  margin: 2px 6px 10px 10px;
+  padding: 7px 0px;
+  border-radius: 10px 8px;
+  box-shadow: 2px 1px 4px rgba(22, 44, 66, 0.5);
+  transform: rotate(22deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box23 {
+  --cssA-v-23: 182137;
+  color: hsl(131, 99%, 41%);
+  background-color: hsl(311, 99%, 59%);
+  border: 4px solid hsl(221, 50%, 50%);
+  margin: 3px 9px 15px 17px;
+  padding: 8px 2px;
+  border-radius: 11px 1px;
+  box-shadow: 3px 2px 5px rgba(23, 46, 69, 0.6);
+  transform: rotate(23deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box24 {
+  --cssA-v-24: 190056;
+  color: hsl(168, 12%, 48%);
+  background-color: hsl(348, 12%, 52%);
+  border: 5px solid hsl(258, 50%, 50%);
+  margin: 4px 12px 20px 6px;
+  padding: 9px 4px;
+  border-radius: 0px 3px;
+  box-shadow: 4px 3px 6px rgba(24, 48, 72, 0.7);
+  transform: rotate(24deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box25 {
+  --cssA-v-25: 197975;
+  color: hsl(205, 25%, 55%);
+  background-color: hsl(25, 25%, 45%);
+  border: 1px solid hsl(295, 50%, 50%);
+  margin: 5px 15px 0px 13px;
+  padding: 10px 6px;
+  border-radius: 1px 5px;
+  box-shadow: 0px 4px 7px rgba(25, 50, 75, 0.8);
+  transform: rotate(25deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box26 {
+  --cssA-v-26: 205894;
+  color: hsl(242, 38%, 62%);
+  background-color: hsl(62, 38%, 38%);
+  border: 2px solid hsl(332, 50%, 50%);
+  margin: 6px 18px 5px 2px;
+  padding: 11px 8px;
+  border-radius: 2px 7px;
+  box-shadow: 1px 5px 8px rgba(26, 52, 78, 0.9);
+  transform: rotate(26deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box27 {
+  --cssA-v-27: 213813;
+  color: hsl(279, 51%, 69%);
+  background-color: hsl(99, 51%, 31%);
+  border: 3px solid hsl(9, 50%, 50%);
+  margin: 7px 21px 10px 9px;
+  padding: 12px 10px;
+  border-radius: 3px 0px;
+  box-shadow: 2px 6px 0px rgba(27, 54, 81, 0.1);
+  transform: rotate(27deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box28 {
+  --cssA-v-28: 221732;
+  color: hsl(316, 64%, 76%);
+  background-color: hsl(136, 64%, 24%);
+  border: 4px solid hsl(46, 50%, 50%);
+  margin: 8px 24px 15px 16px;
+  padding: 13px 12px;
+  border-radius: 4px 2px;
+  box-shadow: 3px 0px 1px rgba(28, 56, 84, 0.2);
+  transform: rotate(28deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box29 {
+  --cssA-v-29: 229651;
+  color: hsl(353, 77%, 33%);
+  background-color: hsl(173, 77%, 67%);
+  border: 5px solid hsl(83, 50%, 50%);
+  margin: 9px 27px 20px 5px;
+  padding: 14px 14px;
+  border-radius: 5px 4px;
+  box-shadow: 4px 1px 2px rgba(29, 58, 87, 0.3);
+  transform: rotate(29deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box30 {
+  --cssA-v-30: 237570;
+  color: hsl(30, 90%, 40%);
+  background-color: hsl(210, 90%, 60%);
+  border: 1px solid hsl(120, 50%, 50%);
+  margin: 10px 0px 0px 12px;
+  padding: 0px 16px;
+  border-radius: 6px 6px;
+  box-shadow: 0px 2px 3px rgba(30, 60, 90, 0.4);
+  transform: rotate(30deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box31 {
+  --cssA-v-31: 245489;
+  color: hsl(67, 3%, 47%);
+  background-color: hsl(247, 3%, 53%);
+  border: 2px solid hsl(157, 50%, 50%);
+  margin: 11px 3px 5px 1px;
+  padding: 1px 18px;
+  border-radius: 7px 8px;
+  box-shadow: 1px 3px 4px rgba(31, 62, 93, 0.5);
+  transform: rotate(31deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box32 {
+  --cssA-v-32: 253408;
+  color: hsl(104, 16%, 54%);
+  background-color: hsl(284, 16%, 46%);
+  border: 3px solid hsl(194, 50%, 50%);
+  margin: 12px 6px 10px 8px;
+  padding: 2px 20px;
+  border-radius: 8px 1px;
+  box-shadow: 2px 4px 5px rgba(32, 64, 96, 0.6);
+  transform: rotate(32deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box33 {
+  --cssA-v-33: 261327;
+  color: hsl(141, 29%, 61%);
+  background-color: hsl(321, 29%, 39%);
+  border: 4px solid hsl(231, 50%, 50%);
+  margin: 13px 9px 15px 15px;
+  padding: 3px 0px;
+  border-radius: 9px 3px;
+  box-shadow: 3px 5px 6px rgba(33, 66, 99, 0.7);
+  transform: rotate(33deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box34 {
+  --cssA-v-34: 269246;
+  color: hsl(178, 42%, 68%);
+  background-color: hsl(358, 42%, 32%);
+  border: 5px solid hsl(268, 50%, 50%);
+  margin: 14px 12px 20px 4px;
+  padding: 4px 2px;
+  border-radius: 10px 5px;
+  box-shadow: 4px 6px 7px rgba(34, 68, 102, 0.8);
+  transform: rotate(34deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box35 {
+  --cssA-v-35: 277165;
+  color: hsl(215, 55%, 75%);
+  background-color: hsl(35, 55%, 25%);
+  border: 1px solid hsl(305, 50%, 50%);
+  margin: 15px 15px 0px 11px;
+  padding: 5px 4px;
+  border-radius: 11px 7px;
+  box-shadow: 0px 0px 8px rgba(35, 70, 105, 0.9);
+  transform: rotate(35deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box36 {
+  --cssA-v-36: 285084;
+  color: hsl(252, 68%, 32%);
+  background-color: hsl(72, 68%, 68%);
+  border: 2px solid hsl(342, 50%, 50%);
+  margin: 16px 18px 5px 0px;
+  padding: 6px 6px;
+  border-radius: 0px 0px;
+  box-shadow: 1px 1px 0px rgba(36, 72, 108, 0.1);
+  transform: rotate(36deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box37 {
+  --cssA-v-37: 293003;
+  color: hsl(289, 81%, 39%);
+  background-color: hsl(109, 81%, 61%);
+  border: 3px solid hsl(19, 50%, 50%);
+  margin: 17px 21px 10px 7px;
+  padding: 7px 8px;
+  border-radius: 1px 2px;
+  box-shadow: 2px 2px 1px rgba(37, 74, 111, 0.2);
+  transform: rotate(37deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box38 {
+  --cssA-v-38: 300922;
+  color: hsl(326, 94%, 46%);
+  background-color: hsl(146, 94%, 54%);
+  border: 4px solid hsl(56, 50%, 50%);
+  margin: 18px 24px 15px 14px;
+  padding: 8px 10px;
+  border-radius: 2px 4px;
+  box-shadow: 3px 3px 2px rgba(38, 76, 114, 0.3);
+  transform: rotate(38deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box39 {
+  --cssA-v-39: 308841;
+  color: hsl(3, 7%, 53%);
+  background-color: hsl(183, 7%, 47%);
+  border: 5px solid hsl(93, 50%, 50%);
+  margin: 19px 27px 20px 3px;
+  padding: 9px 12px;
+  border-radius: 3px 6px;
+  box-shadow: 4px 4px 3px rgba(39, 78, 117, 0.4);
+  transform: rotate(39deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box40 {
+  --cssA-v-40: 316760;
+  color: hsl(40, 20%, 60%);
+  background-color: hsl(220, 20%, 40%);
+  border: 1px solid hsl(130, 50%, 50%);
+  margin: 0px 0px 0px 10px;
+  padding: 10px 14px;
+  border-radius: 4px 8px;
+  box-shadow: 0px 5px 4px rgba(40, 80, 120, 0.5);
+  transform: rotate(40deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box41 {
+  --cssA-v-41: 324679;
+  color: hsl(77, 33%, 67%);
+  background-color: hsl(257, 33%, 33%);
+  border: 2px solid hsl(167, 50%, 50%);
+  margin: 1px 3px 5px 17px;
+  padding: 11px 16px;
+  border-radius: 5px 1px;
+  box-shadow: 1px 6px 5px rgba(41, 82, 123, 0.6);
+  transform: rotate(41deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box42 {
+  --cssA-v-42: 332598;
+  color: hsl(114, 46%, 74%);
+  background-color: hsl(294, 46%, 26%);
+  border: 3px solid hsl(204, 50%, 50%);
+  margin: 2px 6px 10px 6px;
+  padding: 12px 18px;
+  border-radius: 6px 3px;
+  box-shadow: 2px 0px 6px rgba(42, 84, 126, 0.7);
+  transform: rotate(42deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box43 {
+  --cssA-v-43: 340517;
+  color: hsl(151, 59%, 31%);
+  background-color: hsl(331, 59%, 69%);
+  border: 4px solid hsl(241, 50%, 50%);
+  margin: 3px 9px 15px 13px;
+  padding: 13px 20px;
+  border-radius: 7px 5px;
+  box-shadow: 3px 1px 7px rgba(43, 86, 129, 0.8);
+  transform: rotate(43deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box44 {
+  --cssA-v-44: 348436;
+  color: hsl(188, 72%, 38%);
+  background-color: hsl(8, 72%, 62%);
+  border: 5px solid hsl(278, 50%, 50%);
+  margin: 4px 12px 20px 2px;
+  padding: 14px 0px;
+  border-radius: 8px 7px;
+  box-shadow: 4px 2px 8px rgba(44, 88, 132, 0.9);
+  transform: rotate(44deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box45 {
+  --cssA-v-45: 356355;
+  color: hsl(225, 85%, 45%);
+  background-color: hsl(45, 85%, 55%);
+  border: 1px solid hsl(315, 50%, 50%);
+  margin: 5px 15px 0px 9px;
+  padding: 0px 2px;
+  border-radius: 9px 0px;
+  box-shadow: 0px 3px 0px rgba(45, 90, 135, 0.1);
+  transform: rotate(45deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box46 {
+  --cssA-v-46: 364274;
+  color: hsl(262, 98%, 52%);
+  background-color: hsl(82, 98%, 48%);
+  border: 2px solid hsl(352, 50%, 50%);
+  margin: 6px 18px 5px 16px;
+  padding: 1px 4px;
+  border-radius: 10px 2px;
+  box-shadow: 1px 4px 1px rgba(46, 92, 138, 0.2);
+  transform: rotate(46deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box47 {
+  --cssA-v-47: 372193;
+  color: hsl(299, 11%, 59%);
+  background-color: hsl(119, 11%, 41%);
+  border: 3px solid hsl(29, 50%, 50%);
+  margin: 7px 21px 10px 5px;
+  padding: 2px 6px;
+  border-radius: 11px 4px;
+  box-shadow: 2px 5px 2px rgba(47, 94, 141, 0.3);
+  transform: rotate(47deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box48 {
+  --cssA-v-48: 380112;
+  color: hsl(336, 24%, 66%);
+  background-color: hsl(156, 24%, 34%);
+  border: 4px solid hsl(66, 50%, 50%);
+  margin: 8px 24px 15px 12px;
+  padding: 3px 8px;
+  border-radius: 0px 6px;
+  box-shadow: 3px 6px 3px rgba(48, 96, 144, 0.4);
+  transform: rotate(48deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box49 {
+  --cssA-v-49: 388031;
+  color: hsl(13, 37%, 73%);
+  background-color: hsl(193, 37%, 27%);
+  border: 5px solid hsl(103, 50%, 50%);
+  margin: 9px 27px 20px 1px;
+  padding: 4px 10px;
+  border-radius: 1px 8px;
+  box-shadow: 4px 0px 4px rgba(49, 98, 147, 0.5);
+  transform: rotate(49deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box50 {
+  --cssA-v-50: 395950;
+  color: hsl(50, 50%, 30%);
+  background-color: hsl(230, 50%, 70%);
+  border: 1px solid hsl(140, 50%, 50%);
+  margin: 10px 0px 0px 8px;
+  padding: 5px 12px;
+  border-radius: 2px 1px;
+  box-shadow: 0px 1px 5px rgba(50, 100, 150, 0.6);
+  transform: rotate(50deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box51 {
+  --cssA-v-51: 403869;
+  color: hsl(87, 63%, 37%);
+  background-color: hsl(267, 63%, 63%);
+  border: 2px solid hsl(177, 50%, 50%);
+  margin: 11px 3px 5px 15px;
+  padding: 6px 14px;
+  border-radius: 3px 3px;
+  box-shadow: 1px 2px 6px rgba(51, 102, 153, 0.7);
+  transform: rotate(51deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box52 {
+  --cssA-v-52: 411788;
+  color: hsl(124, 76%, 44%);
+  background-color: hsl(304, 76%, 56%);
+  border: 3px solid hsl(214, 50%, 50%);
+  margin: 12px 6px 10px 4px;
+  padding: 7px 16px;
+  border-radius: 4px 5px;
+  box-shadow: 2px 3px 7px rgba(52, 104, 156, 0.8);
+  transform: rotate(52deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box53 {
+  --cssA-v-53: 419707;
+  color: hsl(161, 89%, 51%);
+  background-color: hsl(341, 89%, 49%);
+  border: 4px solid hsl(251, 50%, 50%);
+  margin: 13px 9px 15px 11px;
+  padding: 8px 18px;
+  border-radius: 5px 7px;
+  box-shadow: 3px 4px 8px rgba(53, 106, 159, 0.9);
+  transform: rotate(53deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box54 {
+  --cssA-v-54: 427626;
+  color: hsl(198, 2%, 58%);
+  background-color: hsl(18, 2%, 42%);
+  border: 5px solid hsl(288, 50%, 50%);
+  margin: 14px 12px 20px 0px;
+  padding: 9px 20px;
+  border-radius: 6px 0px;
+  box-shadow: 4px 5px 0px rgba(54, 108, 162, 0.1);
+  transform: rotate(54deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box55 {
+  --cssA-v-55: 435545;
+  color: hsl(235, 15%, 65%);
+  background-color: hsl(55, 15%, 35%);
+  border: 1px solid hsl(325, 50%, 50%);
+  margin: 15px 15px 0px 7px;
+  padding: 10px 0px;
+  border-radius: 7px 2px;
+  box-shadow: 0px 6px 1px rgba(55, 110, 165, 0.2);
+  transform: rotate(55deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box56 {
+  --cssA-v-56: 443464;
+  color: hsl(272, 28%, 72%);
+  background-color: hsl(92, 28%, 28%);
+  border: 2px solid hsl(2, 50%, 50%);
+  margin: 16px 18px 5px 14px;
+  padding: 11px 2px;
+  border-radius: 8px 4px;
+  box-shadow: 1px 0px 2px rgba(56, 112, 168, 0.3);
+  transform: rotate(56deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box57 {
+  --cssA-v-57: 451383;
+  color: hsl(309, 41%, 79%);
+  background-color: hsl(129, 41%, 21%);
+  border: 3px solid hsl(39, 50%, 50%);
+  margin: 17px 21px 10px 3px;
+  padding: 12px 4px;
+  border-radius: 9px 6px;
+  box-shadow: 2px 1px 3px rgba(57, 114, 171, 0.4);
+  transform: rotate(57deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box58 {
+  --cssA-v-58: 459302;
+  color: hsl(346, 54%, 36%);
+  background-color: hsl(166, 54%, 64%);
+  border: 4px solid hsl(76, 50%, 50%);
+  margin: 18px 24px 15px 10px;
+  padding: 13px 6px;
+  border-radius: 10px 8px;
+  box-shadow: 3px 2px 4px rgba(58, 116, 174, 0.5);
+  transform: rotate(58deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box59 {
+  --cssA-v-59: 467221;
+  color: hsl(23, 67%, 43%);
+  background-color: hsl(203, 67%, 57%);
+  border: 5px solid hsl(113, 50%, 50%);
+  margin: 19px 27px 20px 17px;
+  padding: 14px 8px;
+  border-radius: 11px 1px;
+  box-shadow: 4px 3px 5px rgba(59, 118, 177, 0.6);
+  transform: rotate(59deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box60 {
+  --cssA-v-60: 475140;
+  color: hsl(60, 80%, 50%);
+  background-color: hsl(240, 80%, 50%);
+  border: 1px solid hsl(150, 50%, 50%);
+  margin: 0px 0px 0px 6px;
+  padding: 0px 10px;
+  border-radius: 0px 3px;
+  box-shadow: 0px 4px 6px rgba(60, 120, 180, 0.7);
+  transform: rotate(60deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box61 {
+  --cssA-v-61: 483059;
+  color: hsl(97, 93%, 57%);
+  background-color: hsl(277, 93%, 43%);
+  border: 2px solid hsl(187, 50%, 50%);
+  margin: 1px 3px 5px 13px;
+  padding: 1px 12px;
+  border-radius: 1px 5px;
+  box-shadow: 1px 5px 7px rgba(61, 122, 183, 0.8);
+  transform: rotate(61deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box62 {
+  --cssA-v-62: 490978;
+  color: hsl(134, 6%, 64%);
+  background-color: hsl(314, 6%, 36%);
+  border: 3px solid hsl(224, 50%, 50%);
+  margin: 2px 6px 10px 2px;
+  padding: 2px 14px;
+  border-radius: 2px 7px;
+  box-shadow: 2px 6px 8px rgba(62, 124, 186, 0.9);
+  transform: rotate(62deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box63 {
+  --cssA-v-63: 498897;
+  color: hsl(171, 19%, 71%);
+  background-color: hsl(351, 19%, 29%);
+  border: 4px solid hsl(261, 50%, 50%);
+  margin: 3px 9px 15px 9px;
+  padding: 3px 16px;
+  border-radius: 3px 0px;
+  box-shadow: 3px 0px 0px rgba(63, 126, 189, 0.1);
+  transform: rotate(63deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box64 {
+  --cssA-v-64: 506816;
+  color: hsl(208, 32%, 78%);
+  background-color: hsl(28, 32%, 22%);
+  border: 5px solid hsl(298, 50%, 50%);
+  margin: 4px 12px 20px 16px;
+  padding: 4px 18px;
+  border-radius: 4px 2px;
+  box-shadow: 4px 1px 1px rgba(64, 128, 192, 0.2);
+  transform: rotate(64deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box65 {
+  --cssA-v-65: 514735;
+  color: hsl(245, 45%, 35%);
+  background-color: hsl(65, 45%, 65%);
+  border: 1px solid hsl(335, 50%, 50%);
+  margin: 5px 15px 0px 5px;
+  padding: 5px 20px;
+  border-radius: 5px 4px;
+  box-shadow: 0px 2px 2px rgba(65, 130, 195, 0.3);
+  transform: rotate(65deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box66 {
+  --cssA-v-66: 522654;
+  color: hsl(282, 58%, 42%);
+  background-color: hsl(102, 58%, 58%);
+  border: 2px solid hsl(12, 50%, 50%);
+  margin: 6px 18px 5px 12px;
+  padding: 6px 0px;
+  border-radius: 6px 6px;
+  box-shadow: 1px 3px 3px rgba(66, 132, 198, 0.4);
+  transform: rotate(66deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box67 {
+  --cssA-v-67: 530573;
+  color: hsl(319, 71%, 49%);
+  background-color: hsl(139, 71%, 51%);
+  border: 3px solid hsl(49, 50%, 50%);
+  margin: 7px 21px 10px 1px;
+  padding: 7px 2px;
+  border-radius: 7px 8px;
+  box-shadow: 2px 4px 4px rgba(67, 134, 201, 0.5);
+  transform: rotate(67deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box68 {
+  --cssA-v-68: 538492;
+  color: hsl(356, 84%, 56%);
+  background-color: hsl(176, 84%, 44%);
+  border: 4px solid hsl(86, 50%, 50%);
+  margin: 8px 24px 15px 8px;
+  padding: 8px 4px;
+  border-radius: 8px 1px;
+  box-shadow: 3px 5px 5px rgba(68, 136, 204, 0.6);
+  transform: rotate(68deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box69 {
+  --cssA-v-69: 546411;
+  color: hsl(33, 97%, 63%);
+  background-color: hsl(213, 97%, 37%);
+  border: 5px solid hsl(123, 50%, 50%);
+  margin: 9px 27px 20px 15px;
+  padding: 9px 6px;
+  border-radius: 9px 3px;
+  box-shadow: 4px 6px 6px rgba(69, 138, 207, 0.7);
+  transform: rotate(69deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box70 {
+  --cssA-v-70: 554330;
+  color: hsl(70, 10%, 70%);
+  background-color: hsl(250, 10%, 30%);
+  border: 1px solid hsl(160, 50%, 50%);
+  margin: 10px 0px 0px 4px;
+  padding: 10px 8px;
+  border-radius: 10px 5px;
+  box-shadow: 0px 0px 7px rgba(70, 140, 210, 0.8);
+  transform: rotate(70deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box71 {
+  --cssA-v-71: 562249;
+  color: hsl(107, 23%, 77%);
+  background-color: hsl(287, 23%, 23%);
+  border: 2px solid hsl(197, 50%, 50%);
+  margin: 11px 3px 5px 11px;
+  padding: 11px 10px;
+  border-radius: 11px 7px;
+  box-shadow: 1px 1px 8px rgba(71, 142, 213, 0.9);
+  transform: rotate(71deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box72 {
+  --cssA-v-72: 570168;
+  color: hsl(144, 36%, 34%);
+  background-color: hsl(324, 36%, 66%);
+  border: 3px solid hsl(234, 50%, 50%);
+  margin: 12px 6px 10px 0px;
+  padding: 12px 12px;
+  border-radius: 0px 0px;
+  box-shadow: 2px 2px 0px rgba(72, 144, 216, 0.1);
+  transform: rotate(72deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box73 {
+  --cssA-v-73: 578087;
+  color: hsl(181, 49%, 41%);
+  background-color: hsl(1, 49%, 59%);
+  border: 4px solid hsl(271, 50%, 50%);
+  margin: 13px 9px 15px 7px;
+  padding: 13px 14px;
+  border-radius: 1px 2px;
+  box-shadow: 3px 3px 1px rgba(73, 146, 219, 0.2);
+  transform: rotate(73deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box74 {
+  --cssA-v-74: 586006;
+  color: hsl(218, 62%, 48%);
+  background-color: hsl(38, 62%, 52%);
+  border: 5px solid hsl(308, 50%, 50%);
+  margin: 14px 12px 20px 14px;
+  padding: 14px 16px;
+  border-radius: 2px 4px;
+  box-shadow: 4px 4px 2px rgba(74, 148, 222, 0.3);
+  transform: rotate(74deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box75 {
+  --cssA-v-75: 593925;
+  color: hsl(255, 75%, 55%);
+  background-color: hsl(75, 75%, 45%);
+  border: 1px solid hsl(345, 50%, 50%);
+  margin: 15px 15px 0px 3px;
+  padding: 0px 18px;
+  border-radius: 3px 6px;
+  box-shadow: 0px 5px 3px rgba(75, 150, 225, 0.4);
+  transform: rotate(75deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box76 {
+  --cssA-v-76: 601844;
+  color: hsl(292, 88%, 62%);
+  background-color: hsl(112, 88%, 38%);
+  border: 2px solid hsl(22, 50%, 50%);
+  margin: 16px 18px 5px 10px;
+  padding: 1px 20px;
+  border-radius: 4px 8px;
+  box-shadow: 1px 6px 4px rgba(76, 152, 228, 0.5);
+  transform: rotate(76deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box77 {
+  --cssA-v-77: 609763;
+  color: hsl(329, 1%, 69%);
+  background-color: hsl(149, 1%, 31%);
+  border: 3px solid hsl(59, 50%, 50%);
+  margin: 17px 21px 10px 17px;
+  padding: 2px 0px;
+  border-radius: 5px 1px;
+  box-shadow: 2px 0px 5px rgba(77, 154, 231, 0.6);
+  transform: rotate(77deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box78 {
+  --cssA-v-78: 617682;
+  color: hsl(6, 14%, 76%);
+  background-color: hsl(186, 14%, 24%);
+  border: 4px solid hsl(96, 50%, 50%);
+  margin: 18px 24px 15px 6px;
+  padding: 3px 2px;
+  border-radius: 6px 3px;
+  box-shadow: 3px 1px 6px rgba(78, 156, 234, 0.7);
+  transform: rotate(78deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box79 {
+  --cssA-v-79: 625601;
+  color: hsl(43, 27%, 33%);
+  background-color: hsl(223, 27%, 67%);
+  border: 5px solid hsl(133, 50%, 50%);
+  margin: 19px 27px 20px 13px;
+  padding: 4px 4px;
+  border-radius: 7px 5px;
+  box-shadow: 4px 2px 7px rgba(79, 158, 237, 0.8);
+  transform: rotate(79deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box80 {
+  --cssA-v-80: 633520;
+  color: hsl(80, 40%, 40%);
+  background-color: hsl(260, 40%, 60%);
+  border: 1px solid hsl(170, 50%, 50%);
+  margin: 0px 0px 0px 2px;
+  padding: 5px 6px;
+  border-radius: 8px 7px;
+  box-shadow: 0px 3px 8px rgba(80, 160, 240, 0.9);
+  transform: rotate(80deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box81 {
+  --cssA-v-81: 641439;
+  color: hsl(117, 53%, 47%);
+  background-color: hsl(297, 53%, 53%);
+  border: 2px solid hsl(207, 50%, 50%);
+  margin: 1px 3px 5px 9px;
+  padding: 6px 8px;
+  border-radius: 9px 0px;
+  box-shadow: 1px 4px 0px rgba(81, 162, 243, 0.1);
+  transform: rotate(81deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box82 {
+  --cssA-v-82: 649358;
+  color: hsl(154, 66%, 54%);
+  background-color: hsl(334, 66%, 46%);
+  border: 3px solid hsl(244, 50%, 50%);
+  margin: 2px 6px 10px 16px;
+  padding: 7px 10px;
+  border-radius: 10px 2px;
+  box-shadow: 2px 5px 1px rgba(82, 164, 246, 0.2);
+  transform: rotate(82deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box83 {
+  --cssA-v-83: 657277;
+  color: hsl(191, 79%, 61%);
+  background-color: hsl(11, 79%, 39%);
+  border: 4px solid hsl(281, 50%, 50%);
+  margin: 3px 9px 15px 5px;
+  padding: 8px 12px;
+  border-radius: 11px 4px;
+  box-shadow: 3px 6px 2px rgba(83, 166, 249, 0.3);
+  transform: rotate(83deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box84 {
+  --cssA-v-84: 665196;
+  color: hsl(228, 92%, 68%);
+  background-color: hsl(48, 92%, 32%);
+  border: 5px solid hsl(318, 50%, 50%);
+  margin: 4px 12px 20px 12px;
+  padding: 9px 14px;
+  border-radius: 0px 6px;
+  box-shadow: 4px 0px 3px rgba(84, 168, 252, 0.4);
+  transform: rotate(84deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box85 {
+  --cssA-v-85: 673115;
+  color: hsl(265, 5%, 75%);
+  background-color: hsl(85, 5%, 25%);
+  border: 1px solid hsl(355, 50%, 50%);
+  margin: 5px 15px 0px 1px;
+  padding: 10px 16px;
+  border-radius: 1px 8px;
+  box-shadow: 0px 1px 4px rgba(85, 170, 0, 0.5);
+  transform: rotate(85deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box86 {
+  --cssA-v-86: 681034;
+  color: hsl(302, 18%, 32%);
+  background-color: hsl(122, 18%, 68%);
+  border: 2px solid hsl(32, 50%, 50%);
+  margin: 6px 18px 5px 8px;
+  padding: 11px 18px;
+  border-radius: 2px 1px;
+  box-shadow: 1px 2px 5px rgba(86, 172, 3, 0.6);
+  transform: rotate(86deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box87 {
+  --cssA-v-87: 688953;
+  color: hsl(339, 31%, 39%);
+  background-color: hsl(159, 31%, 61%);
+  border: 3px solid hsl(69, 50%, 50%);
+  margin: 7px 21px 10px 15px;
+  padding: 12px 20px;
+  border-radius: 3px 3px;
+  box-shadow: 2px 3px 6px rgba(87, 174, 6, 0.7);
+  transform: rotate(87deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box88 {
+  --cssA-v-88: 696872;
+  color: hsl(16, 44%, 46%);
+  background-color: hsl(196, 44%, 54%);
+  border: 4px solid hsl(106, 50%, 50%);
+  margin: 8px 24px 15px 4px;
+  padding: 13px 0px;
+  border-radius: 4px 5px;
+  box-shadow: 3px 4px 7px rgba(88, 176, 9, 0.8);
+  transform: rotate(88deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box89 {
+  --cssA-v-89: 704791;
+  color: hsl(53, 57%, 53%);
+  background-color: hsl(233, 57%, 47%);
+  border: 5px solid hsl(143, 50%, 50%);
+  margin: 9px 27px 20px 11px;
+  padding: 14px 2px;
+  border-radius: 5px 7px;
+  box-shadow: 4px 5px 8px rgba(89, 178, 12, 0.9);
+  transform: rotate(89deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box90 {
+  --cssA-v-90: 712710;
+  color: hsl(90, 70%, 60%);
+  background-color: hsl(270, 70%, 40%);
+  border: 1px solid hsl(180, 50%, 50%);
+  margin: 10px 0px 0px 0px;
+  padding: 0px 4px;
+  border-radius: 6px 0px;
+  box-shadow: 0px 6px 0px rgba(90, 180, 15, 0.1);
+  transform: rotate(90deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box91 {
+  --cssA-v-91: 720629;
+  color: hsl(127, 83%, 67%);
+  background-color: hsl(307, 83%, 33%);
+  border: 2px solid hsl(217, 50%, 50%);
+  margin: 11px 3px 5px 7px;
+  padding: 1px 6px;
+  border-radius: 7px 2px;
+  box-shadow: 1px 0px 1px rgba(91, 182, 18, 0.2);
+  transform: rotate(91deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box92 {
+  --cssA-v-92: 728548;
+  color: hsl(164, 96%, 74%);
+  background-color: hsl(344, 96%, 26%);
+  border: 3px solid hsl(254, 50%, 50%);
+  margin: 12px 6px 10px 14px;
+  padding: 2px 8px;
+  border-radius: 8px 4px;
+  box-shadow: 2px 1px 2px rgba(92, 184, 21, 0.3);
+  transform: rotate(92deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box93 {
+  --cssA-v-93: 736467;
+  color: hsl(201, 9%, 31%);
+  background-color: hsl(21, 9%, 69%);
+  border: 4px solid hsl(291, 50%, 50%);
+  margin: 13px 9px 15px 3px;
+  padding: 3px 10px;
+  border-radius: 9px 6px;
+  box-shadow: 3px 2px 3px rgba(93, 186, 24, 0.4);
+  transform: rotate(93deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box94 {
+  --cssA-v-94: 744386;
+  color: hsl(238, 22%, 38%);
+  background-color: hsl(58, 22%, 62%);
+  border: 5px solid hsl(328, 50%, 50%);
+  margin: 14px 12px 20px 10px;
+  padding: 4px 12px;
+  border-radius: 10px 8px;
+  box-shadow: 4px 3px 4px rgba(94, 188, 27, 0.5);
+  transform: rotate(94deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box95 {
+  --cssA-v-95: 752305;
+  color: hsl(275, 35%, 45%);
+  background-color: hsl(95, 35%, 55%);
+  border: 1px solid hsl(5, 50%, 50%);
+  margin: 15px 15px 0px 17px;
+  padding: 5px 14px;
+  border-radius: 11px 1px;
+  box-shadow: 0px 4px 5px rgba(95, 190, 30, 0.6);
+  transform: rotate(95deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box96 {
+  --cssA-v-96: 760224;
+  color: hsl(312, 48%, 52%);
+  background-color: hsl(132, 48%, 48%);
+  border: 2px solid hsl(42, 50%, 50%);
+  margin: 16px 18px 5px 6px;
+  padding: 6px 16px;
+  border-radius: 0px 3px;
+  box-shadow: 1px 5px 6px rgba(96, 192, 33, 0.7);
+  transform: rotate(96deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box97 {
+  --cssA-v-97: 768143;
+  color: hsl(349, 61%, 59%);
+  background-color: hsl(169, 61%, 41%);
+  border: 3px solid hsl(79, 50%, 50%);
+  margin: 17px 21px 10px 13px;
+  padding: 7px 18px;
+  border-radius: 1px 5px;
+  box-shadow: 2px 6px 7px rgba(97, 194, 36, 0.8);
+  transform: rotate(97deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box98 {
+  --cssA-v-98: 776062;
+  color: hsl(26, 74%, 66%);
+  background-color: hsl(206, 74%, 34%);
+  border: 4px solid hsl(116, 50%, 50%);
+  margin: 18px 24px 15px 2px;
+  padding: 8px 20px;
+  border-radius: 2px 7px;
+  box-shadow: 3px 0px 8px rgba(98, 196, 39, 0.9);
+  transform: rotate(98deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box99 {
+  --cssA-v-99: 783981;
+  color: hsl(63, 87%, 73%);
+  background-color: hsl(243, 87%, 27%);
+  border: 5px solid hsl(153, 50%, 50%);
+  margin: 19px 27px 20px 9px;
+  padding: 9px 0px;
+  border-radius: 3px 0px;
+  box-shadow: 4px 1px 0px rgba(99, 198, 42, 0.1);
+  transform: rotate(99deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box100 {
+  --cssA-v-100: 791900;
+  color: hsl(100, 0%, 30%);
+  background-color: hsl(280, 0%, 70%);
+  border: 1px solid hsl(190, 50%, 50%);
+  margin: 0px 0px 0px 16px;
+  padding: 10px 2px;
+  border-radius: 4px 2px;
+  box-shadow: 0px 2px 1px rgba(100, 200, 45, 0.2);
+  transform: rotate(100deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box101 {
+  --cssA-v-101: 799819;
+  color: hsl(137, 13%, 37%);
+  background-color: hsl(317, 13%, 63%);
+  border: 2px solid hsl(227, 50%, 50%);
+  margin: 1px 3px 5px 5px;
+  padding: 11px 4px;
+  border-radius: 5px 4px;
+  box-shadow: 1px 3px 2px rgba(101, 202, 48, 0.3);
+  transform: rotate(101deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box102 {
+  --cssA-v-102: 807738;
+  color: hsl(174, 26%, 44%);
+  background-color: hsl(354, 26%, 56%);
+  border: 3px solid hsl(264, 50%, 50%);
+  margin: 2px 6px 10px 12px;
+  padding: 12px 6px;
+  border-radius: 6px 6px;
+  box-shadow: 2px 4px 3px rgba(102, 204, 51, 0.4);
+  transform: rotate(102deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box103 {
+  --cssA-v-103: 815657;
+  color: hsl(211, 39%, 51%);
+  background-color: hsl(31, 39%, 49%);
+  border: 4px solid hsl(301, 50%, 50%);
+  margin: 3px 9px 15px 1px;
+  padding: 13px 8px;
+  border-radius: 7px 8px;
+  box-shadow: 3px 5px 4px rgba(103, 206, 54, 0.5);
+  transform: rotate(103deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box104 {
+  --cssA-v-104: 823576;
+  color: hsl(248, 52%, 58%);
+  background-color: hsl(68, 52%, 42%);
+  border: 5px solid hsl(338, 50%, 50%);
+  margin: 4px 12px 20px 8px;
+  padding: 14px 10px;
+  border-radius: 8px 1px;
+  box-shadow: 4px 6px 5px rgba(104, 208, 57, 0.6);
+  transform: rotate(104deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box105 {
+  --cssA-v-105: 831495;
+  color: hsl(285, 65%, 65%);
+  background-color: hsl(105, 65%, 35%);
+  border: 1px solid hsl(15, 50%, 50%);
+  margin: 5px 15px 0px 15px;
+  padding: 0px 12px;
+  border-radius: 9px 3px;
+  box-shadow: 0px 0px 6px rgba(105, 210, 60, 0.7);
+  transform: rotate(105deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box106 {
+  --cssA-v-106: 839414;
+  color: hsl(322, 78%, 72%);
+  background-color: hsl(142, 78%, 28%);
+  border: 2px solid hsl(52, 50%, 50%);
+  margin: 6px 18px 5px 4px;
+  padding: 1px 14px;
+  border-radius: 10px 5px;
+  box-shadow: 1px 1px 7px rgba(106, 212, 63, 0.8);
+  transform: rotate(106deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box107 {
+  --cssA-v-107: 847333;
+  color: hsl(359, 91%, 79%);
+  background-color: hsl(179, 91%, 21%);
+  border: 3px solid hsl(89, 50%, 50%);
+  margin: 7px 21px 10px 11px;
+  padding: 2px 16px;
+  border-radius: 11px 7px;
+  box-shadow: 2px 2px 8px rgba(107, 214, 66, 0.9);
+  transform: rotate(107deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box108 {
+  --cssA-v-108: 855252;
+  color: hsl(36, 4%, 36%);
+  background-color: hsl(216, 4%, 64%);
+  border: 4px solid hsl(126, 50%, 50%);
+  margin: 8px 24px 15px 0px;
+  padding: 3px 18px;
+  border-radius: 0px 0px;
+  box-shadow: 3px 3px 0px rgba(108, 216, 69, 0.1);
+  transform: rotate(108deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box109 {
+  --cssA-v-109: 863171;
+  color: hsl(73, 17%, 43%);
+  background-color: hsl(253, 17%, 57%);
+  border: 5px solid hsl(163, 50%, 50%);
+  margin: 9px 27px 20px 7px;
+  padding: 4px 20px;
+  border-radius: 1px 2px;
+  box-shadow: 4px 4px 1px rgba(109, 218, 72, 0.2);
+  transform: rotate(109deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box110 {
+  --cssA-v-110: 871090;
+  color: hsl(110, 30%, 50%);
+  background-color: hsl(290, 30%, 50%);
+  border: 1px solid hsl(200, 50%, 50%);
+  margin: 10px 0px 0px 14px;
+  padding: 5px 0px;
+  border-radius: 2px 4px;
+  box-shadow: 0px 5px 2px rgba(110, 220, 75, 0.3);
+  transform: rotate(110deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box111 {
+  --cssA-v-111: 879009;
+  color: hsl(147, 43%, 57%);
+  background-color: hsl(327, 43%, 43%);
+  border: 2px solid hsl(237, 50%, 50%);
+  margin: 11px 3px 5px 3px;
+  padding: 6px 2px;
+  border-radius: 3px 6px;
+  box-shadow: 1px 6px 3px rgba(111, 222, 78, 0.4);
+  transform: rotate(111deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box112 {
+  --cssA-v-112: 886928;
+  color: hsl(184, 56%, 64%);
+  background-color: hsl(4, 56%, 36%);
+  border: 3px solid hsl(274, 50%, 50%);
+  margin: 12px 6px 10px 10px;
+  padding: 7px 4px;
+  border-radius: 4px 8px;
+  box-shadow: 2px 0px 4px rgba(112, 224, 81, 0.5);
+  transform: rotate(112deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box113 {
+  --cssA-v-113: 894847;
+  color: hsl(221, 69%, 71%);
+  background-color: hsl(41, 69%, 29%);
+  border: 4px solid hsl(311, 50%, 50%);
+  margin: 13px 9px 15px 17px;
+  padding: 8px 6px;
+  border-radius: 5px 1px;
+  box-shadow: 3px 1px 5px rgba(113, 226, 84, 0.6);
+  transform: rotate(113deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box114 {
+  --cssA-v-114: 902766;
+  color: hsl(258, 82%, 78%);
+  background-color: hsl(78, 82%, 22%);
+  border: 5px solid hsl(348, 50%, 50%);
+  margin: 14px 12px 20px 6px;
+  padding: 9px 8px;
+  border-radius: 6px 3px;
+  box-shadow: 4px 2px 6px rgba(114, 228, 87, 0.7);
+  transform: rotate(114deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box115 {
+  --cssA-v-115: 910685;
+  color: hsl(295, 95%, 35%);
+  background-color: hsl(115, 95%, 65%);
+  border: 1px solid hsl(25, 50%, 50%);
+  margin: 15px 15px 0px 13px;
+  padding: 10px 10px;
+  border-radius: 7px 5px;
+  box-shadow: 0px 3px 7px rgba(115, 230, 90, 0.8);
+  transform: rotate(115deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box116 {
+  --cssA-v-116: 918604;
+  color: hsl(332, 8%, 42%);
+  background-color: hsl(152, 8%, 58%);
+  border: 2px solid hsl(62, 50%, 50%);
+  margin: 16px 18px 5px 2px;
+  padding: 11px 12px;
+  border-radius: 8px 7px;
+  box-shadow: 1px 4px 8px rgba(116, 232, 93, 0.9);
+  transform: rotate(116deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box117 {
+  --cssA-v-117: 926523;
+  color: hsl(9, 21%, 49%);
+  background-color: hsl(189, 21%, 51%);
+  border: 3px solid hsl(99, 50%, 50%);
+  margin: 17px 21px 10px 9px;
+  padding: 12px 14px;
+  border-radius: 9px 0px;
+  box-shadow: 2px 5px 0px rgba(117, 234, 96, 0.1);
+  transform: rotate(117deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box118 {
+  --cssA-v-118: 934442;
+  color: hsl(46, 34%, 56%);
+  background-color: hsl(226, 34%, 44%);
+  border: 4px solid hsl(136, 50%, 50%);
+  margin: 18px 24px 15px 16px;
+  padding: 13px 16px;
+  border-radius: 10px 2px;
+  box-shadow: 3px 6px 1px rgba(118, 236, 99, 0.2);
+  transform: rotate(118deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box119 {
+  --cssA-v-119: 942361;
+  color: hsl(83, 47%, 63%);
+  background-color: hsl(263, 47%, 37%);
+  border: 5px solid hsl(173, 50%, 50%);
+  margin: 19px 27px 20px 5px;
+  padding: 14px 18px;
+  border-radius: 11px 4px;
+  box-shadow: 4px 0px 2px rgba(119, 238, 102, 0.3);
+  transform: rotate(119deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box120 {
+  --cssA-v-120: 950280;
+  color: hsl(120, 60%, 70%);
+  background-color: hsl(300, 60%, 30%);
+  border: 1px solid hsl(210, 50%, 50%);
+  margin: 0px 0px 0px 12px;
+  padding: 0px 20px;
+  border-radius: 0px 6px;
+  box-shadow: 0px 1px 3px rgba(120, 240, 105, 0.4);
+  transform: rotate(120deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box121 {
+  --cssA-v-121: 958199;
+  color: hsl(157, 73%, 77%);
+  background-color: hsl(337, 73%, 23%);
+  border: 2px solid hsl(247, 50%, 50%);
+  margin: 1px 3px 5px 1px;
+  padding: 1px 0px;
+  border-radius: 1px 8px;
+  box-shadow: 1px 2px 4px rgba(121, 242, 108, 0.5);
+  transform: rotate(121deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box122 {
+  --cssA-v-122: 966118;
+  color: hsl(194, 86%, 34%);
+  background-color: hsl(14, 86%, 66%);
+  border: 3px solid hsl(284, 50%, 50%);
+  margin: 2px 6px 10px 8px;
+  padding: 2px 2px;
+  border-radius: 2px 1px;
+  box-shadow: 2px 3px 5px rgba(122, 244, 111, 0.6);
+  transform: rotate(122deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box123 {
+  --cssA-v-123: 974037;
+  color: hsl(231, 99%, 41%);
+  background-color: hsl(51, 99%, 59%);
+  border: 4px solid hsl(321, 50%, 50%);
+  margin: 3px 9px 15px 15px;
+  padding: 3px 4px;
+  border-radius: 3px 3px;
+  box-shadow: 3px 4px 6px rgba(123, 246, 114, 0.7);
+  transform: rotate(123deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box124 {
+  --cssA-v-124: 981956;
+  color: hsl(268, 12%, 48%);
+  background-color: hsl(88, 12%, 52%);
+  border: 5px solid hsl(358, 50%, 50%);
+  margin: 4px 12px 20px 4px;
+  padding: 4px 6px;
+  border-radius: 4px 5px;
+  box-shadow: 4px 5px 7px rgba(124, 248, 117, 0.8);
+  transform: rotate(124deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box125 {
+  --cssA-v-125: 989875;
+  color: hsl(305, 25%, 55%);
+  background-color: hsl(125, 25%, 45%);
+  border: 1px solid hsl(35, 50%, 50%);
+  margin: 5px 15px 0px 11px;
+  padding: 5px 8px;
+  border-radius: 5px 7px;
+  box-shadow: 0px 6px 8px rgba(125, 250, 120, 0.9);
+  transform: rotate(125deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box126 {
+  --cssA-v-126: 997794;
+  color: hsl(342, 38%, 62%);
+  background-color: hsl(162, 38%, 38%);
+  border: 2px solid hsl(72, 50%, 50%);
+  margin: 6px 18px 5px 0px;
+  padding: 6px 10px;
+  border-radius: 6px 0px;
+  box-shadow: 1px 0px 0px rgba(126, 252, 123, 0.1);
+  transform: rotate(126deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box127 {
+  --cssA-v-127: 5713;
+  color: hsl(19, 51%, 69%);
+  background-color: hsl(199, 51%, 31%);
+  border: 3px solid hsl(109, 50%, 50%);
+  margin: 7px 21px 10px 7px;
+  padding: 7px 12px;
+  border-radius: 7px 2px;
+  box-shadow: 2px 1px 1px rgba(127, 254, 126, 0.2);
+  transform: rotate(127deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box128 {
+  --cssA-v-128: 13632;
+  color: hsl(56, 64%, 76%);
+  background-color: hsl(236, 64%, 24%);
+  border: 4px solid hsl(146, 50%, 50%);
+  margin: 8px 24px 15px 14px;
+  padding: 8px 14px;
+  border-radius: 8px 4px;
+  box-shadow: 3px 2px 2px rgba(128, 1, 129, 0.3);
+  transform: rotate(128deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box129 {
+  --cssA-v-129: 21551;
+  color: hsl(93, 77%, 33%);
+  background-color: hsl(273, 77%, 67%);
+  border: 5px solid hsl(183, 50%, 50%);
+  margin: 9px 27px 20px 3px;
+  padding: 9px 16px;
+  border-radius: 9px 6px;
+  box-shadow: 4px 3px 3px rgba(129, 3, 132, 0.4);
+  transform: rotate(129deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box130 {
+  --cssA-v-130: 29470;
+  color: hsl(130, 90%, 40%);
+  background-color: hsl(310, 90%, 60%);
+  border: 1px solid hsl(220, 50%, 50%);
+  margin: 10px 0px 0px 10px;
+  padding: 10px 18px;
+  border-radius: 10px 8px;
+  box-shadow: 0px 4px 4px rgba(130, 5, 135, 0.5);
+  transform: rotate(130deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box131 {
+  --cssA-v-131: 37389;
+  color: hsl(167, 3%, 47%);
+  background-color: hsl(347, 3%, 53%);
+  border: 2px solid hsl(257, 50%, 50%);
+  margin: 11px 3px 5px 17px;
+  padding: 11px 20px;
+  border-radius: 11px 1px;
+  box-shadow: 1px 5px 5px rgba(131, 7, 138, 0.6);
+  transform: rotate(131deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box132 {
+  --cssA-v-132: 45308;
+  color: hsl(204, 16%, 54%);
+  background-color: hsl(24, 16%, 46%);
+  border: 3px solid hsl(294, 50%, 50%);
+  margin: 12px 6px 10px 6px;
+  padding: 12px 0px;
+  border-radius: 0px 3px;
+  box-shadow: 2px 6px 6px rgba(132, 9, 141, 0.7);
+  transform: rotate(132deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box133 {
+  --cssA-v-133: 53227;
+  color: hsl(241, 29%, 61%);
+  background-color: hsl(61, 29%, 39%);
+  border: 4px solid hsl(331, 50%, 50%);
+  margin: 13px 9px 15px 13px;
+  padding: 13px 2px;
+  border-radius: 1px 5px;
+  box-shadow: 3px 0px 7px rgba(133, 11, 144, 0.8);
+  transform: rotate(133deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box134 {
+  --cssA-v-134: 61146;
+  color: hsl(278, 42%, 68%);
+  background-color: hsl(98, 42%, 32%);
+  border: 5px solid hsl(8, 50%, 50%);
+  margin: 14px 12px 20px 2px;
+  padding: 14px 4px;
+  border-radius: 2px 7px;
+  box-shadow: 4px 1px 8px rgba(134, 13, 147, 0.9);
+  transform: rotate(134deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box135 {
+  --cssA-v-135: 69065;
+  color: hsl(315, 55%, 75%);
+  background-color: hsl(135, 55%, 25%);
+  border: 1px solid hsl(45, 50%, 50%);
+  margin: 15px 15px 0px 9px;
+  padding: 0px 6px;
+  border-radius: 3px 0px;
+  box-shadow: 0px 2px 0px rgba(135, 15, 150, 0.1);
+  transform: rotate(135deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box136 {
+  --cssA-v-136: 76984;
+  color: hsl(352, 68%, 32%);
+  background-color: hsl(172, 68%, 68%);
+  border: 2px solid hsl(82, 50%, 50%);
+  margin: 16px 18px 5px 16px;
+  padding: 1px 8px;
+  border-radius: 4px 2px;
+  box-shadow: 1px 3px 1px rgba(136, 17, 153, 0.2);
+  transform: rotate(136deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box137 {
+  --cssA-v-137: 84903;
+  color: hsl(29, 81%, 39%);
+  background-color: hsl(209, 81%, 61%);
+  border: 3px solid hsl(119, 50%, 50%);
+  margin: 17px 21px 10px 5px;
+  padding: 2px 10px;
+  border-radius: 5px 4px;
+  box-shadow: 2px 4px 2px rgba(137, 19, 156, 0.3);
+  transform: rotate(137deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box138 {
+  --cssA-v-138: 92822;
+  color: hsl(66, 94%, 46%);
+  background-color: hsl(246, 94%, 54%);
+  border: 4px solid hsl(156, 50%, 50%);
+  margin: 18px 24px 15px 12px;
+  padding: 3px 12px;
+  border-radius: 6px 6px;
+  box-shadow: 3px 5px 3px rgba(138, 21, 159, 0.4);
+  transform: rotate(138deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box139 {
+  --cssA-v-139: 100741;
+  color: hsl(103, 7%, 53%);
+  background-color: hsl(283, 7%, 47%);
+  border: 5px solid hsl(193, 50%, 50%);
+  margin: 19px 27px 20px 1px;
+  padding: 4px 14px;
+  border-radius: 7px 8px;
+  box-shadow: 4px 6px 4px rgba(139, 23, 162, 0.5);
+  transform: rotate(139deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box140 {
+  --cssA-v-140: 108660;
+  color: hsl(140, 20%, 60%);
+  background-color: hsl(320, 20%, 40%);
+  border: 1px solid hsl(230, 50%, 50%);
+  margin: 0px 0px 0px 8px;
+  padding: 5px 16px;
+  border-radius: 8px 1px;
+  box-shadow: 0px 0px 5px rgba(140, 25, 165, 0.6);
+  transform: rotate(140deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box141 {
+  --cssA-v-141: 116579;
+  color: hsl(177, 33%, 67%);
+  background-color: hsl(357, 33%, 33%);
+  border: 2px solid hsl(267, 50%, 50%);
+  margin: 1px 3px 5px 15px;
+  padding: 6px 18px;
+  border-radius: 9px 3px;
+  box-shadow: 1px 1px 6px rgba(141, 27, 168, 0.7);
+  transform: rotate(141deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box142 {
+  --cssA-v-142: 124498;
+  color: hsl(214, 46%, 74%);
+  background-color: hsl(34, 46%, 26%);
+  border: 3px solid hsl(304, 50%, 50%);
+  margin: 2px 6px 10px 4px;
+  padding: 7px 20px;
+  border-radius: 10px 5px;
+  box-shadow: 2px 2px 7px rgba(142, 29, 171, 0.8);
+  transform: rotate(142deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box143 {
+  --cssA-v-143: 132417;
+  color: hsl(251, 59%, 31%);
+  background-color: hsl(71, 59%, 69%);
+  border: 4px solid hsl(341, 50%, 50%);
+  margin: 3px 9px 15px 11px;
+  padding: 8px 0px;
+  border-radius: 11px 7px;
+  box-shadow: 3px 3px 8px rgba(143, 31, 174, 0.9);
+  transform: rotate(143deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box144 {
+  --cssA-v-144: 140336;
+  color: hsl(288, 72%, 38%);
+  background-color: hsl(108, 72%, 62%);
+  border: 5px solid hsl(18, 50%, 50%);
+  margin: 4px 12px 20px 0px;
+  padding: 9px 2px;
+  border-radius: 0px 0px;
+  box-shadow: 4px 4px 0px rgba(144, 33, 177, 0.1);
+  transform: rotate(144deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box145 {
+  --cssA-v-145: 148255;
+  color: hsl(325, 85%, 45%);
+  background-color: hsl(145, 85%, 55%);
+  border: 1px solid hsl(55, 50%, 50%);
+  margin: 5px 15px 0px 7px;
+  padding: 10px 4px;
+  border-radius: 1px 2px;
+  box-shadow: 0px 5px 1px rgba(145, 35, 180, 0.2);
+  transform: rotate(145deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box146 {
+  --cssA-v-146: 156174;
+  color: hsl(2, 98%, 52%);
+  background-color: hsl(182, 98%, 48%);
+  border: 2px solid hsl(92, 50%, 50%);
+  margin: 6px 18px 5px 14px;
+  padding: 11px 6px;
+  border-radius: 2px 4px;
+  box-shadow: 1px 6px 2px rgba(146, 37, 183, 0.3);
+  transform: rotate(146deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box147 {
+  --cssA-v-147: 164093;
+  color: hsl(39, 11%, 59%);
+  background-color: hsl(219, 11%, 41%);
+  border: 3px solid hsl(129, 50%, 50%);
+  margin: 7px 21px 10px 3px;
+  padding: 12px 8px;
+  border-radius: 3px 6px;
+  box-shadow: 2px 0px 3px rgba(147, 39, 186, 0.4);
+  transform: rotate(147deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box148 {
+  --cssA-v-148: 172012;
+  color: hsl(76, 24%, 66%);
+  background-color: hsl(256, 24%, 34%);
+  border: 4px solid hsl(166, 50%, 50%);
+  margin: 8px 24px 15px 10px;
+  padding: 13px 10px;
+  border-radius: 4px 8px;
+  box-shadow: 3px 1px 4px rgba(148, 41, 189, 0.5);
+  transform: rotate(148deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box149 {
+  --cssA-v-149: 179931;
+  color: hsl(113, 37%, 73%);
+  background-color: hsl(293, 37%, 27%);
+  border: 5px solid hsl(203, 50%, 50%);
+  margin: 9px 27px 20px 17px;
+  padding: 14px 12px;
+  border-radius: 5px 1px;
+  box-shadow: 4px 2px 5px rgba(149, 43, 192, 0.6);
+  transform: rotate(149deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box150 {
+  --cssA-v-150: 187850;
+  color: hsl(150, 50%, 30%);
+  background-color: hsl(330, 50%, 70%);
+  border: 1px solid hsl(240, 50%, 50%);
+  margin: 10px 0px 0px 6px;
+  padding: 0px 14px;
+  border-radius: 6px 3px;
+  box-shadow: 0px 3px 6px rgba(150, 45, 195, 0.7);
+  transform: rotate(150deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box151 {
+  --cssA-v-151: 195769;
+  color: hsl(187, 63%, 37%);
+  background-color: hsl(7, 63%, 63%);
+  border: 2px solid hsl(277, 50%, 50%);
+  margin: 11px 3px 5px 13px;
+  padding: 1px 16px;
+  border-radius: 7px 5px;
+  box-shadow: 1px 4px 7px rgba(151, 47, 198, 0.8);
+  transform: rotate(151deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box152 {
+  --cssA-v-152: 203688;
+  color: hsl(224, 76%, 44%);
+  background-color: hsl(44, 76%, 56%);
+  border: 3px solid hsl(314, 50%, 50%);
+  margin: 12px 6px 10px 2px;
+  padding: 2px 18px;
+  border-radius: 8px 7px;
+  box-shadow: 2px 5px 8px rgba(152, 49, 201, 0.9);
+  transform: rotate(152deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box153 {
+  --cssA-v-153: 211607;
+  color: hsl(261, 89%, 51%);
+  background-color: hsl(81, 89%, 49%);
+  border: 4px solid hsl(351, 50%, 50%);
+  margin: 13px 9px 15px 9px;
+  padding: 3px 20px;
+  border-radius: 9px 0px;
+  box-shadow: 3px 6px 0px rgba(153, 51, 204, 0.1);
+  transform: rotate(153deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box154 {
+  --cssA-v-154: 219526;
+  color: hsl(298, 2%, 58%);
+  background-color: hsl(118, 2%, 42%);
+  border: 5px solid hsl(28, 50%, 50%);
+  margin: 14px 12px 20px 16px;
+  padding: 4px 0px;
+  border-radius: 10px 2px;
+  box-shadow: 4px 0px 1px rgba(154, 53, 207, 0.2);
+  transform: rotate(154deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box155 {
+  --cssA-v-155: 227445;
+  color: hsl(335, 15%, 65%);
+  background-color: hsl(155, 15%, 35%);
+  border: 1px solid hsl(65, 50%, 50%);
+  margin: 15px 15px 0px 5px;
+  padding: 5px 2px;
+  border-radius: 11px 4px;
+  box-shadow: 0px 1px 2px rgba(155, 55, 210, 0.3);
+  transform: rotate(155deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box156 {
+  --cssA-v-156: 235364;
+  color: hsl(12, 28%, 72%);
+  background-color: hsl(192, 28%, 28%);
+  border: 2px solid hsl(102, 50%, 50%);
+  margin: 16px 18px 5px 12px;
+  padding: 6px 4px;
+  border-radius: 0px 6px;
+  box-shadow: 1px 2px 3px rgba(156, 57, 213, 0.4);
+  transform: rotate(156deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box157 {
+  --cssA-v-157: 243283;
+  color: hsl(49, 41%, 79%);
+  background-color: hsl(229, 41%, 21%);
+  border: 3px solid hsl(139, 50%, 50%);
+  margin: 17px 21px 10px 1px;
+  padding: 7px 6px;
+  border-radius: 1px 8px;
+  box-shadow: 2px 3px 4px rgba(157, 59, 216, 0.5);
+  transform: rotate(157deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box158 {
+  --cssA-v-158: 251202;
+  color: hsl(86, 54%, 36%);
+  background-color: hsl(266, 54%, 64%);
+  border: 4px solid hsl(176, 50%, 50%);
+  margin: 18px 24px 15px 8px;
+  padding: 8px 8px;
+  border-radius: 2px 1px;
+  box-shadow: 3px 4px 5px rgba(158, 61, 219, 0.6);
+  transform: rotate(158deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box159 {
+  --cssA-v-159: 259121;
+  color: hsl(123, 67%, 43%);
+  background-color: hsl(303, 67%, 57%);
+  border: 5px solid hsl(213, 50%, 50%);
+  margin: 19px 27px 20px 15px;
+  padding: 9px 10px;
+  border-radius: 3px 3px;
+  box-shadow: 4px 5px 6px rgba(159, 63, 222, 0.7);
+  transform: rotate(159deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box160 {
+  --cssA-v-160: 267040;
+  color: hsl(160, 80%, 50%);
+  background-color: hsl(340, 80%, 50%);
+  border: 1px solid hsl(250, 50%, 50%);
+  margin: 0px 0px 0px 4px;
+  padding: 10px 12px;
+  border-radius: 4px 5px;
+  box-shadow: 0px 6px 7px rgba(160, 65, 225, 0.8);
+  transform: rotate(160deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box161 {
+  --cssA-v-161: 274959;
+  color: hsl(197, 93%, 57%);
+  background-color: hsl(17, 93%, 43%);
+  border: 2px solid hsl(287, 50%, 50%);
+  margin: 1px 3px 5px 11px;
+  padding: 11px 14px;
+  border-radius: 5px 7px;
+  box-shadow: 1px 0px 8px rgba(161, 67, 228, 0.9);
+  transform: rotate(161deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box162 {
+  --cssA-v-162: 282878;
+  color: hsl(234, 6%, 64%);
+  background-color: hsl(54, 6%, 36%);
+  border: 3px solid hsl(324, 50%, 50%);
+  margin: 2px 6px 10px 0px;
+  padding: 12px 16px;
+  border-radius: 6px 0px;
+  box-shadow: 2px 1px 0px rgba(162, 69, 231, 0.1);
+  transform: rotate(162deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box163 {
+  --cssA-v-163: 290797;
+  color: hsl(271, 19%, 71%);
+  background-color: hsl(91, 19%, 29%);
+  border: 4px solid hsl(1, 50%, 50%);
+  margin: 3px 9px 15px 7px;
+  padding: 13px 18px;
+  border-radius: 7px 2px;
+  box-shadow: 3px 2px 1px rgba(163, 71, 234, 0.2);
+  transform: rotate(163deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box164 {
+  --cssA-v-164: 298716;
+  color: hsl(308, 32%, 78%);
+  background-color: hsl(128, 32%, 22%);
+  border: 5px solid hsl(38, 50%, 50%);
+  margin: 4px 12px 20px 14px;
+  padding: 14px 20px;
+  border-radius: 8px 4px;
+  box-shadow: 4px 3px 2px rgba(164, 73, 237, 0.3);
+  transform: rotate(164deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box165 {
+  --cssA-v-165: 306635;
+  color: hsl(345, 45%, 35%);
+  background-color: hsl(165, 45%, 65%);
+  border: 1px solid hsl(75, 50%, 50%);
+  margin: 5px 15px 0px 3px;
+  padding: 0px 0px;
+  border-radius: 9px 6px;
+  box-shadow: 0px 4px 3px rgba(165, 75, 240, 0.4);
+  transform: rotate(165deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box166 {
+  --cssA-v-166: 314554;
+  color: hsl(22, 58%, 42%);
+  background-color: hsl(202, 58%, 58%);
+  border: 2px solid hsl(112, 50%, 50%);
+  margin: 6px 18px 5px 10px;
+  padding: 1px 2px;
+  border-radius: 10px 8px;
+  box-shadow: 1px 5px 4px rgba(166, 77, 243, 0.5);
+  transform: rotate(166deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box167 {
+  --cssA-v-167: 322473;
+  color: hsl(59, 71%, 49%);
+  background-color: hsl(239, 71%, 51%);
+  border: 3px solid hsl(149, 50%, 50%);
+  margin: 7px 21px 10px 17px;
+  padding: 2px 4px;
+  border-radius: 11px 1px;
+  box-shadow: 2px 6px 5px rgba(167, 79, 246, 0.6);
+  transform: rotate(167deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box168 {
+  --cssA-v-168: 330392;
+  color: hsl(96, 84%, 56%);
+  background-color: hsl(276, 84%, 44%);
+  border: 4px solid hsl(186, 50%, 50%);
+  margin: 8px 24px 15px 6px;
+  padding: 3px 6px;
+  border-radius: 0px 3px;
+  box-shadow: 3px 0px 6px rgba(168, 81, 249, 0.7);
+  transform: rotate(168deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box169 {
+  --cssA-v-169: 338311;
+  color: hsl(133, 97%, 63%);
+  background-color: hsl(313, 97%, 37%);
+  border: 5px solid hsl(223, 50%, 50%);
+  margin: 9px 27px 20px 13px;
+  padding: 4px 8px;
+  border-radius: 1px 5px;
+  box-shadow: 4px 1px 7px rgba(169, 83, 252, 0.8);
+  transform: rotate(169deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box170 {
+  --cssA-v-170: 346230;
+  color: hsl(170, 10%, 70%);
+  background-color: hsl(350, 10%, 30%);
+  border: 1px solid hsl(260, 50%, 50%);
+  margin: 10px 0px 0px 2px;
+  padding: 5px 10px;
+  border-radius: 2px 7px;
+  box-shadow: 0px 2px 8px rgba(170, 85, 0, 0.9);
+  transform: rotate(170deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box171 {
+  --cssA-v-171: 354149;
+  color: hsl(207, 23%, 77%);
+  background-color: hsl(27, 23%, 23%);
+  border: 2px solid hsl(297, 50%, 50%);
+  margin: 11px 3px 5px 9px;
+  padding: 6px 12px;
+  border-radius: 3px 0px;
+  box-shadow: 1px 3px 0px rgba(171, 87, 3, 0.1);
+  transform: rotate(171deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box172 {
+  --cssA-v-172: 362068;
+  color: hsl(244, 36%, 34%);
+  background-color: hsl(64, 36%, 66%);
+  border: 3px solid hsl(334, 50%, 50%);
+  margin: 12px 6px 10px 16px;
+  padding: 7px 14px;
+  border-radius: 4px 2px;
+  box-shadow: 2px 4px 1px rgba(172, 89, 6, 0.2);
+  transform: rotate(172deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box173 {
+  --cssA-v-173: 369987;
+  color: hsl(281, 49%, 41%);
+  background-color: hsl(101, 49%, 59%);
+  border: 4px solid hsl(11, 50%, 50%);
+  margin: 13px 9px 15px 5px;
+  padding: 8px 16px;
+  border-radius: 5px 4px;
+  box-shadow: 3px 5px 2px rgba(173, 91, 9, 0.3);
+  transform: rotate(173deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box174 {
+  --cssA-v-174: 377906;
+  color: hsl(318, 62%, 48%);
+  background-color: hsl(138, 62%, 52%);
+  border: 5px solid hsl(48, 50%, 50%);
+  margin: 14px 12px 20px 12px;
+  padding: 9px 18px;
+  border-radius: 6px 6px;
+  box-shadow: 4px 6px 3px rgba(174, 93, 12, 0.4);
+  transform: rotate(174deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box175 {
+  --cssA-v-175: 385825;
+  color: hsl(355, 75%, 55%);
+  background-color: hsl(175, 75%, 45%);
+  border: 1px solid hsl(85, 50%, 50%);
+  margin: 15px 15px 0px 1px;
+  padding: 10px 20px;
+  border-radius: 7px 8px;
+  box-shadow: 0px 0px 4px rgba(175, 95, 15, 0.5);
+  transform: rotate(175deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box176 {
+  --cssA-v-176: 393744;
+  color: hsl(32, 88%, 62%);
+  background-color: hsl(212, 88%, 38%);
+  border: 2px solid hsl(122, 50%, 50%);
+  margin: 16px 18px 5px 8px;
+  padding: 11px 0px;
+  border-radius: 8px 1px;
+  box-shadow: 1px 1px 5px rgba(176, 97, 18, 0.6);
+  transform: rotate(176deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box177 {
+  --cssA-v-177: 401663;
+  color: hsl(69, 1%, 69%);
+  background-color: hsl(249, 1%, 31%);
+  border: 3px solid hsl(159, 50%, 50%);
+  margin: 17px 21px 10px 15px;
+  padding: 12px 2px;
+  border-radius: 9px 3px;
+  box-shadow: 2px 2px 6px rgba(177, 99, 21, 0.7);
+  transform: rotate(177deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box178 {
+  --cssA-v-178: 409582;
+  color: hsl(106, 14%, 76%);
+  background-color: hsl(286, 14%, 24%);
+  border: 4px solid hsl(196, 50%, 50%);
+  margin: 18px 24px 15px 4px;
+  padding: 13px 4px;
+  border-radius: 10px 5px;
+  box-shadow: 3px 3px 7px rgba(178, 101, 24, 0.8);
+  transform: rotate(178deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box179 {
+  --cssA-v-179: 417501;
+  color: hsl(143, 27%, 33%);
+  background-color: hsl(323, 27%, 67%);
+  border: 5px solid hsl(233, 50%, 50%);
+  margin: 19px 27px 20px 11px;
+  padding: 14px 6px;
+  border-radius: 11px 7px;
+  box-shadow: 4px 4px 8px rgba(179, 103, 27, 0.9);
+  transform: rotate(179deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box180 {
+  --cssA-v-180: 425420;
+  color: hsl(180, 40%, 40%);
+  background-color: hsl(0, 40%, 60%);
+  border: 1px solid hsl(270, 50%, 50%);
+  margin: 0px 0px 0px 0px;
+  padding: 0px 8px;
+  border-radius: 0px 0px;
+  box-shadow: 0px 5px 0px rgba(180, 105, 30, 0.1);
+  transform: rotate(180deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box181 {
+  --cssA-v-181: 433339;
+  color: hsl(217, 53%, 47%);
+  background-color: hsl(37, 53%, 53%);
+  border: 2px solid hsl(307, 50%, 50%);
+  margin: 1px 3px 5px 7px;
+  padding: 1px 10px;
+  border-radius: 1px 2px;
+  box-shadow: 1px 6px 1px rgba(181, 107, 33, 0.2);
+  transform: rotate(181deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box182 {
+  --cssA-v-182: 441258;
+  color: hsl(254, 66%, 54%);
+  background-color: hsl(74, 66%, 46%);
+  border: 3px solid hsl(344, 50%, 50%);
+  margin: 2px 6px 10px 14px;
+  padding: 2px 12px;
+  border-radius: 2px 4px;
+  box-shadow: 2px 0px 2px rgba(182, 109, 36, 0.3);
+  transform: rotate(182deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box183 {
+  --cssA-v-183: 449177;
+  color: hsl(291, 79%, 61%);
+  background-color: hsl(111, 79%, 39%);
+  border: 4px solid hsl(21, 50%, 50%);
+  margin: 3px 9px 15px 3px;
+  padding: 3px 14px;
+  border-radius: 3px 6px;
+  box-shadow: 3px 1px 3px rgba(183, 111, 39, 0.4);
+  transform: rotate(183deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box184 {
+  --cssA-v-184: 457096;
+  color: hsl(328, 92%, 68%);
+  background-color: hsl(148, 92%, 32%);
+  border: 5px solid hsl(58, 50%, 50%);
+  margin: 4px 12px 20px 10px;
+  padding: 4px 16px;
+  border-radius: 4px 8px;
+  box-shadow: 4px 2px 4px rgba(184, 113, 42, 0.5);
+  transform: rotate(184deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box185 {
+  --cssA-v-185: 465015;
+  color: hsl(5, 5%, 75%);
+  background-color: hsl(185, 5%, 25%);
+  border: 1px solid hsl(95, 50%, 50%);
+  margin: 5px 15px 0px 17px;
+  padding: 5px 18px;
+  border-radius: 5px 1px;
+  box-shadow: 0px 3px 5px rgba(185, 115, 45, 0.6);
+  transform: rotate(185deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box186 {
+  --cssA-v-186: 472934;
+  color: hsl(42, 18%, 32%);
+  background-color: hsl(222, 18%, 68%);
+  border: 2px solid hsl(132, 50%, 50%);
+  margin: 6px 18px 5px 6px;
+  padding: 6px 20px;
+  border-radius: 6px 3px;
+  box-shadow: 1px 4px 6px rgba(186, 117, 48, 0.7);
+  transform: rotate(186deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box187 {
+  --cssA-v-187: 480853;
+  color: hsl(79, 31%, 39%);
+  background-color: hsl(259, 31%, 61%);
+  border: 3px solid hsl(169, 50%, 50%);
+  margin: 7px 21px 10px 13px;
+  padding: 7px 0px;
+  border-radius: 7px 5px;
+  box-shadow: 2px 5px 7px rgba(187, 119, 51, 0.8);
+  transform: rotate(187deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box188 {
+  --cssA-v-188: 488772;
+  color: hsl(116, 44%, 46%);
+  background-color: hsl(296, 44%, 54%);
+  border: 4px solid hsl(206, 50%, 50%);
+  margin: 8px 24px 15px 2px;
+  padding: 8px 2px;
+  border-radius: 8px 7px;
+  box-shadow: 3px 6px 8px rgba(188, 121, 54, 0.9);
+  transform: rotate(188deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box189 {
+  --cssA-v-189: 496691;
+  color: hsl(153, 57%, 53%);
+  background-color: hsl(333, 57%, 47%);
+  border: 5px solid hsl(243, 50%, 50%);
+  margin: 9px 27px 20px 9px;
+  padding: 9px 4px;
+  border-radius: 9px 0px;
+  box-shadow: 4px 0px 0px rgba(189, 123, 57, 0.1);
+  transform: rotate(189deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box190 {
+  --cssA-v-190: 504610;
+  color: hsl(190, 70%, 60%);
+  background-color: hsl(10, 70%, 40%);
+  border: 1px solid hsl(280, 50%, 50%);
+  margin: 10px 0px 0px 16px;
+  padding: 10px 6px;
+  border-radius: 10px 2px;
+  box-shadow: 0px 1px 1px rgba(190, 125, 60, 0.2);
+  transform: rotate(190deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box191 {
+  --cssA-v-191: 512529;
+  color: hsl(227, 83%, 67%);
+  background-color: hsl(47, 83%, 33%);
+  border: 2px solid hsl(317, 50%, 50%);
+  margin: 11px 3px 5px 5px;
+  padding: 11px 8px;
+  border-radius: 11px 4px;
+  box-shadow: 1px 2px 2px rgba(191, 127, 63, 0.3);
+  transform: rotate(191deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box192 {
+  --cssA-v-192: 520448;
+  color: hsl(264, 96%, 74%);
+  background-color: hsl(84, 96%, 26%);
+  border: 3px solid hsl(354, 50%, 50%);
+  margin: 12px 6px 10px 12px;
+  padding: 12px 10px;
+  border-radius: 0px 6px;
+  box-shadow: 2px 3px 3px rgba(192, 129, 66, 0.4);
+  transform: rotate(192deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box193 {
+  --cssA-v-193: 528367;
+  color: hsl(301, 9%, 31%);
+  background-color: hsl(121, 9%, 69%);
+  border: 4px solid hsl(31, 50%, 50%);
+  margin: 13px 9px 15px 1px;
+  padding: 13px 12px;
+  border-radius: 1px 8px;
+  box-shadow: 3px 4px 4px rgba(193, 131, 69, 0.5);
+  transform: rotate(193deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box194 {
+  --cssA-v-194: 536286;
+  color: hsl(338, 22%, 38%);
+  background-color: hsl(158, 22%, 62%);
+  border: 5px solid hsl(68, 50%, 50%);
+  margin: 14px 12px 20px 8px;
+  padding: 14px 14px;
+  border-radius: 2px 1px;
+  box-shadow: 4px 5px 5px rgba(194, 133, 72, 0.6);
+  transform: rotate(194deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box195 {
+  --cssA-v-195: 544205;
+  color: hsl(15, 35%, 45%);
+  background-color: hsl(195, 35%, 55%);
+  border: 1px solid hsl(105, 50%, 50%);
+  margin: 15px 15px 0px 15px;
+  padding: 0px 16px;
+  border-radius: 3px 3px;
+  box-shadow: 0px 6px 6px rgba(195, 135, 75, 0.7);
+  transform: rotate(195deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box196 {
+  --cssA-v-196: 552124;
+  color: hsl(52, 48%, 52%);
+  background-color: hsl(232, 48%, 48%);
+  border: 2px solid hsl(142, 50%, 50%);
+  margin: 16px 18px 5px 4px;
+  padding: 1px 18px;
+  border-radius: 4px 5px;
+  box-shadow: 1px 0px 7px rgba(196, 137, 78, 0.8);
+  transform: rotate(196deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box197 {
+  --cssA-v-197: 560043;
+  color: hsl(89, 61%, 59%);
+  background-color: hsl(269, 61%, 41%);
+  border: 3px solid hsl(179, 50%, 50%);
+  margin: 17px 21px 10px 11px;
+  padding: 2px 20px;
+  border-radius: 5px 7px;
+  box-shadow: 2px 1px 8px rgba(197, 139, 81, 0.9);
+  transform: rotate(197deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box198 {
+  --cssA-v-198: 567962;
+  color: hsl(126, 74%, 66%);
+  background-color: hsl(306, 74%, 34%);
+  border: 4px solid hsl(216, 50%, 50%);
+  margin: 18px 24px 15px 0px;
+  padding: 3px 0px;
+  border-radius: 6px 0px;
+  box-shadow: 3px 2px 0px rgba(198, 141, 84, 0.1);
+  transform: rotate(198deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box199 {
+  --cssA-v-199: 575881;
+  color: hsl(163, 87%, 73%);
+  background-color: hsl(343, 87%, 27%);
+  border: 5px solid hsl(253, 50%, 50%);
+  margin: 19px 27px 20px 7px;
+  padding: 4px 2px;
+  border-radius: 7px 2px;
+  box-shadow: 4px 3px 1px rgba(199, 143, 87, 0.2);
+  transform: rotate(199deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box200 {
+  --cssA-v-200: 583800;
+  color: hsl(200, 0%, 30%);
+  background-color: hsl(20, 0%, 70%);
+  border: 1px solid hsl(290, 50%, 50%);
+  margin: 0px 0px 0px 14px;
+  padding: 5px 4px;
+  border-radius: 8px 4px;
+  box-shadow: 0px 4px 2px rgba(200, 145, 90, 0.3);
+  transform: rotate(200deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box201 {
+  --cssA-v-201: 591719;
+  color: hsl(237, 13%, 37%);
+  background-color: hsl(57, 13%, 63%);
+  border: 2px solid hsl(327, 50%, 50%);
+  margin: 1px 3px 5px 3px;
+  padding: 6px 6px;
+  border-radius: 9px 6px;
+  box-shadow: 1px 5px 3px rgba(201, 147, 93, 0.4);
+  transform: rotate(201deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box202 {
+  --cssA-v-202: 599638;
+  color: hsl(274, 26%, 44%);
+  background-color: hsl(94, 26%, 56%);
+  border: 3px solid hsl(4, 50%, 50%);
+  margin: 2px 6px 10px 10px;
+  padding: 7px 8px;
+  border-radius: 10px 8px;
+  box-shadow: 2px 6px 4px rgba(202, 149, 96, 0.5);
+  transform: rotate(202deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box203 {
+  --cssA-v-203: 607557;
+  color: hsl(311, 39%, 51%);
+  background-color: hsl(131, 39%, 49%);
+  border: 4px solid hsl(41, 50%, 50%);
+  margin: 3px 9px 15px 17px;
+  padding: 8px 10px;
+  border-radius: 11px 1px;
+  box-shadow: 3px 0px 5px rgba(203, 151, 99, 0.6);
+  transform: rotate(203deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box204 {
+  --cssA-v-204: 615476;
+  color: hsl(348, 52%, 58%);
+  background-color: hsl(168, 52%, 42%);
+  border: 5px solid hsl(78, 50%, 50%);
+  margin: 4px 12px 20px 6px;
+  padding: 9px 12px;
+  border-radius: 0px 3px;
+  box-shadow: 4px 1px 6px rgba(204, 153, 102, 0.7);
+  transform: rotate(204deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box205 {
+  --cssA-v-205: 623395;
+  color: hsl(25, 65%, 65%);
+  background-color: hsl(205, 65%, 35%);
+  border: 1px solid hsl(115, 50%, 50%);
+  margin: 5px 15px 0px 13px;
+  padding: 10px 14px;
+  border-radius: 1px 5px;
+  box-shadow: 0px 2px 7px rgba(205, 155, 105, 0.8);
+  transform: rotate(205deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box206 {
+  --cssA-v-206: 631314;
+  color: hsl(62, 78%, 72%);
+  background-color: hsl(242, 78%, 28%);
+  border: 2px solid hsl(152, 50%, 50%);
+  margin: 6px 18px 5px 2px;
+  padding: 11px 16px;
+  border-radius: 2px 7px;
+  box-shadow: 1px 3px 8px rgba(206, 157, 108, 0.9);
+  transform: rotate(206deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box207 {
+  --cssA-v-207: 639233;
+  color: hsl(99, 91%, 79%);
+  background-color: hsl(279, 91%, 21%);
+  border: 3px solid hsl(189, 50%, 50%);
+  margin: 7px 21px 10px 9px;
+  padding: 12px 18px;
+  border-radius: 3px 0px;
+  box-shadow: 2px 4px 0px rgba(207, 159, 111, 0.1);
+  transform: rotate(207deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box208 {
+  --cssA-v-208: 647152;
+  color: hsl(136, 4%, 36%);
+  background-color: hsl(316, 4%, 64%);
+  border: 4px solid hsl(226, 50%, 50%);
+  margin: 8px 24px 15px 16px;
+  padding: 13px 20px;
+  border-radius: 4px 2px;
+  box-shadow: 3px 5px 1px rgba(208, 161, 114, 0.2);
+  transform: rotate(208deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box209 {
+  --cssA-v-209: 655071;
+  color: hsl(173, 17%, 43%);
+  background-color: hsl(353, 17%, 57%);
+  border: 5px solid hsl(263, 50%, 50%);
+  margin: 9px 27px 20px 5px;
+  padding: 14px 0px;
+  border-radius: 5px 4px;
+  box-shadow: 4px 6px 2px rgba(209, 163, 117, 0.3);
+  transform: rotate(209deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box210 {
+  --cssA-v-210: 662990;
+  color: hsl(210, 30%, 50%);
+  background-color: hsl(30, 30%, 50%);
+  border: 1px solid hsl(300, 50%, 50%);
+  margin: 10px 0px 0px 12px;
+  padding: 0px 2px;
+  border-radius: 6px 6px;
+  box-shadow: 0px 0px 3px rgba(210, 165, 120, 0.4);
+  transform: rotate(210deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box211 {
+  --cssA-v-211: 670909;
+  color: hsl(247, 43%, 57%);
+  background-color: hsl(67, 43%, 43%);
+  border: 2px solid hsl(337, 50%, 50%);
+  margin: 11px 3px 5px 1px;
+  padding: 1px 4px;
+  border-radius: 7px 8px;
+  box-shadow: 1px 1px 4px rgba(211, 167, 123, 0.5);
+  transform: rotate(211deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box212 {
+  --cssA-v-212: 678828;
+  color: hsl(284, 56%, 64%);
+  background-color: hsl(104, 56%, 36%);
+  border: 3px solid hsl(14, 50%, 50%);
+  margin: 12px 6px 10px 8px;
+  padding: 2px 6px;
+  border-radius: 8px 1px;
+  box-shadow: 2px 2px 5px rgba(212, 169, 126, 0.6);
+  transform: rotate(212deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box213 {
+  --cssA-v-213: 686747;
+  color: hsl(321, 69%, 71%);
+  background-color: hsl(141, 69%, 29%);
+  border: 4px solid hsl(51, 50%, 50%);
+  margin: 13px 9px 15px 15px;
+  padding: 3px 8px;
+  border-radius: 9px 3px;
+  box-shadow: 3px 3px 6px rgba(213, 171, 129, 0.7);
+  transform: rotate(213deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box214 {
+  --cssA-v-214: 694666;
+  color: hsl(358, 82%, 78%);
+  background-color: hsl(178, 82%, 22%);
+  border: 5px solid hsl(88, 50%, 50%);
+  margin: 14px 12px 20px 4px;
+  padding: 4px 10px;
+  border-radius: 10px 5px;
+  box-shadow: 4px 4px 7px rgba(214, 173, 132, 0.8);
+  transform: rotate(214deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box215 {
+  --cssA-v-215: 702585;
+  color: hsl(35, 95%, 35%);
+  background-color: hsl(215, 95%, 65%);
+  border: 1px solid hsl(125, 50%, 50%);
+  margin: 15px 15px 0px 11px;
+  padding: 5px 12px;
+  border-radius: 11px 7px;
+  box-shadow: 0px 5px 8px rgba(215, 175, 135, 0.9);
+  transform: rotate(215deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box216 {
+  --cssA-v-216: 710504;
+  color: hsl(72, 8%, 42%);
+  background-color: hsl(252, 8%, 58%);
+  border: 2px solid hsl(162, 50%, 50%);
+  margin: 16px 18px 5px 0px;
+  padding: 6px 14px;
+  border-radius: 0px 0px;
+  box-shadow: 1px 6px 0px rgba(216, 177, 138, 0.1);
+  transform: rotate(216deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box217 {
+  --cssA-v-217: 718423;
+  color: hsl(109, 21%, 49%);
+  background-color: hsl(289, 21%, 51%);
+  border: 3px solid hsl(199, 50%, 50%);
+  margin: 17px 21px 10px 7px;
+  padding: 7px 16px;
+  border-radius: 1px 2px;
+  box-shadow: 2px 0px 1px rgba(217, 179, 141, 0.2);
+  transform: rotate(217deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box218 {
+  --cssA-v-218: 726342;
+  color: hsl(146, 34%, 56%);
+  background-color: hsl(326, 34%, 44%);
+  border: 4px solid hsl(236, 50%, 50%);
+  margin: 18px 24px 15px 14px;
+  padding: 8px 18px;
+  border-radius: 2px 4px;
+  box-shadow: 3px 1px 2px rgba(218, 181, 144, 0.3);
+  transform: rotate(218deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box219 {
+  --cssA-v-219: 734261;
+  color: hsl(183, 47%, 63%);
+  background-color: hsl(3, 47%, 37%);
+  border: 5px solid hsl(273, 50%, 50%);
+  margin: 19px 27px 20px 3px;
+  padding: 9px 20px;
+  border-radius: 3px 6px;
+  box-shadow: 4px 2px 3px rgba(219, 183, 147, 0.4);
+  transform: rotate(219deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box220 {
+  --cssA-v-220: 742180;
+  color: hsl(220, 60%, 70%);
+  background-color: hsl(40, 60%, 30%);
+  border: 1px solid hsl(310, 50%, 50%);
+  margin: 0px 0px 0px 10px;
+  padding: 10px 0px;
+  border-radius: 4px 8px;
+  box-shadow: 0px 3px 4px rgba(220, 185, 150, 0.5);
+  transform: rotate(220deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box221 {
+  --cssA-v-221: 750099;
+  color: hsl(257, 73%, 77%);
+  background-color: hsl(77, 73%, 23%);
+  border: 2px solid hsl(347, 50%, 50%);
+  margin: 1px 3px 5px 17px;
+  padding: 11px 2px;
+  border-radius: 5px 1px;
+  box-shadow: 1px 4px 5px rgba(221, 187, 153, 0.6);
+  transform: rotate(221deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box222 {
+  --cssA-v-222: 758018;
+  color: hsl(294, 86%, 34%);
+  background-color: hsl(114, 86%, 66%);
+  border: 3px solid hsl(24, 50%, 50%);
+  margin: 2px 6px 10px 6px;
+  padding: 12px 4px;
+  border-radius: 6px 3px;
+  box-shadow: 2px 5px 6px rgba(222, 189, 156, 0.7);
+  transform: rotate(222deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box223 {
+  --cssA-v-223: 765937;
+  color: hsl(331, 99%, 41%);
+  background-color: hsl(151, 99%, 59%);
+  border: 4px solid hsl(61, 50%, 50%);
+  margin: 3px 9px 15px 13px;
+  padding: 13px 6px;
+  border-radius: 7px 5px;
+  box-shadow: 3px 6px 7px rgba(223, 191, 159, 0.8);
+  transform: rotate(223deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box224 {
+  --cssA-v-224: 773856;
+  color: hsl(8, 12%, 48%);
+  background-color: hsl(188, 12%, 52%);
+  border: 5px solid hsl(98, 50%, 50%);
+  margin: 4px 12px 20px 2px;
+  padding: 14px 8px;
+  border-radius: 8px 7px;
+  box-shadow: 4px 0px 8px rgba(224, 193, 162, 0.9);
+  transform: rotate(224deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box225 {
+  --cssA-v-225: 781775;
+  color: hsl(45, 25%, 55%);
+  background-color: hsl(225, 25%, 45%);
+  border: 1px solid hsl(135, 50%, 50%);
+  margin: 5px 15px 0px 9px;
+  padding: 0px 10px;
+  border-radius: 9px 0px;
+  box-shadow: 0px 1px 0px rgba(225, 195, 165, 0.1);
+  transform: rotate(225deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box226 {
+  --cssA-v-226: 789694;
+  color: hsl(82, 38%, 62%);
+  background-color: hsl(262, 38%, 38%);
+  border: 2px solid hsl(172, 50%, 50%);
+  margin: 6px 18px 5px 16px;
+  padding: 1px 12px;
+  border-radius: 10px 2px;
+  box-shadow: 1px 2px 1px rgba(226, 197, 168, 0.2);
+  transform: rotate(226deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box227 {
+  --cssA-v-227: 797613;
+  color: hsl(119, 51%, 69%);
+  background-color: hsl(299, 51%, 31%);
+  border: 3px solid hsl(209, 50%, 50%);
+  margin: 7px 21px 10px 5px;
+  padding: 2px 14px;
+  border-radius: 11px 4px;
+  box-shadow: 2px 3px 2px rgba(227, 199, 171, 0.3);
+  transform: rotate(227deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box228 {
+  --cssA-v-228: 805532;
+  color: hsl(156, 64%, 76%);
+  background-color: hsl(336, 64%, 24%);
+  border: 4px solid hsl(246, 50%, 50%);
+  margin: 8px 24px 15px 12px;
+  padding: 3px 16px;
+  border-radius: 0px 6px;
+  box-shadow: 3px 4px 3px rgba(228, 201, 174, 0.4);
+  transform: rotate(228deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box229 {
+  --cssA-v-229: 813451;
+  color: hsl(193, 77%, 33%);
+  background-color: hsl(13, 77%, 67%);
+  border: 5px solid hsl(283, 50%, 50%);
+  margin: 9px 27px 20px 1px;
+  padding: 4px 18px;
+  border-radius: 1px 8px;
+  box-shadow: 4px 5px 4px rgba(229, 203, 177, 0.5);
+  transform: rotate(229deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box230 {
+  --cssA-v-230: 821370;
+  color: hsl(230, 90%, 40%);
+  background-color: hsl(50, 90%, 60%);
+  border: 1px solid hsl(320, 50%, 50%);
+  margin: 10px 0px 0px 8px;
+  padding: 5px 20px;
+  border-radius: 2px 1px;
+  box-shadow: 0px 6px 5px rgba(230, 205, 180, 0.6);
+  transform: rotate(230deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box231 {
+  --cssA-v-231: 829289;
+  color: hsl(267, 3%, 47%);
+  background-color: hsl(87, 3%, 53%);
+  border: 2px solid hsl(357, 50%, 50%);
+  margin: 11px 3px 5px 15px;
+  padding: 6px 0px;
+  border-radius: 3px 3px;
+  box-shadow: 1px 0px 6px rgba(231, 207, 183, 0.7);
+  transform: rotate(231deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box232 {
+  --cssA-v-232: 837208;
+  color: hsl(304, 16%, 54%);
+  background-color: hsl(124, 16%, 46%);
+  border: 3px solid hsl(34, 50%, 50%);
+  margin: 12px 6px 10px 4px;
+  padding: 7px 2px;
+  border-radius: 4px 5px;
+  box-shadow: 2px 1px 7px rgba(232, 209, 186, 0.8);
+  transform: rotate(232deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box233 {
+  --cssA-v-233: 845127;
+  color: hsl(341, 29%, 61%);
+  background-color: hsl(161, 29%, 39%);
+  border: 4px solid hsl(71, 50%, 50%);
+  margin: 13px 9px 15px 11px;
+  padding: 8px 4px;
+  border-radius: 5px 7px;
+  box-shadow: 3px 2px 8px rgba(233, 211, 189, 0.9);
+  transform: rotate(233deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box234 {
+  --cssA-v-234: 853046;
+  color: hsl(18, 42%, 68%);
+  background-color: hsl(198, 42%, 32%);
+  border: 5px solid hsl(108, 50%, 50%);
+  margin: 14px 12px 20px 0px;
+  padding: 9px 6px;
+  border-radius: 6px 0px;
+  box-shadow: 4px 3px 0px rgba(234, 213, 192, 0.1);
+  transform: rotate(234deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box235 {
+  --cssA-v-235: 860965;
+  color: hsl(55, 55%, 75%);
+  background-color: hsl(235, 55%, 25%);
+  border: 1px solid hsl(145, 50%, 50%);
+  margin: 15px 15px 0px 7px;
+  padding: 10px 8px;
+  border-radius: 7px 2px;
+  box-shadow: 0px 4px 1px rgba(235, 215, 195, 0.2);
+  transform: rotate(235deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box236 {
+  --cssA-v-236: 868884;
+  color: hsl(92, 68%, 32%);
+  background-color: hsl(272, 68%, 68%);
+  border: 2px solid hsl(182, 50%, 50%);
+  margin: 16px 18px 5px 14px;
+  padding: 11px 10px;
+  border-radius: 8px 4px;
+  box-shadow: 1px 5px 2px rgba(236, 217, 198, 0.3);
+  transform: rotate(236deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box237 {
+  --cssA-v-237: 876803;
+  color: hsl(129, 81%, 39%);
+  background-color: hsl(309, 81%, 61%);
+  border: 3px solid hsl(219, 50%, 50%);
+  margin: 17px 21px 10px 3px;
+  padding: 12px 12px;
+  border-radius: 9px 6px;
+  box-shadow: 2px 6px 3px rgba(237, 219, 201, 0.4);
+  transform: rotate(237deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box238 {
+  --cssA-v-238: 884722;
+  color: hsl(166, 94%, 46%);
+  background-color: hsl(346, 94%, 54%);
+  border: 4px solid hsl(256, 50%, 50%);
+  margin: 18px 24px 15px 10px;
+  padding: 13px 14px;
+  border-radius: 10px 8px;
+  box-shadow: 3px 0px 4px rgba(238, 221, 204, 0.5);
+  transform: rotate(238deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box239 {
+  --cssA-v-239: 892641;
+  color: hsl(203, 7%, 53%);
+  background-color: hsl(23, 7%, 47%);
+  border: 5px solid hsl(293, 50%, 50%);
+  margin: 19px 27px 20px 17px;
+  padding: 14px 16px;
+  border-radius: 11px 1px;
+  box-shadow: 4px 1px 5px rgba(239, 223, 207, 0.6);
+  transform: rotate(239deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box240 {
+  --cssA-v-240: 900560;
+  color: hsl(240, 20%, 60%);
+  background-color: hsl(60, 20%, 40%);
+  border: 1px solid hsl(330, 50%, 50%);
+  margin: 0px 0px 0px 6px;
+  padding: 0px 18px;
+  border-radius: 0px 3px;
+  box-shadow: 0px 2px 6px rgba(240, 225, 210, 0.7);
+  transform: rotate(240deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box241 {
+  --cssA-v-241: 908479;
+  color: hsl(277, 33%, 67%);
+  background-color: hsl(97, 33%, 33%);
+  border: 2px solid hsl(7, 50%, 50%);
+  margin: 1px 3px 5px 13px;
+  padding: 1px 20px;
+  border-radius: 1px 5px;
+  box-shadow: 1px 3px 7px rgba(241, 227, 213, 0.8);
+  transform: rotate(241deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box242 {
+  --cssA-v-242: 916398;
+  color: hsl(314, 46%, 74%);
+  background-color: hsl(134, 46%, 26%);
+  border: 3px solid hsl(44, 50%, 50%);
+  margin: 2px 6px 10px 2px;
+  padding: 2px 0px;
+  border-radius: 2px 7px;
+  box-shadow: 2px 4px 8px rgba(242, 229, 216, 0.9);
+  transform: rotate(242deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box243 {
+  --cssA-v-243: 924317;
+  color: hsl(351, 59%, 31%);
+  background-color: hsl(171, 59%, 69%);
+  border: 4px solid hsl(81, 50%, 50%);
+  margin: 3px 9px 15px 9px;
+  padding: 3px 2px;
+  border-radius: 3px 0px;
+  box-shadow: 3px 5px 0px rgba(243, 231, 219, 0.1);
+  transform: rotate(243deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box244 {
+  --cssA-v-244: 932236;
+  color: hsl(28, 72%, 38%);
+  background-color: hsl(208, 72%, 62%);
+  border: 5px solid hsl(118, 50%, 50%);
+  margin: 4px 12px 20px 16px;
+  padding: 4px 4px;
+  border-radius: 4px 2px;
+  box-shadow: 4px 6px 1px rgba(244, 233, 222, 0.2);
+  transform: rotate(244deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box245 {
+  --cssA-v-245: 940155;
+  color: hsl(65, 85%, 45%);
+  background-color: hsl(245, 85%, 55%);
+  border: 1px solid hsl(155, 50%, 50%);
+  margin: 5px 15px 0px 5px;
+  padding: 5px 6px;
+  border-radius: 5px 4px;
+  box-shadow: 0px 0px 2px rgba(245, 235, 225, 0.3);
+  transform: rotate(245deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box246 {
+  --cssA-v-246: 948074;
+  color: hsl(102, 98%, 52%);
+  background-color: hsl(282, 98%, 48%);
+  border: 2px solid hsl(192, 50%, 50%);
+  margin: 6px 18px 5px 12px;
+  padding: 6px 8px;
+  border-radius: 6px 6px;
+  box-shadow: 1px 1px 3px rgba(246, 237, 228, 0.4);
+  transform: rotate(246deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box247 {
+  --cssA-v-247: 955993;
+  color: hsl(139, 11%, 59%);
+  background-color: hsl(319, 11%, 41%);
+  border: 3px solid hsl(229, 50%, 50%);
+  margin: 7px 21px 10px 1px;
+  padding: 7px 10px;
+  border-radius: 7px 8px;
+  box-shadow: 2px 2px 4px rgba(247, 239, 231, 0.5);
+  transform: rotate(247deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box248 {
+  --cssA-v-248: 963912;
+  color: hsl(176, 24%, 66%);
+  background-color: hsl(356, 24%, 34%);
+  border: 4px solid hsl(266, 50%, 50%);
+  margin: 8px 24px 15px 8px;
+  padding: 8px 12px;
+  border-radius: 8px 1px;
+  box-shadow: 3px 3px 5px rgba(248, 241, 234, 0.6);
+  transform: rotate(248deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box249 {
+  --cssA-v-249: 971831;
+  color: hsl(213, 37%, 73%);
+  background-color: hsl(33, 37%, 27%);
+  border: 5px solid hsl(303, 50%, 50%);
+  margin: 9px 27px 20px 15px;
+  padding: 9px 14px;
+  border-radius: 9px 3px;
+  box-shadow: 4px 4px 6px rgba(249, 243, 237, 0.7);
+  transform: rotate(249deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box250 {
+  --cssA-v-250: 979750;
+  color: hsl(250, 50%, 30%);
+  background-color: hsl(70, 50%, 70%);
+  border: 1px solid hsl(340, 50%, 50%);
+  margin: 10px 0px 0px 4px;
+  padding: 10px 16px;
+  border-radius: 10px 5px;
+  box-shadow: 0px 5px 7px rgba(250, 245, 240, 0.8);
+  transform: rotate(250deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box251 {
+  --cssA-v-251: 987669;
+  color: hsl(287, 63%, 37%);
+  background-color: hsl(107, 63%, 63%);
+  border: 2px solid hsl(17, 50%, 50%);
+  margin: 11px 3px 5px 11px;
+  padding: 11px 18px;
+  border-radius: 11px 7px;
+  box-shadow: 1px 6px 8px rgba(251, 247, 243, 0.9);
+  transform: rotate(251deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box252 {
+  --cssA-v-252: 995588;
+  color: hsl(324, 76%, 44%);
+  background-color: hsl(144, 76%, 56%);
+  border: 3px solid hsl(54, 50%, 50%);
+  margin: 12px 6px 10px 0px;
+  padding: 12px 20px;
+  border-radius: 0px 0px;
+  box-shadow: 2px 0px 0px rgba(252, 249, 246, 0.1);
+  transform: rotate(252deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box253 {
+  --cssA-v-253: 3507;
+  color: hsl(1, 89%, 51%);
+  background-color: hsl(181, 89%, 49%);
+  border: 4px solid hsl(91, 50%, 50%);
+  margin: 13px 9px 15px 7px;
+  padding: 13px 0px;
+  border-radius: 1px 2px;
+  box-shadow: 3px 1px 1px rgba(253, 251, 249, 0.2);
+  transform: rotate(253deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box254 {
+  --cssA-v-254: 11426;
+  color: hsl(38, 2%, 58%);
+  background-color: hsl(218, 2%, 42%);
+  border: 5px solid hsl(128, 50%, 50%);
+  margin: 14px 12px 20px 14px;
+  padding: 14px 2px;
+  border-radius: 2px 4px;
+  box-shadow: 4px 2px 2px rgba(254, 253, 252, 0.3);
+  transform: rotate(254deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box255 {
+  --cssA-v-255: 19345;
+  color: hsl(75, 15%, 65%);
+  background-color: hsl(255, 15%, 35%);
+  border: 1px solid hsl(165, 50%, 50%);
+  margin: 15px 15px 0px 3px;
+  padding: 0px 4px;
+  border-radius: 3px 6px;
+  box-shadow: 0px 3px 3px rgba(0, 0, 0, 0.4);
+  transform: rotate(255deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box256 {
+  --cssA-v-256: 27264;
+  color: hsl(112, 28%, 72%);
+  background-color: hsl(292, 28%, 28%);
+  border: 2px solid hsl(202, 50%, 50%);
+  margin: 16px 18px 5px 10px;
+  padding: 1px 6px;
+  border-radius: 4px 8px;
+  box-shadow: 1px 4px 4px rgba(1, 2, 3, 0.5);
+  transform: rotate(256deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box257 {
+  --cssA-v-257: 35183;
+  color: hsl(149, 41%, 79%);
+  background-color: hsl(329, 41%, 21%);
+  border: 3px solid hsl(239, 50%, 50%);
+  margin: 17px 21px 10px 17px;
+  padding: 2px 8px;
+  border-radius: 5px 1px;
+  box-shadow: 2px 5px 5px rgba(2, 4, 6, 0.6);
+  transform: rotate(257deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box258 {
+  --cssA-v-258: 43102;
+  color: hsl(186, 54%, 36%);
+  background-color: hsl(6, 54%, 64%);
+  border: 4px solid hsl(276, 50%, 50%);
+  margin: 18px 24px 15px 6px;
+  padding: 3px 10px;
+  border-radius: 6px 3px;
+  box-shadow: 3px 6px 6px rgba(3, 6, 9, 0.7);
+  transform: rotate(258deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box259 {
+  --cssA-v-259: 51021;
+  color: hsl(223, 67%, 43%);
+  background-color: hsl(43, 67%, 57%);
+  border: 5px solid hsl(313, 50%, 50%);
+  margin: 19px 27px 20px 13px;
+  padding: 4px 12px;
+  border-radius: 7px 5px;
+  box-shadow: 4px 0px 7px rgba(4, 8, 12, 0.8);
+  transform: rotate(259deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box260 {
+  --cssA-v-260: 58940;
+  color: hsl(260, 80%, 50%);
+  background-color: hsl(80, 80%, 50%);
+  border: 1px solid hsl(350, 50%, 50%);
+  margin: 0px 0px 0px 2px;
+  padding: 5px 14px;
+  border-radius: 8px 7px;
+  box-shadow: 0px 1px 8px rgba(5, 10, 15, 0.9);
+  transform: rotate(260deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box261 {
+  --cssA-v-261: 66859;
+  color: hsl(297, 93%, 57%);
+  background-color: hsl(117, 93%, 43%);
+  border: 2px solid hsl(27, 50%, 50%);
+  margin: 1px 3px 5px 9px;
+  padding: 6px 16px;
+  border-radius: 9px 0px;
+  box-shadow: 1px 2px 0px rgba(6, 12, 18, 0.1);
+  transform: rotate(261deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box262 {
+  --cssA-v-262: 74778;
+  color: hsl(334, 6%, 64%);
+  background-color: hsl(154, 6%, 36%);
+  border: 3px solid hsl(64, 50%, 50%);
+  margin: 2px 6px 10px 16px;
+  padding: 7px 18px;
+  border-radius: 10px 2px;
+  box-shadow: 2px 3px 1px rgba(7, 14, 21, 0.2);
+  transform: rotate(262deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box263 {
+  --cssA-v-263: 82697;
+  color: hsl(11, 19%, 71%);
+  background-color: hsl(191, 19%, 29%);
+  border: 4px solid hsl(101, 50%, 50%);
+  margin: 3px 9px 15px 5px;
+  padding: 8px 20px;
+  border-radius: 11px 4px;
+  box-shadow: 3px 4px 2px rgba(8, 16, 24, 0.3);
+  transform: rotate(263deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box264 {
+  --cssA-v-264: 90616;
+  color: hsl(48, 32%, 78%);
+  background-color: hsl(228, 32%, 22%);
+  border: 5px solid hsl(138, 50%, 50%);
+  margin: 4px 12px 20px 12px;
+  padding: 9px 0px;
+  border-radius: 0px 6px;
+  box-shadow: 4px 5px 3px rgba(9, 18, 27, 0.4);
+  transform: rotate(264deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box265 {
+  --cssA-v-265: 98535;
+  color: hsl(85, 45%, 35%);
+  background-color: hsl(265, 45%, 65%);
+  border: 1px solid hsl(175, 50%, 50%);
+  margin: 5px 15px 0px 1px;
+  padding: 10px 2px;
+  border-radius: 1px 8px;
+  box-shadow: 0px 6px 4px rgba(10, 20, 30, 0.5);
+  transform: rotate(265deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box266 {
+  --cssA-v-266: 106454;
+  color: hsl(122, 58%, 42%);
+  background-color: hsl(302, 58%, 58%);
+  border: 2px solid hsl(212, 50%, 50%);
+  margin: 6px 18px 5px 8px;
+  padding: 11px 4px;
+  border-radius: 2px 1px;
+  box-shadow: 1px 0px 5px rgba(11, 22, 33, 0.6);
+  transform: rotate(266deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box267 {
+  --cssA-v-267: 114373;
+  color: hsl(159, 71%, 49%);
+  background-color: hsl(339, 71%, 51%);
+  border: 3px solid hsl(249, 50%, 50%);
+  margin: 7px 21px 10px 15px;
+  padding: 12px 6px;
+  border-radius: 3px 3px;
+  box-shadow: 2px 1px 6px rgba(12, 24, 36, 0.7);
+  transform: rotate(267deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box268 {
+  --cssA-v-268: 122292;
+  color: hsl(196, 84%, 56%);
+  background-color: hsl(16, 84%, 44%);
+  border: 4px solid hsl(286, 50%, 50%);
+  margin: 8px 24px 15px 4px;
+  padding: 13px 8px;
+  border-radius: 4px 5px;
+  box-shadow: 3px 2px 7px rgba(13, 26, 39, 0.8);
+  transform: rotate(268deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box269 {
+  --cssA-v-269: 130211;
+  color: hsl(233, 97%, 63%);
+  background-color: hsl(53, 97%, 37%);
+  border: 5px solid hsl(323, 50%, 50%);
+  margin: 9px 27px 20px 11px;
+  padding: 14px 10px;
+  border-radius: 5px 7px;
+  box-shadow: 4px 3px 8px rgba(14, 28, 42, 0.9);
+  transform: rotate(269deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box270 {
+  --cssA-v-270: 138130;
+  color: hsl(270, 10%, 70%);
+  background-color: hsl(90, 10%, 30%);
+  border: 1px solid hsl(0, 50%, 50%);
+  margin: 10px 0px 0px 0px;
+  padding: 0px 12px;
+  border-radius: 6px 0px;
+  box-shadow: 0px 4px 0px rgba(15, 30, 45, 0.1);
+  transform: rotate(270deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box271 {
+  --cssA-v-271: 146049;
+  color: hsl(307, 23%, 77%);
+  background-color: hsl(127, 23%, 23%);
+  border: 2px solid hsl(37, 50%, 50%);
+  margin: 11px 3px 5px 7px;
+  padding: 1px 14px;
+  border-radius: 7px 2px;
+  box-shadow: 1px 5px 1px rgba(16, 32, 48, 0.2);
+  transform: rotate(271deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box272 {
+  --cssA-v-272: 153968;
+  color: hsl(344, 36%, 34%);
+  background-color: hsl(164, 36%, 66%);
+  border: 3px solid hsl(74, 50%, 50%);
+  margin: 12px 6px 10px 14px;
+  padding: 2px 16px;
+  border-radius: 8px 4px;
+  box-shadow: 2px 6px 2px rgba(17, 34, 51, 0.3);
+  transform: rotate(272deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box273 {
+  --cssA-v-273: 161887;
+  color: hsl(21, 49%, 41%);
+  background-color: hsl(201, 49%, 59%);
+  border: 4px solid hsl(111, 50%, 50%);
+  margin: 13px 9px 15px 3px;
+  padding: 3px 18px;
+  border-radius: 9px 6px;
+  box-shadow: 3px 0px 3px rgba(18, 36, 54, 0.4);
+  transform: rotate(273deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box274 {
+  --cssA-v-274: 169806;
+  color: hsl(58, 62%, 48%);
+  background-color: hsl(238, 62%, 52%);
+  border: 5px solid hsl(148, 50%, 50%);
+  margin: 14px 12px 20px 10px;
+  padding: 4px 20px;
+  border-radius: 10px 8px;
+  box-shadow: 4px 1px 4px rgba(19, 38, 57, 0.5);
+  transform: rotate(274deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box275 {
+  --cssA-v-275: 177725;
+  color: hsl(95, 75%, 55%);
+  background-color: hsl(275, 75%, 45%);
+  border: 1px solid hsl(185, 50%, 50%);
+  margin: 15px 15px 0px 17px;
+  padding: 5px 0px;
+  border-radius: 11px 1px;
+  box-shadow: 0px 2px 5px rgba(20, 40, 60, 0.6);
+  transform: rotate(275deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box276 {
+  --cssA-v-276: 185644;
+  color: hsl(132, 88%, 62%);
+  background-color: hsl(312, 88%, 38%);
+  border: 2px solid hsl(222, 50%, 50%);
+  margin: 16px 18px 5px 6px;
+  padding: 6px 2px;
+  border-radius: 0px 3px;
+  box-shadow: 1px 3px 6px rgba(21, 42, 63, 0.7);
+  transform: rotate(276deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box277 {
+  --cssA-v-277: 193563;
+  color: hsl(169, 1%, 69%);
+  background-color: hsl(349, 1%, 31%);
+  border: 3px solid hsl(259, 50%, 50%);
+  margin: 17px 21px 10px 13px;
+  padding: 7px 4px;
+  border-radius: 1px 5px;
+  box-shadow: 2px 4px 7px rgba(22, 44, 66, 0.8);
+  transform: rotate(277deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box278 {
+  --cssA-v-278: 201482;
+  color: hsl(206, 14%, 76%);
+  background-color: hsl(26, 14%, 24%);
+  border: 4px solid hsl(296, 50%, 50%);
+  margin: 18px 24px 15px 2px;
+  padding: 8px 6px;
+  border-radius: 2px 7px;
+  box-shadow: 3px 5px 8px rgba(23, 46, 69, 0.9);
+  transform: rotate(278deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box279 {
+  --cssA-v-279: 209401;
+  color: hsl(243, 27%, 33%);
+  background-color: hsl(63, 27%, 67%);
+  border: 5px solid hsl(333, 50%, 50%);
+  margin: 19px 27px 20px 9px;
+  padding: 9px 8px;
+  border-radius: 3px 0px;
+  box-shadow: 4px 6px 0px rgba(24, 48, 72, 0.1);
+  transform: rotate(279deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box280 {
+  --cssA-v-280: 217320;
+  color: hsl(280, 40%, 40%);
+  background-color: hsl(100, 40%, 60%);
+  border: 1px solid hsl(10, 50%, 50%);
+  margin: 0px 0px 0px 16px;
+  padding: 10px 10px;
+  border-radius: 4px 2px;
+  box-shadow: 0px 0px 1px rgba(25, 50, 75, 0.2);
+  transform: rotate(280deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box281 {
+  --cssA-v-281: 225239;
+  color: hsl(317, 53%, 47%);
+  background-color: hsl(137, 53%, 53%);
+  border: 2px solid hsl(47, 50%, 50%);
+  margin: 1px 3px 5px 5px;
+  padding: 11px 12px;
+  border-radius: 5px 4px;
+  box-shadow: 1px 1px 2px rgba(26, 52, 78, 0.3);
+  transform: rotate(281deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box282 {
+  --cssA-v-282: 233158;
+  color: hsl(354, 66%, 54%);
+  background-color: hsl(174, 66%, 46%);
+  border: 3px solid hsl(84, 50%, 50%);
+  margin: 2px 6px 10px 12px;
+  padding: 12px 14px;
+  border-radius: 6px 6px;
+  box-shadow: 2px 2px 3px rgba(27, 54, 81, 0.4);
+  transform: rotate(282deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box283 {
+  --cssA-v-283: 241077;
+  color: hsl(31, 79%, 61%);
+  background-color: hsl(211, 79%, 39%);
+  border: 4px solid hsl(121, 50%, 50%);
+  margin: 3px 9px 15px 1px;
+  padding: 13px 16px;
+  border-radius: 7px 8px;
+  box-shadow: 3px 3px 4px rgba(28, 56, 84, 0.5);
+  transform: rotate(283deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box284 {
+  --cssA-v-284: 248996;
+  color: hsl(68, 92%, 68%);
+  background-color: hsl(248, 92%, 32%);
+  border: 5px solid hsl(158, 50%, 50%);
+  margin: 4px 12px 20px 8px;
+  padding: 14px 18px;
+  border-radius: 8px 1px;
+  box-shadow: 4px 4px 5px rgba(29, 58, 87, 0.6);
+  transform: rotate(284deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box285 {
+  --cssA-v-285: 256915;
+  color: hsl(105, 5%, 75%);
+  background-color: hsl(285, 5%, 25%);
+  border: 1px solid hsl(195, 50%, 50%);
+  margin: 5px 15px 0px 15px;
+  padding: 0px 20px;
+  border-radius: 9px 3px;
+  box-shadow: 0px 5px 6px rgba(30, 60, 90, 0.7);
+  transform: rotate(285deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box286 {
+  --cssA-v-286: 264834;
+  color: hsl(142, 18%, 32%);
+  background-color: hsl(322, 18%, 68%);
+  border: 2px solid hsl(232, 50%, 50%);
+  margin: 6px 18px 5px 4px;
+  padding: 1px 0px;
+  border-radius: 10px 5px;
+  box-shadow: 1px 6px 7px rgba(31, 62, 93, 0.8);
+  transform: rotate(286deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box287 {
+  --cssA-v-287: 272753;
+  color: hsl(179, 31%, 39%);
+  background-color: hsl(359, 31%, 61%);
+  border: 3px solid hsl(269, 50%, 50%);
+  margin: 7px 21px 10px 11px;
+  padding: 2px 2px;
+  border-radius: 11px 7px;
+  box-shadow: 2px 0px 8px rgba(32, 64, 96, 0.9);
+  transform: rotate(287deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box288 {
+  --cssA-v-288: 280672;
+  color: hsl(216, 44%, 46%);
+  background-color: hsl(36, 44%, 54%);
+  border: 4px solid hsl(306, 50%, 50%);
+  margin: 8px 24px 15px 0px;
+  padding: 3px 4px;
+  border-radius: 0px 0px;
+  box-shadow: 3px 1px 0px rgba(33, 66, 99, 0.1);
+  transform: rotate(288deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box289 {
+  --cssA-v-289: 288591;
+  color: hsl(253, 57%, 53%);
+  background-color: hsl(73, 57%, 47%);
+  border: 5px solid hsl(343, 50%, 50%);
+  margin: 9px 27px 20px 7px;
+  padding: 4px 6px;
+  border-radius: 1px 2px;
+  box-shadow: 4px 2px 1px rgba(34, 68, 102, 0.2);
+  transform: rotate(289deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box290 {
+  --cssA-v-290: 296510;
+  color: hsl(290, 70%, 60%);
+  background-color: hsl(110, 70%, 40%);
+  border: 1px solid hsl(20, 50%, 50%);
+  margin: 10px 0px 0px 14px;
+  padding: 5px 8px;
+  border-radius: 2px 4px;
+  box-shadow: 0px 3px 2px rgba(35, 70, 105, 0.3);
+  transform: rotate(290deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box291 {
+  --cssA-v-291: 304429;
+  color: hsl(327, 83%, 67%);
+  background-color: hsl(147, 83%, 33%);
+  border: 2px solid hsl(57, 50%, 50%);
+  margin: 11px 3px 5px 3px;
+  padding: 6px 10px;
+  border-radius: 3px 6px;
+  box-shadow: 1px 4px 3px rgba(36, 72, 108, 0.4);
+  transform: rotate(291deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box292 {
+  --cssA-v-292: 312348;
+  color: hsl(4, 96%, 74%);
+  background-color: hsl(184, 96%, 26%);
+  border: 3px solid hsl(94, 50%, 50%);
+  margin: 12px 6px 10px 10px;
+  padding: 7px 12px;
+  border-radius: 4px 8px;
+  box-shadow: 2px 5px 4px rgba(37, 74, 111, 0.5);
+  transform: rotate(292deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box293 {
+  --cssA-v-293: 320267;
+  color: hsl(41, 9%, 31%);
+  background-color: hsl(221, 9%, 69%);
+  border: 4px solid hsl(131, 50%, 50%);
+  margin: 13px 9px 15px 17px;
+  padding: 8px 14px;
+  border-radius: 5px 1px;
+  box-shadow: 3px 6px 5px rgba(38, 76, 114, 0.6);
+  transform: rotate(293deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box294 {
+  --cssA-v-294: 328186;
+  color: hsl(78, 22%, 38%);
+  background-color: hsl(258, 22%, 62%);
+  border: 5px solid hsl(168, 50%, 50%);
+  margin: 14px 12px 20px 6px;
+  padding: 9px 16px;
+  border-radius: 6px 3px;
+  box-shadow: 4px 0px 6px rgba(39, 78, 117, 0.7);
+  transform: rotate(294deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box295 {
+  --cssA-v-295: 336105;
+  color: hsl(115, 35%, 45%);
+  background-color: hsl(295, 35%, 55%);
+  border: 1px solid hsl(205, 50%, 50%);
+  margin: 15px 15px 0px 13px;
+  padding: 10px 18px;
+  border-radius: 7px 5px;
+  box-shadow: 0px 1px 7px rgba(40, 80, 120, 0.8);
+  transform: rotate(295deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box296 {
+  --cssA-v-296: 344024;
+  color: hsl(152, 48%, 52%);
+  background-color: hsl(332, 48%, 48%);
+  border: 2px solid hsl(242, 50%, 50%);
+  margin: 16px 18px 5px 2px;
+  padding: 11px 20px;
+  border-radius: 8px 7px;
+  box-shadow: 1px 2px 8px rgba(41, 82, 123, 0.9);
+  transform: rotate(296deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box297 {
+  --cssA-v-297: 351943;
+  color: hsl(189, 61%, 59%);
+  background-color: hsl(9, 61%, 41%);
+  border: 3px solid hsl(279, 50%, 50%);
+  margin: 17px 21px 10px 9px;
+  padding: 12px 0px;
+  border-radius: 9px 0px;
+  box-shadow: 2px 3px 0px rgba(42, 84, 126, 0.1);
+  transform: rotate(297deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box298 {
+  --cssA-v-298: 359862;
+  color: hsl(226, 74%, 66%);
+  background-color: hsl(46, 74%, 34%);
+  border: 4px solid hsl(316, 50%, 50%);
+  margin: 18px 24px 15px 16px;
+  padding: 13px 2px;
+  border-radius: 10px 2px;
+  box-shadow: 3px 4px 1px rgba(43, 86, 129, 0.2);
+  transform: rotate(298deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box299 {
+  --cssA-v-299: 367781;
+  color: hsl(263, 87%, 73%);
+  background-color: hsl(83, 87%, 27%);
+  border: 5px solid hsl(353, 50%, 50%);
+  margin: 19px 27px 20px 5px;
+  padding: 14px 4px;
+  border-radius: 11px 4px;
+  box-shadow: 4px 5px 2px rgba(44, 88, 132, 0.3);
+  transform: rotate(299deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box300 {
+  --cssA-v-300: 375700;
+  color: hsl(300, 0%, 30%);
+  background-color: hsl(120, 0%, 70%);
+  border: 1px solid hsl(30, 50%, 50%);
+  margin: 0px 0px 0px 12px;
+  padding: 0px 6px;
+  border-radius: 0px 6px;
+  box-shadow: 0px 6px 3px rgba(45, 90, 135, 0.4);
+  transform: rotate(300deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box301 {
+  --cssA-v-301: 383619;
+  color: hsl(337, 13%, 37%);
+  background-color: hsl(157, 13%, 63%);
+  border: 2px solid hsl(67, 50%, 50%);
+  margin: 1px 3px 5px 1px;
+  padding: 1px 8px;
+  border-radius: 1px 8px;
+  box-shadow: 1px 0px 4px rgba(46, 92, 138, 0.5);
+  transform: rotate(301deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box302 {
+  --cssA-v-302: 391538;
+  color: hsl(14, 26%, 44%);
+  background-color: hsl(194, 26%, 56%);
+  border: 3px solid hsl(104, 50%, 50%);
+  margin: 2px 6px 10px 8px;
+  padding: 2px 10px;
+  border-radius: 2px 1px;
+  box-shadow: 2px 1px 5px rgba(47, 94, 141, 0.6);
+  transform: rotate(302deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box303 {
+  --cssA-v-303: 399457;
+  color: hsl(51, 39%, 51%);
+  background-color: hsl(231, 39%, 49%);
+  border: 4px solid hsl(141, 50%, 50%);
+  margin: 3px 9px 15px 15px;
+  padding: 3px 12px;
+  border-radius: 3px 3px;
+  box-shadow: 3px 2px 6px rgba(48, 96, 144, 0.7);
+  transform: rotate(303deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box304 {
+  --cssA-v-304: 407376;
+  color: hsl(88, 52%, 58%);
+  background-color: hsl(268, 52%, 42%);
+  border: 5px solid hsl(178, 50%, 50%);
+  margin: 4px 12px 20px 4px;
+  padding: 4px 14px;
+  border-radius: 4px 5px;
+  box-shadow: 4px 3px 7px rgba(49, 98, 147, 0.8);
+  transform: rotate(304deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box305 {
+  --cssA-v-305: 415295;
+  color: hsl(125, 65%, 65%);
+  background-color: hsl(305, 65%, 35%);
+  border: 1px solid hsl(215, 50%, 50%);
+  margin: 5px 15px 0px 11px;
+  padding: 5px 16px;
+  border-radius: 5px 7px;
+  box-shadow: 0px 4px 8px rgba(50, 100, 150, 0.9);
+  transform: rotate(305deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box306 {
+  --cssA-v-306: 423214;
+  color: hsl(162, 78%, 72%);
+  background-color: hsl(342, 78%, 28%);
+  border: 2px solid hsl(252, 50%, 50%);
+  margin: 6px 18px 5px 0px;
+  padding: 6px 18px;
+  border-radius: 6px 0px;
+  box-shadow: 1px 5px 0px rgba(51, 102, 153, 0.1);
+  transform: rotate(306deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box307 {
+  --cssA-v-307: 431133;
+  color: hsl(199, 91%, 79%);
+  background-color: hsl(19, 91%, 21%);
+  border: 3px solid hsl(289, 50%, 50%);
+  margin: 7px 21px 10px 7px;
+  padding: 7px 20px;
+  border-radius: 7px 2px;
+  box-shadow: 2px 6px 1px rgba(52, 104, 156, 0.2);
+  transform: rotate(307deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box308 {
+  --cssA-v-308: 439052;
+  color: hsl(236, 4%, 36%);
+  background-color: hsl(56, 4%, 64%);
+  border: 4px solid hsl(326, 50%, 50%);
+  margin: 8px 24px 15px 14px;
+  padding: 8px 0px;
+  border-radius: 8px 4px;
+  box-shadow: 3px 0px 2px rgba(53, 106, 159, 0.3);
+  transform: rotate(308deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box309 {
+  --cssA-v-309: 446971;
+  color: hsl(273, 17%, 43%);
+  background-color: hsl(93, 17%, 57%);
+  border: 5px solid hsl(3, 50%, 50%);
+  margin: 9px 27px 20px 3px;
+  padding: 9px 2px;
+  border-radius: 9px 6px;
+  box-shadow: 4px 1px 3px rgba(54, 108, 162, 0.4);
+  transform: rotate(309deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box310 {
+  --cssA-v-310: 454890;
+  color: hsl(310, 30%, 50%);
+  background-color: hsl(130, 30%, 50%);
+  border: 1px solid hsl(40, 50%, 50%);
+  margin: 10px 0px 0px 10px;
+  padding: 10px 4px;
+  border-radius: 10px 8px;
+  box-shadow: 0px 2px 4px rgba(55, 110, 165, 0.5);
+  transform: rotate(310deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box311 {
+  --cssA-v-311: 462809;
+  color: hsl(347, 43%, 57%);
+  background-color: hsl(167, 43%, 43%);
+  border: 2px solid hsl(77, 50%, 50%);
+  margin: 11px 3px 5px 17px;
+  padding: 11px 6px;
+  border-radius: 11px 1px;
+  box-shadow: 1px 3px 5px rgba(56, 112, 168, 0.6);
+  transform: rotate(311deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box312 {
+  --cssA-v-312: 470728;
+  color: hsl(24, 56%, 64%);
+  background-color: hsl(204, 56%, 36%);
+  border: 3px solid hsl(114, 50%, 50%);
+  margin: 12px 6px 10px 6px;
+  padding: 12px 8px;
+  border-radius: 0px 3px;
+  box-shadow: 2px 4px 6px rgba(57, 114, 171, 0.7);
+  transform: rotate(312deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box313 {
+  --cssA-v-313: 478647;
+  color: hsl(61, 69%, 71%);
+  background-color: hsl(241, 69%, 29%);
+  border: 4px solid hsl(151, 50%, 50%);
+  margin: 13px 9px 15px 13px;
+  padding: 13px 10px;
+  border-radius: 1px 5px;
+  box-shadow: 3px 5px 7px rgba(58, 116, 174, 0.8);
+  transform: rotate(313deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box314 {
+  --cssA-v-314: 486566;
+  color: hsl(98, 82%, 78%);
+  background-color: hsl(278, 82%, 22%);
+  border: 5px solid hsl(188, 50%, 50%);
+  margin: 14px 12px 20px 2px;
+  padding: 14px 12px;
+  border-radius: 2px 7px;
+  box-shadow: 4px 6px 8px rgba(59, 118, 177, 0.9);
+  transform: rotate(314deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box315 {
+  --cssA-v-315: 494485;
+  color: hsl(135, 95%, 35%);
+  background-color: hsl(315, 95%, 65%);
+  border: 1px solid hsl(225, 50%, 50%);
+  margin: 15px 15px 0px 9px;
+  padding: 0px 14px;
+  border-radius: 3px 0px;
+  box-shadow: 0px 0px 0px rgba(60, 120, 180, 0.1);
+  transform: rotate(315deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box316 {
+  --cssA-v-316: 502404;
+  color: hsl(172, 8%, 42%);
+  background-color: hsl(352, 8%, 58%);
+  border: 2px solid hsl(262, 50%, 50%);
+  margin: 16px 18px 5px 16px;
+  padding: 1px 16px;
+  border-radius: 4px 2px;
+  box-shadow: 1px 1px 1px rgba(61, 122, 183, 0.2);
+  transform: rotate(316deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box317 {
+  --cssA-v-317: 510323;
+  color: hsl(209, 21%, 49%);
+  background-color: hsl(29, 21%, 51%);
+  border: 3px solid hsl(299, 50%, 50%);
+  margin: 17px 21px 10px 5px;
+  padding: 2px 18px;
+  border-radius: 5px 4px;
+  box-shadow: 2px 2px 2px rgba(62, 124, 186, 0.3);
+  transform: rotate(317deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box318 {
+  --cssA-v-318: 518242;
+  color: hsl(246, 34%, 56%);
+  background-color: hsl(66, 34%, 44%);
+  border: 4px solid hsl(336, 50%, 50%);
+  margin: 18px 24px 15px 12px;
+  padding: 3px 20px;
+  border-radius: 6px 6px;
+  box-shadow: 3px 3px 3px rgba(63, 126, 189, 0.4);
+  transform: rotate(318deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box319 {
+  --cssA-v-319: 526161;
+  color: hsl(283, 47%, 63%);
+  background-color: hsl(103, 47%, 37%);
+  border: 5px solid hsl(13, 50%, 50%);
+  margin: 19px 27px 20px 1px;
+  padding: 4px 0px;
+  border-radius: 7px 8px;
+  box-shadow: 4px 4px 4px rgba(64, 128, 192, 0.5);
+  transform: rotate(319deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box320 {
+  --cssA-v-320: 534080;
+  color: hsl(320, 60%, 70%);
+  background-color: hsl(140, 60%, 30%);
+  border: 1px solid hsl(50, 50%, 50%);
+  margin: 0px 0px 0px 8px;
+  padding: 5px 2px;
+  border-radius: 8px 1px;
+  box-shadow: 0px 5px 5px rgba(65, 130, 195, 0.6);
+  transform: rotate(320deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box321 {
+  --cssA-v-321: 541999;
+  color: hsl(357, 73%, 77%);
+  background-color: hsl(177, 73%, 23%);
+  border: 2px solid hsl(87, 50%, 50%);
+  margin: 1px 3px 5px 15px;
+  padding: 6px 4px;
+  border-radius: 9px 3px;
+  box-shadow: 1px 6px 6px rgba(66, 132, 198, 0.7);
+  transform: rotate(321deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box322 {
+  --cssA-v-322: 549918;
+  color: hsl(34, 86%, 34%);
+  background-color: hsl(214, 86%, 66%);
+  border: 3px solid hsl(124, 50%, 50%);
+  margin: 2px 6px 10px 4px;
+  padding: 7px 6px;
+  border-radius: 10px 5px;
+  box-shadow: 2px 0px 7px rgba(67, 134, 201, 0.8);
+  transform: rotate(322deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box323 {
+  --cssA-v-323: 557837;
+  color: hsl(71, 99%, 41%);
+  background-color: hsl(251, 99%, 59%);
+  border: 4px solid hsl(161, 50%, 50%);
+  margin: 3px 9px 15px 11px;
+  padding: 8px 8px;
+  border-radius: 11px 7px;
+  box-shadow: 3px 1px 8px rgba(68, 136, 204, 0.9);
+  transform: rotate(323deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box324 {
+  --cssA-v-324: 565756;
+  color: hsl(108, 12%, 48%);
+  background-color: hsl(288, 12%, 52%);
+  border: 5px solid hsl(198, 50%, 50%);
+  margin: 4px 12px 20px 0px;
+  padding: 9px 10px;
+  border-radius: 0px 0px;
+  box-shadow: 4px 2px 0px rgba(69, 138, 207, 0.1);
+  transform: rotate(324deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box325 {
+  --cssA-v-325: 573675;
+  color: hsl(145, 25%, 55%);
+  background-color: hsl(325, 25%, 45%);
+  border: 1px solid hsl(235, 50%, 50%);
+  margin: 5px 15px 0px 7px;
+  padding: 10px 12px;
+  border-radius: 1px 2px;
+  box-shadow: 0px 3px 1px rgba(70, 140, 210, 0.2);
+  transform: rotate(325deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box326 {
+  --cssA-v-326: 581594;
+  color: hsl(182, 38%, 62%);
+  background-color: hsl(2, 38%, 38%);
+  border: 2px solid hsl(272, 50%, 50%);
+  margin: 6px 18px 5px 14px;
+  padding: 11px 14px;
+  border-radius: 2px 4px;
+  box-shadow: 1px 4px 2px rgba(71, 142, 213, 0.3);
+  transform: rotate(326deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box327 {
+  --cssA-v-327: 589513;
+  color: hsl(219, 51%, 69%);
+  background-color: hsl(39, 51%, 31%);
+  border: 3px solid hsl(309, 50%, 50%);
+  margin: 7px 21px 10px 3px;
+  padding: 12px 16px;
+  border-radius: 3px 6px;
+  box-shadow: 2px 5px 3px rgba(72, 144, 216, 0.4);
+  transform: rotate(327deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box328 {
+  --cssA-v-328: 597432;
+  color: hsl(256, 64%, 76%);
+  background-color: hsl(76, 64%, 24%);
+  border: 4px solid hsl(346, 50%, 50%);
+  margin: 8px 24px 15px 10px;
+  padding: 13px 18px;
+  border-radius: 4px 8px;
+  box-shadow: 3px 6px 4px rgba(73, 146, 219, 0.5);
+  transform: rotate(328deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box329 {
+  --cssA-v-329: 605351;
+  color: hsl(293, 77%, 33%);
+  background-color: hsl(113, 77%, 67%);
+  border: 5px solid hsl(23, 50%, 50%);
+  margin: 9px 27px 20px 17px;
+  padding: 14px 20px;
+  border-radius: 5px 1px;
+  box-shadow: 4px 0px 5px rgba(74, 148, 222, 0.6);
+  transform: rotate(329deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box330 {
+  --cssA-v-330: 613270;
+  color: hsl(330, 90%, 40%);
+  background-color: hsl(150, 90%, 60%);
+  border: 1px solid hsl(60, 50%, 50%);
+  margin: 10px 0px 0px 6px;
+  padding: 0px 0px;
+  border-radius: 6px 3px;
+  box-shadow: 0px 1px 6px rgba(75, 150, 225, 0.7);
+  transform: rotate(330deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box331 {
+  --cssA-v-331: 621189;
+  color: hsl(7, 3%, 47%);
+  background-color: hsl(187, 3%, 53%);
+  border: 2px solid hsl(97, 50%, 50%);
+  margin: 11px 3px 5px 13px;
+  padding: 1px 2px;
+  border-radius: 7px 5px;
+  box-shadow: 1px 2px 7px rgba(76, 152, 228, 0.8);
+  transform: rotate(331deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box332 {
+  --cssA-v-332: 629108;
+  color: hsl(44, 16%, 54%);
+  background-color: hsl(224, 16%, 46%);
+  border: 3px solid hsl(134, 50%, 50%);
+  margin: 12px 6px 10px 2px;
+  padding: 2px 4px;
+  border-radius: 8px 7px;
+  box-shadow: 2px 3px 8px rgba(77, 154, 231, 0.9);
+  transform: rotate(332deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box333 {
+  --cssA-v-333: 637027;
+  color: hsl(81, 29%, 61%);
+  background-color: hsl(261, 29%, 39%);
+  border: 4px solid hsl(171, 50%, 50%);
+  margin: 13px 9px 15px 9px;
+  padding: 3px 6px;
+  border-radius: 9px 0px;
+  box-shadow: 3px 4px 0px rgba(78, 156, 234, 0.1);
+  transform: rotate(333deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box334 {
+  --cssA-v-334: 644946;
+  color: hsl(118, 42%, 68%);
+  background-color: hsl(298, 42%, 32%);
+  border: 5px solid hsl(208, 50%, 50%);
+  margin: 14px 12px 20px 16px;
+  padding: 4px 8px;
+  border-radius: 10px 2px;
+  box-shadow: 4px 5px 1px rgba(79, 158, 237, 0.2);
+  transform: rotate(334deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box335 {
+  --cssA-v-335: 652865;
+  color: hsl(155, 55%, 75%);
+  background-color: hsl(335, 55%, 25%);
+  border: 1px solid hsl(245, 50%, 50%);
+  margin: 15px 15px 0px 5px;
+  padding: 5px 10px;
+  border-radius: 11px 4px;
+  box-shadow: 0px 6px 2px rgba(80, 160, 240, 0.3);
+  transform: rotate(335deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box336 {
+  --cssA-v-336: 660784;
+  color: hsl(192, 68%, 32%);
+  background-color: hsl(12, 68%, 68%);
+  border: 2px solid hsl(282, 50%, 50%);
+  margin: 16px 18px 5px 12px;
+  padding: 6px 12px;
+  border-radius: 0px 6px;
+  box-shadow: 1px 0px 3px rgba(81, 162, 243, 0.4);
+  transform: rotate(336deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box337 {
+  --cssA-v-337: 668703;
+  color: hsl(229, 81%, 39%);
+  background-color: hsl(49, 81%, 61%);
+  border: 3px solid hsl(319, 50%, 50%);
+  margin: 17px 21px 10px 1px;
+  padding: 7px 14px;
+  border-radius: 1px 8px;
+  box-shadow: 2px 1px 4px rgba(82, 164, 246, 0.5);
+  transform: rotate(337deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box338 {
+  --cssA-v-338: 676622;
+  color: hsl(266, 94%, 46%);
+  background-color: hsl(86, 94%, 54%);
+  border: 4px solid hsl(356, 50%, 50%);
+  margin: 18px 24px 15px 8px;
+  padding: 8px 16px;
+  border-radius: 2px 1px;
+  box-shadow: 3px 2px 5px rgba(83, 166, 249, 0.6);
+  transform: rotate(338deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box339 {
+  --cssA-v-339: 684541;
+  color: hsl(303, 7%, 53%);
+  background-color: hsl(123, 7%, 47%);
+  border: 5px solid hsl(33, 50%, 50%);
+  margin: 19px 27px 20px 15px;
+  padding: 9px 18px;
+  border-radius: 3px 3px;
+  box-shadow: 4px 3px 6px rgba(84, 168, 252, 0.7);
+  transform: rotate(339deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box340 {
+  --cssA-v-340: 692460;
+  color: hsl(340, 20%, 60%);
+  background-color: hsl(160, 20%, 40%);
+  border: 1px solid hsl(70, 50%, 50%);
+  margin: 0px 0px 0px 4px;
+  padding: 10px 20px;
+  border-radius: 4px 5px;
+  box-shadow: 0px 4px 7px rgba(85, 170, 0, 0.8);
+  transform: rotate(340deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box341 {
+  --cssA-v-341: 700379;
+  color: hsl(17, 33%, 67%);
+  background-color: hsl(197, 33%, 33%);
+  border: 2px solid hsl(107, 50%, 50%);
+  margin: 1px 3px 5px 11px;
+  padding: 11px 0px;
+  border-radius: 5px 7px;
+  box-shadow: 1px 5px 8px rgba(86, 172, 3, 0.9);
+  transform: rotate(341deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box342 {
+  --cssA-v-342: 708298;
+  color: hsl(54, 46%, 74%);
+  background-color: hsl(234, 46%, 26%);
+  border: 3px solid hsl(144, 50%, 50%);
+  margin: 2px 6px 10px 0px;
+  padding: 12px 2px;
+  border-radius: 6px 0px;
+  box-shadow: 2px 6px 0px rgba(87, 174, 6, 0.1);
+  transform: rotate(342deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box343 {
+  --cssA-v-343: 716217;
+  color: hsl(91, 59%, 31%);
+  background-color: hsl(271, 59%, 69%);
+  border: 4px solid hsl(181, 50%, 50%);
+  margin: 3px 9px 15px 7px;
+  padding: 13px 4px;
+  border-radius: 7px 2px;
+  box-shadow: 3px 0px 1px rgba(88, 176, 9, 0.2);
+  transform: rotate(343deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box344 {
+  --cssA-v-344: 724136;
+  color: hsl(128, 72%, 38%);
+  background-color: hsl(308, 72%, 62%);
+  border: 5px solid hsl(218, 50%, 50%);
+  margin: 4px 12px 20px 14px;
+  padding: 14px 6px;
+  border-radius: 8px 4px;
+  box-shadow: 4px 1px 2px rgba(89, 178, 12, 0.3);
+  transform: rotate(344deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box345 {
+  --cssA-v-345: 732055;
+  color: hsl(165, 85%, 45%);
+  background-color: hsl(345, 85%, 55%);
+  border: 1px solid hsl(255, 50%, 50%);
+  margin: 5px 15px 0px 3px;
+  padding: 0px 8px;
+  border-radius: 9px 6px;
+  box-shadow: 0px 2px 3px rgba(90, 180, 15, 0.4);
+  transform: rotate(345deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box346 {
+  --cssA-v-346: 739974;
+  color: hsl(202, 98%, 52%);
+  background-color: hsl(22, 98%, 48%);
+  border: 2px solid hsl(292, 50%, 50%);
+  margin: 6px 18px 5px 10px;
+  padding: 1px 10px;
+  border-radius: 10px 8px;
+  box-shadow: 1px 3px 4px rgba(91, 182, 18, 0.5);
+  transform: rotate(346deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box347 {
+  --cssA-v-347: 747893;
+  color: hsl(239, 11%, 59%);
+  background-color: hsl(59, 11%, 41%);
+  border: 3px solid hsl(329, 50%, 50%);
+  margin: 7px 21px 10px 17px;
+  padding: 2px 12px;
+  border-radius: 11px 1px;
+  box-shadow: 2px 4px 5px rgba(92, 184, 21, 0.6);
+  transform: rotate(347deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box348 {
+  --cssA-v-348: 755812;
+  color: hsl(276, 24%, 66%);
+  background-color: hsl(96, 24%, 34%);
+  border: 4px solid hsl(6, 50%, 50%);
+  margin: 8px 24px 15px 6px;
+  padding: 3px 14px;
+  border-radius: 0px 3px;
+  box-shadow: 3px 5px 6px rgba(93, 186, 24, 0.7);
+  transform: rotate(348deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box349 {
+  --cssA-v-349: 763731;
+  color: hsl(313, 37%, 73%);
+  background-color: hsl(133, 37%, 27%);
+  border: 5px solid hsl(43, 50%, 50%);
+  margin: 9px 27px 20px 13px;
+  padding: 4px 16px;
+  border-radius: 1px 5px;
+  box-shadow: 4px 6px 7px rgba(94, 188, 27, 0.8);
+  transform: rotate(349deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box350 {
+  --cssA-v-350: 771650;
+  color: hsl(350, 50%, 30%);
+  background-color: hsl(170, 50%, 70%);
+  border: 1px solid hsl(80, 50%, 50%);
+  margin: 10px 0px 0px 2px;
+  padding: 5px 18px;
+  border-radius: 2px 7px;
+  box-shadow: 0px 0px 8px rgba(95, 190, 30, 0.9);
+  transform: rotate(350deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box351 {
+  --cssA-v-351: 779569;
+  color: hsl(27, 63%, 37%);
+  background-color: hsl(207, 63%, 63%);
+  border: 2px solid hsl(117, 50%, 50%);
+  margin: 11px 3px 5px 9px;
+  padding: 6px 20px;
+  border-radius: 3px 0px;
+  box-shadow: 1px 1px 0px rgba(96, 192, 33, 0.1);
+  transform: rotate(351deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box352 {
+  --cssA-v-352: 787488;
+  color: hsl(64, 76%, 44%);
+  background-color: hsl(244, 76%, 56%);
+  border: 3px solid hsl(154, 50%, 50%);
+  margin: 12px 6px 10px 16px;
+  padding: 7px 0px;
+  border-radius: 4px 2px;
+  box-shadow: 2px 2px 1px rgba(97, 194, 36, 0.2);
+  transform: rotate(352deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box353 {
+  --cssA-v-353: 795407;
+  color: hsl(101, 89%, 51%);
+  background-color: hsl(281, 89%, 49%);
+  border: 4px solid hsl(191, 50%, 50%);
+  margin: 13px 9px 15px 5px;
+  padding: 8px 2px;
+  border-radius: 5px 4px;
+  box-shadow: 3px 3px 2px rgba(98, 196, 39, 0.3);
+  transform: rotate(353deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box354 {
+  --cssA-v-354: 803326;
+  color: hsl(138, 2%, 58%);
+  background-color: hsl(318, 2%, 42%);
+  border: 5px solid hsl(228, 50%, 50%);
+  margin: 14px 12px 20px 12px;
+  padding: 9px 4px;
+  border-radius: 6px 6px;
+  box-shadow: 4px 4px 3px rgba(99, 198, 42, 0.4);
+  transform: rotate(354deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box355 {
+  --cssA-v-355: 811245;
+  color: hsl(175, 15%, 65%);
+  background-color: hsl(355, 15%, 35%);
+  border: 1px solid hsl(265, 50%, 50%);
+  margin: 15px 15px 0px 1px;
+  padding: 10px 6px;
+  border-radius: 7px 8px;
+  box-shadow: 0px 5px 4px rgba(100, 200, 45, 0.5);
+  transform: rotate(355deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box356 {
+  --cssA-v-356: 819164;
+  color: hsl(212, 28%, 72%);
+  background-color: hsl(32, 28%, 28%);
+  border: 2px solid hsl(302, 50%, 50%);
+  margin: 16px 18px 5px 8px;
+  padding: 11px 8px;
+  border-radius: 8px 1px;
+  box-shadow: 1px 6px 5px rgba(101, 202, 48, 0.6);
+  transform: rotate(356deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box357 {
+  --cssA-v-357: 827083;
+  color: hsl(249, 41%, 79%);
+  background-color: hsl(69, 41%, 21%);
+  border: 3px solid hsl(339, 50%, 50%);
+  margin: 17px 21px 10px 15px;
+  padding: 12px 10px;
+  border-radius: 9px 3px;
+  box-shadow: 2px 0px 6px rgba(102, 204, 51, 0.7);
+  transform: rotate(357deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box358 {
+  --cssA-v-358: 835002;
+  color: hsl(286, 54%, 36%);
+  background-color: hsl(106, 54%, 64%);
+  border: 4px solid hsl(16, 50%, 50%);
+  margin: 18px 24px 15px 4px;
+  padding: 13px 12px;
+  border-radius: 10px 5px;
+  box-shadow: 3px 1px 7px rgba(103, 206, 54, 0.8);
+  transform: rotate(358deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box359 {
+  --cssA-v-359: 842921;
+  color: hsl(323, 67%, 43%);
+  background-color: hsl(143, 67%, 57%);
+  border: 5px solid hsl(53, 50%, 50%);
+  margin: 19px 27px 20px 11px;
+  padding: 14px 14px;
+  border-radius: 11px 7px;
+  box-shadow: 4px 2px 8px rgba(104, 208, 57, 0.9);
+  transform: rotate(359deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box360 {
+  --cssA-v-360: 850840;
+  color: hsl(0, 80%, 50%);
+  background-color: hsl(180, 80%, 50%);
+  border: 1px solid hsl(90, 50%, 50%);
+  margin: 0px 0px 0px 0px;
+  padding: 0px 16px;
+  border-radius: 0px 0px;
+  box-shadow: 0px 3px 0px rgba(105, 210, 60, 0.1);
+  transform: rotate(0deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box361 {
+  --cssA-v-361: 858759;
+  color: hsl(37, 93%, 57%);
+  background-color: hsl(217, 93%, 43%);
+  border: 2px solid hsl(127, 50%, 50%);
+  margin: 1px 3px 5px 7px;
+  padding: 1px 18px;
+  border-radius: 1px 2px;
+  box-shadow: 1px 4px 1px rgba(106, 212, 63, 0.2);
+  transform: rotate(1deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box362 {
+  --cssA-v-362: 866678;
+  color: hsl(74, 6%, 64%);
+  background-color: hsl(254, 6%, 36%);
+  border: 3px solid hsl(164, 50%, 50%);
+  margin: 2px 6px 10px 14px;
+  padding: 2px 20px;
+  border-radius: 2px 4px;
+  box-shadow: 2px 5px 2px rgba(107, 214, 66, 0.3);
+  transform: rotate(2deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box363 {
+  --cssA-v-363: 874597;
+  color: hsl(111, 19%, 71%);
+  background-color: hsl(291, 19%, 29%);
+  border: 4px solid hsl(201, 50%, 50%);
+  margin: 3px 9px 15px 3px;
+  padding: 3px 0px;
+  border-radius: 3px 6px;
+  box-shadow: 3px 6px 3px rgba(108, 216, 69, 0.4);
+  transform: rotate(3deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box364 {
+  --cssA-v-364: 882516;
+  color: hsl(148, 32%, 78%);
+  background-color: hsl(328, 32%, 22%);
+  border: 5px solid hsl(238, 50%, 50%);
+  margin: 4px 12px 20px 10px;
+  padding: 4px 2px;
+  border-radius: 4px 8px;
+  box-shadow: 4px 0px 4px rgba(109, 218, 72, 0.5);
+  transform: rotate(4deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box365 {
+  --cssA-v-365: 890435;
+  color: hsl(185, 45%, 35%);
+  background-color: hsl(5, 45%, 65%);
+  border: 1px solid hsl(275, 50%, 50%);
+  margin: 5px 15px 0px 17px;
+  padding: 5px 4px;
+  border-radius: 5px 1px;
+  box-shadow: 0px 1px 5px rgba(110, 220, 75, 0.6);
+  transform: rotate(5deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box366 {
+  --cssA-v-366: 898354;
+  color: hsl(222, 58%, 42%);
+  background-color: hsl(42, 58%, 58%);
+  border: 2px solid hsl(312, 50%, 50%);
+  margin: 6px 18px 5px 6px;
+  padding: 6px 6px;
+  border-radius: 6px 3px;
+  box-shadow: 1px 2px 6px rgba(111, 222, 78, 0.7);
+  transform: rotate(6deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box367 {
+  --cssA-v-367: 906273;
+  color: hsl(259, 71%, 49%);
+  background-color: hsl(79, 71%, 51%);
+  border: 3px solid hsl(349, 50%, 50%);
+  margin: 7px 21px 10px 13px;
+  padding: 7px 8px;
+  border-radius: 7px 5px;
+  box-shadow: 2px 3px 7px rgba(112, 224, 81, 0.8);
+  transform: rotate(7deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box368 {
+  --cssA-v-368: 914192;
+  color: hsl(296, 84%, 56%);
+  background-color: hsl(116, 84%, 44%);
+  border: 4px solid hsl(26, 50%, 50%);
+  margin: 8px 24px 15px 2px;
+  padding: 8px 10px;
+  border-radius: 8px 7px;
+  box-shadow: 3px 4px 8px rgba(113, 226, 84, 0.9);
+  transform: rotate(8deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box369 {
+  --cssA-v-369: 922111;
+  color: hsl(333, 97%, 63%);
+  background-color: hsl(153, 97%, 37%);
+  border: 5px solid hsl(63, 50%, 50%);
+  margin: 9px 27px 20px 9px;
+  padding: 9px 12px;
+  border-radius: 9px 0px;
+  box-shadow: 4px 5px 0px rgba(114, 228, 87, 0.1);
+  transform: rotate(9deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box370 {
+  --cssA-v-370: 930030;
+  color: hsl(10, 10%, 70%);
+  background-color: hsl(190, 10%, 30%);
+  border: 1px solid hsl(100, 50%, 50%);
+  margin: 10px 0px 0px 16px;
+  padding: 10px 14px;
+  border-radius: 10px 2px;
+  box-shadow: 0px 6px 1px rgba(115, 230, 90, 0.2);
+  transform: rotate(10deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box371 {
+  --cssA-v-371: 937949;
+  color: hsl(47, 23%, 77%);
+  background-color: hsl(227, 23%, 23%);
+  border: 2px solid hsl(137, 50%, 50%);
+  margin: 11px 3px 5px 5px;
+  padding: 11px 16px;
+  border-radius: 11px 4px;
+  box-shadow: 1px 0px 2px rgba(116, 232, 93, 0.3);
+  transform: rotate(11deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box372 {
+  --cssA-v-372: 945868;
+  color: hsl(84, 36%, 34%);
+  background-color: hsl(264, 36%, 66%);
+  border: 3px solid hsl(174, 50%, 50%);
+  margin: 12px 6px 10px 12px;
+  padding: 12px 18px;
+  border-radius: 0px 6px;
+  box-shadow: 2px 1px 3px rgba(117, 234, 96, 0.4);
+  transform: rotate(12deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box373 {
+  --cssA-v-373: 953787;
+  color: hsl(121, 49%, 41%);
+  background-color: hsl(301, 49%, 59%);
+  border: 4px solid hsl(211, 50%, 50%);
+  margin: 13px 9px 15px 1px;
+  padding: 13px 20px;
+  border-radius: 1px 8px;
+  box-shadow: 3px 2px 4px rgba(118, 236, 99, 0.5);
+  transform: rotate(13deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box374 {
+  --cssA-v-374: 961706;
+  color: hsl(158, 62%, 48%);
+  background-color: hsl(338, 62%, 52%);
+  border: 5px solid hsl(248, 50%, 50%);
+  margin: 14px 12px 20px 8px;
+  padding: 14px 0px;
+  border-radius: 2px 1px;
+  box-shadow: 4px 3px 5px rgba(119, 238, 102, 0.6);
+  transform: rotate(14deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box375 {
+  --cssA-v-375: 969625;
+  color: hsl(195, 75%, 55%);
+  background-color: hsl(15, 75%, 45%);
+  border: 1px solid hsl(285, 50%, 50%);
+  margin: 15px 15px 0px 15px;
+  padding: 0px 2px;
+  border-radius: 3px 3px;
+  box-shadow: 0px 4px 6px rgba(120, 240, 105, 0.7);
+  transform: rotate(15deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box376 {
+  --cssA-v-376: 977544;
+  color: hsl(232, 88%, 62%);
+  background-color: hsl(52, 88%, 38%);
+  border: 2px solid hsl(322, 50%, 50%);
+  margin: 16px 18px 5px 4px;
+  padding: 1px 4px;
+  border-radius: 4px 5px;
+  box-shadow: 1px 5px 7px rgba(121, 242, 108, 0.8);
+  transform: rotate(16deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box377 {
+  --cssA-v-377: 985463;
+  color: hsl(269, 1%, 69%);
+  background-color: hsl(89, 1%, 31%);
+  border: 3px solid hsl(359, 50%, 50%);
+  margin: 17px 21px 10px 11px;
+  padding: 2px 6px;
+  border-radius: 5px 7px;
+  box-shadow: 2px 6px 8px rgba(122, 244, 111, 0.9);
+  transform: rotate(17deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box378 {
+  --cssA-v-378: 993382;
+  color: hsl(306, 14%, 76%);
+  background-color: hsl(126, 14%, 24%);
+  border: 4px solid hsl(36, 50%, 50%);
+  margin: 18px 24px 15px 0px;
+  padding: 3px 8px;
+  border-radius: 6px 0px;
+  box-shadow: 3px 0px 0px rgba(123, 246, 114, 0.1);
+  transform: rotate(18deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box379 {
+  --cssA-v-379: 1301;
+  color: hsl(343, 27%, 33%);
+  background-color: hsl(163, 27%, 67%);
+  border: 5px solid hsl(73, 50%, 50%);
+  margin: 19px 27px 20px 7px;
+  padding: 4px 10px;
+  border-radius: 7px 2px;
+  box-shadow: 4px 1px 1px rgba(124, 248, 117, 0.2);
+  transform: rotate(19deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box380 {
+  --cssA-v-380: 9220;
+  color: hsl(20, 40%, 40%);
+  background-color: hsl(200, 40%, 60%);
+  border: 1px solid hsl(110, 50%, 50%);
+  margin: 0px 0px 0px 14px;
+  padding: 5px 12px;
+  border-radius: 8px 4px;
+  box-shadow: 0px 2px 2px rgba(125, 250, 120, 0.3);
+  transform: rotate(20deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box381 {
+  --cssA-v-381: 17139;
+  color: hsl(57, 53%, 47%);
+  background-color: hsl(237, 53%, 53%);
+  border: 2px solid hsl(147, 50%, 50%);
+  margin: 1px 3px 5px 3px;
+  padding: 6px 14px;
+  border-radius: 9px 6px;
+  box-shadow: 1px 3px 3px rgba(126, 252, 123, 0.4);
+  transform: rotate(21deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box382 {
+  --cssA-v-382: 25058;
+  color: hsl(94, 66%, 54%);
+  background-color: hsl(274, 66%, 46%);
+  border: 3px solid hsl(184, 50%, 50%);
+  margin: 2px 6px 10px 10px;
+  padding: 7px 16px;
+  border-radius: 10px 8px;
+  box-shadow: 2px 4px 4px rgba(127, 254, 126, 0.5);
+  transform: rotate(22deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box383 {
+  --cssA-v-383: 32977;
+  color: hsl(131, 79%, 61%);
+  background-color: hsl(311, 79%, 39%);
+  border: 4px solid hsl(221, 50%, 50%);
+  margin: 3px 9px 15px 17px;
+  padding: 8px 18px;
+  border-radius: 11px 1px;
+  box-shadow: 3px 5px 5px rgba(128, 1, 129, 0.6);
+  transform: rotate(23deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box384 {
+  --cssA-v-384: 40896;
+  color: hsl(168, 92%, 68%);
+  background-color: hsl(348, 92%, 32%);
+  border: 5px solid hsl(258, 50%, 50%);
+  margin: 4px 12px 20px 6px;
+  padding: 9px 20px;
+  border-radius: 0px 3px;
+  box-shadow: 4px 6px 6px rgba(129, 3, 132, 0.7);
+  transform: rotate(24deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box385 {
+  --cssA-v-385: 48815;
+  color: hsl(205, 5%, 75%);
+  background-color: hsl(25, 5%, 25%);
+  border: 1px solid hsl(295, 50%, 50%);
+  margin: 5px 15px 0px 13px;
+  padding: 10px 0px;
+  border-radius: 1px 5px;
+  box-shadow: 0px 0px 7px rgba(130, 5, 135, 0.8);
+  transform: rotate(25deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box386 {
+  --cssA-v-386: 56734;
+  color: hsl(242, 18%, 32%);
+  background-color: hsl(62, 18%, 68%);
+  border: 2px solid hsl(332, 50%, 50%);
+  margin: 6px 18px 5px 2px;
+  padding: 11px 2px;
+  border-radius: 2px 7px;
+  box-shadow: 1px 1px 8px rgba(131, 7, 138, 0.9);
+  transform: rotate(26deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box387 {
+  --cssA-v-387: 64653;
+  color: hsl(279, 31%, 39%);
+  background-color: hsl(99, 31%, 61%);
+  border: 3px solid hsl(9, 50%, 50%);
+  margin: 7px 21px 10px 9px;
+  padding: 12px 4px;
+  border-radius: 3px 0px;
+  box-shadow: 2px 2px 0px rgba(132, 9, 141, 0.1);
+  transform: rotate(27deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box388 {
+  --cssA-v-388: 72572;
+  color: hsl(316, 44%, 46%);
+  background-color: hsl(136, 44%, 54%);
+  border: 4px solid hsl(46, 50%, 50%);
+  margin: 8px 24px 15px 16px;
+  padding: 13px 6px;
+  border-radius: 4px 2px;
+  box-shadow: 3px 3px 1px rgba(133, 11, 144, 0.2);
+  transform: rotate(28deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box389 {
+  --cssA-v-389: 80491;
+  color: hsl(353, 57%, 53%);
+  background-color: hsl(173, 57%, 47%);
+  border: 5px solid hsl(83, 50%, 50%);
+  margin: 9px 27px 20px 5px;
+  padding: 14px 8px;
+  border-radius: 5px 4px;
+  box-shadow: 4px 4px 2px rgba(134, 13, 147, 0.3);
+  transform: rotate(29deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box390 {
+  --cssA-v-390: 88410;
+  color: hsl(30, 70%, 60%);
+  background-color: hsl(210, 70%, 40%);
+  border: 1px solid hsl(120, 50%, 50%);
+  margin: 10px 0px 0px 12px;
+  padding: 0px 10px;
+  border-radius: 6px 6px;
+  box-shadow: 0px 5px 3px rgba(135, 15, 150, 0.4);
+  transform: rotate(30deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box391 {
+  --cssA-v-391: 96329;
+  color: hsl(67, 83%, 67%);
+  background-color: hsl(247, 83%, 33%);
+  border: 2px solid hsl(157, 50%, 50%);
+  margin: 11px 3px 5px 1px;
+  padding: 1px 12px;
+  border-radius: 7px 8px;
+  box-shadow: 1px 6px 4px rgba(136, 17, 153, 0.5);
+  transform: rotate(31deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box392 {
+  --cssA-v-392: 104248;
+  color: hsl(104, 96%, 74%);
+  background-color: hsl(284, 96%, 26%);
+  border: 3px solid hsl(194, 50%, 50%);
+  margin: 12px 6px 10px 8px;
+  padding: 2px 14px;
+  border-radius: 8px 1px;
+  box-shadow: 2px 0px 5px rgba(137, 19, 156, 0.6);
+  transform: rotate(32deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box393 {
+  --cssA-v-393: 112167;
+  color: hsl(141, 9%, 31%);
+  background-color: hsl(321, 9%, 69%);
+  border: 4px solid hsl(231, 50%, 50%);
+  margin: 13px 9px 15px 15px;
+  padding: 3px 16px;
+  border-radius: 9px 3px;
+  box-shadow: 3px 1px 6px rgba(138, 21, 159, 0.7);
+  transform: rotate(33deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box394 {
+  --cssA-v-394: 120086;
+  color: hsl(178, 22%, 38%);
+  background-color: hsl(358, 22%, 62%);
+  border: 5px solid hsl(268, 50%, 50%);
+  margin: 14px 12px 20px 4px;
+  padding: 4px 18px;
+  border-radius: 10px 5px;
+  box-shadow: 4px 2px 7px rgba(139, 23, 162, 0.8);
+  transform: rotate(34deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box395 {
+  --cssA-v-395: 128005;
+  color: hsl(215, 35%, 45%);
+  background-color: hsl(35, 35%, 55%);
+  border: 1px solid hsl(305, 50%, 50%);
+  margin: 15px 15px 0px 11px;
+  padding: 5px 20px;
+  border-radius: 11px 7px;
+  box-shadow: 0px 3px 8px rgba(140, 25, 165, 0.9);
+  transform: rotate(35deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box396 {
+  --cssA-v-396: 135924;
+  color: hsl(252, 48%, 52%);
+  background-color: hsl(72, 48%, 48%);
+  border: 2px solid hsl(342, 50%, 50%);
+  margin: 16px 18px 5px 0px;
+  padding: 6px 0px;
+  border-radius: 0px 0px;
+  box-shadow: 1px 4px 0px rgba(141, 27, 168, 0.1);
+  transform: rotate(36deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box397 {
+  --cssA-v-397: 143843;
+  color: hsl(289, 61%, 59%);
+  background-color: hsl(109, 61%, 41%);
+  border: 3px solid hsl(19, 50%, 50%);
+  margin: 17px 21px 10px 7px;
+  padding: 7px 2px;
+  border-radius: 1px 2px;
+  box-shadow: 2px 5px 1px rgba(142, 29, 171, 0.2);
+  transform: rotate(37deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box398 {
+  --cssA-v-398: 151762;
+  color: hsl(326, 74%, 66%);
+  background-color: hsl(146, 74%, 34%);
+  border: 4px solid hsl(56, 50%, 50%);
+  margin: 18px 24px 15px 14px;
+  padding: 8px 4px;
+  border-radius: 2px 4px;
+  box-shadow: 3px 6px 2px rgba(143, 31, 174, 0.3);
+  transform: rotate(38deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box399 {
+  --cssA-v-399: 159681;
+  color: hsl(3, 87%, 73%);
+  background-color: hsl(183, 87%, 27%);
+  border: 5px solid hsl(93, 50%, 50%);
+  margin: 19px 27px 20px 3px;
+  padding: 9px 6px;
+  border-radius: 3px 6px;
+  box-shadow: 4px 0px 3px rgba(144, 33, 177, 0.4);
+  transform: rotate(39deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box400 {
+  --cssA-v-400: 167600;
+  color: hsl(40, 0%, 30%);
+  background-color: hsl(220, 0%, 70%);
+  border: 1px solid hsl(130, 50%, 50%);
+  margin: 0px 0px 0px 10px;
+  padding: 10px 8px;
+  border-radius: 4px 8px;
+  box-shadow: 0px 1px 4px rgba(145, 35, 180, 0.5);
+  transform: rotate(40deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box401 {
+  --cssA-v-401: 175519;
+  color: hsl(77, 13%, 37%);
+  background-color: hsl(257, 13%, 63%);
+  border: 2px solid hsl(167, 50%, 50%);
+  margin: 1px 3px 5px 17px;
+  padding: 11px 10px;
+  border-radius: 5px 1px;
+  box-shadow: 1px 2px 5px rgba(146, 37, 183, 0.6);
+  transform: rotate(41deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box402 {
+  --cssA-v-402: 183438;
+  color: hsl(114, 26%, 44%);
+  background-color: hsl(294, 26%, 56%);
+  border: 3px solid hsl(204, 50%, 50%);
+  margin: 2px 6px 10px 6px;
+  padding: 12px 12px;
+  border-radius: 6px 3px;
+  box-shadow: 2px 3px 6px rgba(147, 39, 186, 0.7);
+  transform: rotate(42deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box403 {
+  --cssA-v-403: 191357;
+  color: hsl(151, 39%, 51%);
+  background-color: hsl(331, 39%, 49%);
+  border: 4px solid hsl(241, 50%, 50%);
+  margin: 3px 9px 15px 13px;
+  padding: 13px 14px;
+  border-radius: 7px 5px;
+  box-shadow: 3px 4px 7px rgba(148, 41, 189, 0.8);
+  transform: rotate(43deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box404 {
+  --cssA-v-404: 199276;
+  color: hsl(188, 52%, 58%);
+  background-color: hsl(8, 52%, 42%);
+  border: 5px solid hsl(278, 50%, 50%);
+  margin: 4px 12px 20px 2px;
+  padding: 14px 16px;
+  border-radius: 8px 7px;
+  box-shadow: 4px 5px 8px rgba(149, 43, 192, 0.9);
+  transform: rotate(44deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box405 {
+  --cssA-v-405: 207195;
+  color: hsl(225, 65%, 65%);
+  background-color: hsl(45, 65%, 35%);
+  border: 1px solid hsl(315, 50%, 50%);
+  margin: 5px 15px 0px 9px;
+  padding: 0px 18px;
+  border-radius: 9px 0px;
+  box-shadow: 0px 6px 0px rgba(150, 45, 195, 0.1);
+  transform: rotate(45deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box406 {
+  --cssA-v-406: 215114;
+  color: hsl(262, 78%, 72%);
+  background-color: hsl(82, 78%, 28%);
+  border: 2px solid hsl(352, 50%, 50%);
+  margin: 6px 18px 5px 16px;
+  padding: 1px 20px;
+  border-radius: 10px 2px;
+  box-shadow: 1px 0px 1px rgba(151, 47, 198, 0.2);
+  transform: rotate(46deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box407 {
+  --cssA-v-407: 223033;
+  color: hsl(299, 91%, 79%);
+  background-color: hsl(119, 91%, 21%);
+  border: 3px solid hsl(29, 50%, 50%);
+  margin: 7px 21px 10px 5px;
+  padding: 2px 0px;
+  border-radius: 11px 4px;
+  box-shadow: 2px 1px 2px rgba(152, 49, 201, 0.3);
+  transform: rotate(47deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box408 {
+  --cssA-v-408: 230952;
+  color: hsl(336, 4%, 36%);
+  background-color: hsl(156, 4%, 64%);
+  border: 4px solid hsl(66, 50%, 50%);
+  margin: 8px 24px 15px 12px;
+  padding: 3px 2px;
+  border-radius: 0px 6px;
+  box-shadow: 3px 2px 3px rgba(153, 51, 204, 0.4);
+  transform: rotate(48deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box409 {
+  --cssA-v-409: 238871;
+  color: hsl(13, 17%, 43%);
+  background-color: hsl(193, 17%, 57%);
+  border: 5px solid hsl(103, 50%, 50%);
+  margin: 9px 27px 20px 1px;
+  padding: 4px 4px;
+  border-radius: 1px 8px;
+  box-shadow: 4px 3px 4px rgba(154, 53, 207, 0.5);
+  transform: rotate(49deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box410 {
+  --cssA-v-410: 246790;
+  color: hsl(50, 30%, 50%);
+  background-color: hsl(230, 30%, 50%);
+  border: 1px solid hsl(140, 50%, 50%);
+  margin: 10px 0px 0px 8px;
+  padding: 5px 6px;
+  border-radius: 2px 1px;
+  box-shadow: 0px 4px 5px rgba(155, 55, 210, 0.6);
+  transform: rotate(50deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box411 {
+  --cssA-v-411: 254709;
+  color: hsl(87, 43%, 57%);
+  background-color: hsl(267, 43%, 43%);
+  border: 2px solid hsl(177, 50%, 50%);
+  margin: 11px 3px 5px 15px;
+  padding: 6px 8px;
+  border-radius: 3px 3px;
+  box-shadow: 1px 5px 6px rgba(156, 57, 213, 0.7);
+  transform: rotate(51deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box412 {
+  --cssA-v-412: 262628;
+  color: hsl(124, 56%, 64%);
+  background-color: hsl(304, 56%, 36%);
+  border: 3px solid hsl(214, 50%, 50%);
+  margin: 12px 6px 10px 4px;
+  padding: 7px 10px;
+  border-radius: 4px 5px;
+  box-shadow: 2px 6px 7px rgba(157, 59, 216, 0.8);
+  transform: rotate(52deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box413 {
+  --cssA-v-413: 270547;
+  color: hsl(161, 69%, 71%);
+  background-color: hsl(341, 69%, 29%);
+  border: 4px solid hsl(251, 50%, 50%);
+  margin: 13px 9px 15px 11px;
+  padding: 8px 12px;
+  border-radius: 5px 7px;
+  box-shadow: 3px 0px 8px rgba(158, 61, 219, 0.9);
+  transform: rotate(53deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box414 {
+  --cssA-v-414: 278466;
+  color: hsl(198, 82%, 78%);
+  background-color: hsl(18, 82%, 22%);
+  border: 5px solid hsl(288, 50%, 50%);
+  margin: 14px 12px 20px 0px;
+  padding: 9px 14px;
+  border-radius: 6px 0px;
+  box-shadow: 4px 1px 0px rgba(159, 63, 222, 0.1);
+  transform: rotate(54deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box415 {
+  --cssA-v-415: 286385;
+  color: hsl(235, 95%, 35%);
+  background-color: hsl(55, 95%, 65%);
+  border: 1px solid hsl(325, 50%, 50%);
+  margin: 15px 15px 0px 7px;
+  padding: 10px 16px;
+  border-radius: 7px 2px;
+  box-shadow: 0px 2px 1px rgba(160, 65, 225, 0.2);
+  transform: rotate(55deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box416 {
+  --cssA-v-416: 294304;
+  color: hsl(272, 8%, 42%);
+  background-color: hsl(92, 8%, 58%);
+  border: 2px solid hsl(2, 50%, 50%);
+  margin: 16px 18px 5px 14px;
+  padding: 11px 18px;
+  border-radius: 8px 4px;
+  box-shadow: 1px 3px 2px rgba(161, 67, 228, 0.3);
+  transform: rotate(56deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box417 {
+  --cssA-v-417: 302223;
+  color: hsl(309, 21%, 49%);
+  background-color: hsl(129, 21%, 51%);
+  border: 3px solid hsl(39, 50%, 50%);
+  margin: 17px 21px 10px 3px;
+  padding: 12px 20px;
+  border-radius: 9px 6px;
+  box-shadow: 2px 4px 3px rgba(162, 69, 231, 0.4);
+  transform: rotate(57deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box418 {
+  --cssA-v-418: 310142;
+  color: hsl(346, 34%, 56%);
+  background-color: hsl(166, 34%, 44%);
+  border: 4px solid hsl(76, 50%, 50%);
+  margin: 18px 24px 15px 10px;
+  padding: 13px 0px;
+  border-radius: 10px 8px;
+  box-shadow: 3px 5px 4px rgba(163, 71, 234, 0.5);
+  transform: rotate(58deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box419 {
+  --cssA-v-419: 318061;
+  color: hsl(23, 47%, 63%);
+  background-color: hsl(203, 47%, 37%);
+  border: 5px solid hsl(113, 50%, 50%);
+  margin: 19px 27px 20px 17px;
+  padding: 14px 2px;
+  border-radius: 11px 1px;
+  box-shadow: 4px 6px 5px rgba(164, 73, 237, 0.6);
+  transform: rotate(59deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box420 {
+  --cssA-v-420: 325980;
+  color: hsl(60, 60%, 70%);
+  background-color: hsl(240, 60%, 30%);
+  border: 1px solid hsl(150, 50%, 50%);
+  margin: 0px 0px 0px 6px;
+  padding: 0px 4px;
+  border-radius: 0px 3px;
+  box-shadow: 0px 0px 6px rgba(165, 75, 240, 0.7);
+  transform: rotate(60deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box421 {
+  --cssA-v-421: 333899;
+  color: hsl(97, 73%, 77%);
+  background-color: hsl(277, 73%, 23%);
+  border: 2px solid hsl(187, 50%, 50%);
+  margin: 1px 3px 5px 13px;
+  padding: 1px 6px;
+  border-radius: 1px 5px;
+  box-shadow: 1px 1px 7px rgba(166, 77, 243, 0.8);
+  transform: rotate(61deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box422 {
+  --cssA-v-422: 341818;
+  color: hsl(134, 86%, 34%);
+  background-color: hsl(314, 86%, 66%);
+  border: 3px solid hsl(224, 50%, 50%);
+  margin: 2px 6px 10px 2px;
+  padding: 2px 8px;
+  border-radius: 2px 7px;
+  box-shadow: 2px 2px 8px rgba(167, 79, 246, 0.9);
+  transform: rotate(62deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box423 {
+  --cssA-v-423: 349737;
+  color: hsl(171, 99%, 41%);
+  background-color: hsl(351, 99%, 59%);
+  border: 4px solid hsl(261, 50%, 50%);
+  margin: 3px 9px 15px 9px;
+  padding: 3px 10px;
+  border-radius: 3px 0px;
+  box-shadow: 3px 3px 0px rgba(168, 81, 249, 0.1);
+  transform: rotate(63deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box424 {
+  --cssA-v-424: 357656;
+  color: hsl(208, 12%, 48%);
+  background-color: hsl(28, 12%, 52%);
+  border: 5px solid hsl(298, 50%, 50%);
+  margin: 4px 12px 20px 16px;
+  padding: 4px 12px;
+  border-radius: 4px 2px;
+  box-shadow: 4px 4px 1px rgba(169, 83, 252, 0.2);
+  transform: rotate(64deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box425 {
+  --cssA-v-425: 365575;
+  color: hsl(245, 25%, 55%);
+  background-color: hsl(65, 25%, 45%);
+  border: 1px solid hsl(335, 50%, 50%);
+  margin: 5px 15px 0px 5px;
+  padding: 5px 14px;
+  border-radius: 5px 4px;
+  box-shadow: 0px 5px 2px rgba(170, 85, 0, 0.3);
+  transform: rotate(65deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box426 {
+  --cssA-v-426: 373494;
+  color: hsl(282, 38%, 62%);
+  background-color: hsl(102, 38%, 38%);
+  border: 2px solid hsl(12, 50%, 50%);
+  margin: 6px 18px 5px 12px;
+  padding: 6px 16px;
+  border-radius: 6px 6px;
+  box-shadow: 1px 6px 3px rgba(171, 87, 3, 0.4);
+  transform: rotate(66deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box427 {
+  --cssA-v-427: 381413;
+  color: hsl(319, 51%, 69%);
+  background-color: hsl(139, 51%, 31%);
+  border: 3px solid hsl(49, 50%, 50%);
+  margin: 7px 21px 10px 1px;
+  padding: 7px 18px;
+  border-radius: 7px 8px;
+  box-shadow: 2px 0px 4px rgba(172, 89, 6, 0.5);
+  transform: rotate(67deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box428 {
+  --cssA-v-428: 389332;
+  color: hsl(356, 64%, 76%);
+  background-color: hsl(176, 64%, 24%);
+  border: 4px solid hsl(86, 50%, 50%);
+  margin: 8px 24px 15px 8px;
+  padding: 8px 20px;
+  border-radius: 8px 1px;
+  box-shadow: 3px 1px 5px rgba(173, 91, 9, 0.6);
+  transform: rotate(68deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box429 {
+  --cssA-v-429: 397251;
+  color: hsl(33, 77%, 33%);
+  background-color: hsl(213, 77%, 67%);
+  border: 5px solid hsl(123, 50%, 50%);
+  margin: 9px 27px 20px 15px;
+  padding: 9px 0px;
+  border-radius: 9px 3px;
+  box-shadow: 4px 2px 6px rgba(174, 93, 12, 0.7);
+  transform: rotate(69deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box430 {
+  --cssA-v-430: 405170;
+  color: hsl(70, 90%, 40%);
+  background-color: hsl(250, 90%, 60%);
+  border: 1px solid hsl(160, 50%, 50%);
+  margin: 10px 0px 0px 4px;
+  padding: 10px 2px;
+  border-radius: 10px 5px;
+  box-shadow: 0px 3px 7px rgba(175, 95, 15, 0.8);
+  transform: rotate(70deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box431 {
+  --cssA-v-431: 413089;
+  color: hsl(107, 3%, 47%);
+  background-color: hsl(287, 3%, 53%);
+  border: 2px solid hsl(197, 50%, 50%);
+  margin: 11px 3px 5px 11px;
+  padding: 11px 4px;
+  border-radius: 11px 7px;
+  box-shadow: 1px 4px 8px rgba(176, 97, 18, 0.9);
+  transform: rotate(71deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box432 {
+  --cssA-v-432: 421008;
+  color: hsl(144, 16%, 54%);
+  background-color: hsl(324, 16%, 46%);
+  border: 3px solid hsl(234, 50%, 50%);
+  margin: 12px 6px 10px 0px;
+  padding: 12px 6px;
+  border-radius: 0px 0px;
+  box-shadow: 2px 5px 0px rgba(177, 99, 21, 0.1);
+  transform: rotate(72deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box433 {
+  --cssA-v-433: 428927;
+  color: hsl(181, 29%, 61%);
+  background-color: hsl(1, 29%, 39%);
+  border: 4px solid hsl(271, 50%, 50%);
+  margin: 13px 9px 15px 7px;
+  padding: 13px 8px;
+  border-radius: 1px 2px;
+  box-shadow: 3px 6px 1px rgba(178, 101, 24, 0.2);
+  transform: rotate(73deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box434 {
+  --cssA-v-434: 436846;
+  color: hsl(218, 42%, 68%);
+  background-color: hsl(38, 42%, 32%);
+  border: 5px solid hsl(308, 50%, 50%);
+  margin: 14px 12px 20px 14px;
+  padding: 14px 10px;
+  border-radius: 2px 4px;
+  box-shadow: 4px 0px 2px rgba(179, 103, 27, 0.3);
+  transform: rotate(74deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box435 {
+  --cssA-v-435: 444765;
+  color: hsl(255, 55%, 75%);
+  background-color: hsl(75, 55%, 25%);
+  border: 1px solid hsl(345, 50%, 50%);
+  margin: 15px 15px 0px 3px;
+  padding: 0px 12px;
+  border-radius: 3px 6px;
+  box-shadow: 0px 1px 3px rgba(180, 105, 30, 0.4);
+  transform: rotate(75deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box436 {
+  --cssA-v-436: 452684;
+  color: hsl(292, 68%, 32%);
+  background-color: hsl(112, 68%, 68%);
+  border: 2px solid hsl(22, 50%, 50%);
+  margin: 16px 18px 5px 10px;
+  padding: 1px 14px;
+  border-radius: 4px 8px;
+  box-shadow: 1px 2px 4px rgba(181, 107, 33, 0.5);
+  transform: rotate(76deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box437 {
+  --cssA-v-437: 460603;
+  color: hsl(329, 81%, 39%);
+  background-color: hsl(149, 81%, 61%);
+  border: 3px solid hsl(59, 50%, 50%);
+  margin: 17px 21px 10px 17px;
+  padding: 2px 16px;
+  border-radius: 5px 1px;
+  box-shadow: 2px 3px 5px rgba(182, 109, 36, 0.6);
+  transform: rotate(77deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box438 {
+  --cssA-v-438: 468522;
+  color: hsl(6, 94%, 46%);
+  background-color: hsl(186, 94%, 54%);
+  border: 4px solid hsl(96, 50%, 50%);
+  margin: 18px 24px 15px 6px;
+  padding: 3px 18px;
+  border-radius: 6px 3px;
+  box-shadow: 3px 4px 6px rgba(183, 111, 39, 0.7);
+  transform: rotate(78deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box439 {
+  --cssA-v-439: 476441;
+  color: hsl(43, 7%, 53%);
+  background-color: hsl(223, 7%, 47%);
+  border: 5px solid hsl(133, 50%, 50%);
+  margin: 19px 27px 20px 13px;
+  padding: 4px 20px;
+  border-radius: 7px 5px;
+  box-shadow: 4px 5px 7px rgba(184, 113, 42, 0.8);
+  transform: rotate(79deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box440 {
+  --cssA-v-440: 484360;
+  color: hsl(80, 20%, 60%);
+  background-color: hsl(260, 20%, 40%);
+  border: 1px solid hsl(170, 50%, 50%);
+  margin: 0px 0px 0px 2px;
+  padding: 5px 0px;
+  border-radius: 8px 7px;
+  box-shadow: 0px 6px 8px rgba(185, 115, 45, 0.9);
+  transform: rotate(80deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box441 {
+  --cssA-v-441: 492279;
+  color: hsl(117, 33%, 67%);
+  background-color: hsl(297, 33%, 33%);
+  border: 2px solid hsl(207, 50%, 50%);
+  margin: 1px 3px 5px 9px;
+  padding: 6px 2px;
+  border-radius: 9px 0px;
+  box-shadow: 1px 0px 0px rgba(186, 117, 48, 0.1);
+  transform: rotate(81deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box442 {
+  --cssA-v-442: 500198;
+  color: hsl(154, 46%, 74%);
+  background-color: hsl(334, 46%, 26%);
+  border: 3px solid hsl(244, 50%, 50%);
+  margin: 2px 6px 10px 16px;
+  padding: 7px 4px;
+  border-radius: 10px 2px;
+  box-shadow: 2px 1px 1px rgba(187, 119, 51, 0.2);
+  transform: rotate(82deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box443 {
+  --cssA-v-443: 508117;
+  color: hsl(191, 59%, 31%);
+  background-color: hsl(11, 59%, 69%);
+  border: 4px solid hsl(281, 50%, 50%);
+  margin: 3px 9px 15px 5px;
+  padding: 8px 6px;
+  border-radius: 11px 4px;
+  box-shadow: 3px 2px 2px rgba(188, 121, 54, 0.3);
+  transform: rotate(83deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box444 {
+  --cssA-v-444: 516036;
+  color: hsl(228, 72%, 38%);
+  background-color: hsl(48, 72%, 62%);
+  border: 5px solid hsl(318, 50%, 50%);
+  margin: 4px 12px 20px 12px;
+  padding: 9px 8px;
+  border-radius: 0px 6px;
+  box-shadow: 4px 3px 3px rgba(189, 123, 57, 0.4);
+  transform: rotate(84deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box445 {
+  --cssA-v-445: 523955;
+  color: hsl(265, 85%, 45%);
+  background-color: hsl(85, 85%, 55%);
+  border: 1px solid hsl(355, 50%, 50%);
+  margin: 5px 15px 0px 1px;
+  padding: 10px 10px;
+  border-radius: 1px 8px;
+  box-shadow: 0px 4px 4px rgba(190, 125, 60, 0.5);
+  transform: rotate(85deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box446 {
+  --cssA-v-446: 531874;
+  color: hsl(302, 98%, 52%);
+  background-color: hsl(122, 98%, 48%);
+  border: 2px solid hsl(32, 50%, 50%);
+  margin: 6px 18px 5px 8px;
+  padding: 11px 12px;
+  border-radius: 2px 1px;
+  box-shadow: 1px 5px 5px rgba(191, 127, 63, 0.6);
+  transform: rotate(86deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box447 {
+  --cssA-v-447: 539793;
+  color: hsl(339, 11%, 59%);
+  background-color: hsl(159, 11%, 41%);
+  border: 3px solid hsl(69, 50%, 50%);
+  margin: 7px 21px 10px 15px;
+  padding: 12px 14px;
+  border-radius: 3px 3px;
+  box-shadow: 2px 6px 6px rgba(192, 129, 66, 0.7);
+  transform: rotate(87deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box448 {
+  --cssA-v-448: 547712;
+  color: hsl(16, 24%, 66%);
+  background-color: hsl(196, 24%, 34%);
+  border: 4px solid hsl(106, 50%, 50%);
+  margin: 8px 24px 15px 4px;
+  padding: 13px 16px;
+  border-radius: 4px 5px;
+  box-shadow: 3px 0px 7px rgba(193, 131, 69, 0.8);
+  transform: rotate(88deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box449 {
+  --cssA-v-449: 555631;
+  color: hsl(53, 37%, 73%);
+  background-color: hsl(233, 37%, 27%);
+  border: 5px solid hsl(143, 50%, 50%);
+  margin: 9px 27px 20px 11px;
+  padding: 14px 18px;
+  border-radius: 5px 7px;
+  box-shadow: 4px 1px 8px rgba(194, 133, 72, 0.9);
+  transform: rotate(89deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box450 {
+  --cssA-v-450: 563550;
+  color: hsl(90, 50%, 30%);
+  background-color: hsl(270, 50%, 70%);
+  border: 1px solid hsl(180, 50%, 50%);
+  margin: 10px 0px 0px 0px;
+  padding: 0px 20px;
+  border-radius: 6px 0px;
+  box-shadow: 0px 2px 0px rgba(195, 135, 75, 0.1);
+  transform: rotate(90deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box451 {
+  --cssA-v-451: 571469;
+  color: hsl(127, 63%, 37%);
+  background-color: hsl(307, 63%, 63%);
+  border: 2px solid hsl(217, 50%, 50%);
+  margin: 11px 3px 5px 7px;
+  padding: 1px 0px;
+  border-radius: 7px 2px;
+  box-shadow: 1px 3px 1px rgba(196, 137, 78, 0.2);
+  transform: rotate(91deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box452 {
+  --cssA-v-452: 579388;
+  color: hsl(164, 76%, 44%);
+  background-color: hsl(344, 76%, 56%);
+  border: 3px solid hsl(254, 50%, 50%);
+  margin: 12px 6px 10px 14px;
+  padding: 2px 2px;
+  border-radius: 8px 4px;
+  box-shadow: 2px 4px 2px rgba(197, 139, 81, 0.3);
+  transform: rotate(92deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box453 {
+  --cssA-v-453: 587307;
+  color: hsl(201, 89%, 51%);
+  background-color: hsl(21, 89%, 49%);
+  border: 4px solid hsl(291, 50%, 50%);
+  margin: 13px 9px 15px 3px;
+  padding: 3px 4px;
+  border-radius: 9px 6px;
+  box-shadow: 3px 5px 3px rgba(198, 141, 84, 0.4);
+  transform: rotate(93deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box454 {
+  --cssA-v-454: 595226;
+  color: hsl(238, 2%, 58%);
+  background-color: hsl(58, 2%, 42%);
+  border: 5px solid hsl(328, 50%, 50%);
+  margin: 14px 12px 20px 10px;
+  padding: 4px 6px;
+  border-radius: 10px 8px;
+  box-shadow: 4px 6px 4px rgba(199, 143, 87, 0.5);
+  transform: rotate(94deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box455 {
+  --cssA-v-455: 603145;
+  color: hsl(275, 15%, 65%);
+  background-color: hsl(95, 15%, 35%);
+  border: 1px solid hsl(5, 50%, 50%);
+  margin: 15px 15px 0px 17px;
+  padding: 5px 8px;
+  border-radius: 11px 1px;
+  box-shadow: 0px 0px 5px rgba(200, 145, 90, 0.6);
+  transform: rotate(95deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box456 {
+  --cssA-v-456: 611064;
+  color: hsl(312, 28%, 72%);
+  background-color: hsl(132, 28%, 28%);
+  border: 2px solid hsl(42, 50%, 50%);
+  margin: 16px 18px 5px 6px;
+  padding: 6px 10px;
+  border-radius: 0px 3px;
+  box-shadow: 1px 1px 6px rgba(201, 147, 93, 0.7);
+  transform: rotate(96deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box457 {
+  --cssA-v-457: 618983;
+  color: hsl(349, 41%, 79%);
+  background-color: hsl(169, 41%, 21%);
+  border: 3px solid hsl(79, 50%, 50%);
+  margin: 17px 21px 10px 13px;
+  padding: 7px 12px;
+  border-radius: 1px 5px;
+  box-shadow: 2px 2px 7px rgba(202, 149, 96, 0.8);
+  transform: rotate(97deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box458 {
+  --cssA-v-458: 626902;
+  color: hsl(26, 54%, 36%);
+  background-color: hsl(206, 54%, 64%);
+  border: 4px solid hsl(116, 50%, 50%);
+  margin: 18px 24px 15px 2px;
+  padding: 8px 14px;
+  border-radius: 2px 7px;
+  box-shadow: 3px 3px 8px rgba(203, 151, 99, 0.9);
+  transform: rotate(98deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box459 {
+  --cssA-v-459: 634821;
+  color: hsl(63, 67%, 43%);
+  background-color: hsl(243, 67%, 57%);
+  border: 5px solid hsl(153, 50%, 50%);
+  margin: 19px 27px 20px 9px;
+  padding: 9px 16px;
+  border-radius: 3px 0px;
+  box-shadow: 4px 4px 0px rgba(204, 153, 102, 0.1);
+  transform: rotate(99deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box460 {
+  --cssA-v-460: 642740;
+  color: hsl(100, 80%, 50%);
+  background-color: hsl(280, 80%, 50%);
+  border: 1px solid hsl(190, 50%, 50%);
+  margin: 0px 0px 0px 16px;
+  padding: 10px 18px;
+  border-radius: 4px 2px;
+  box-shadow: 0px 5px 1px rgba(205, 155, 105, 0.2);
+  transform: rotate(100deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box461 {
+  --cssA-v-461: 650659;
+  color: hsl(137, 93%, 57%);
+  background-color: hsl(317, 93%, 43%);
+  border: 2px solid hsl(227, 50%, 50%);
+  margin: 1px 3px 5px 5px;
+  padding: 11px 20px;
+  border-radius: 5px 4px;
+  box-shadow: 1px 6px 2px rgba(206, 157, 108, 0.3);
+  transform: rotate(101deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box462 {
+  --cssA-v-462: 658578;
+  color: hsl(174, 6%, 64%);
+  background-color: hsl(354, 6%, 36%);
+  border: 3px solid hsl(264, 50%, 50%);
+  margin: 2px 6px 10px 12px;
+  padding: 12px 0px;
+  border-radius: 6px 6px;
+  box-shadow: 2px 0px 3px rgba(207, 159, 111, 0.4);
+  transform: rotate(102deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box463 {
+  --cssA-v-463: 666497;
+  color: hsl(211, 19%, 71%);
+  background-color: hsl(31, 19%, 29%);
+  border: 4px solid hsl(301, 50%, 50%);
+  margin: 3px 9px 15px 1px;
+  padding: 13px 2px;
+  border-radius: 7px 8px;
+  box-shadow: 3px 1px 4px rgba(208, 161, 114, 0.5);
+  transform: rotate(103deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box464 {
+  --cssA-v-464: 674416;
+  color: hsl(248, 32%, 78%);
+  background-color: hsl(68, 32%, 22%);
+  border: 5px solid hsl(338, 50%, 50%);
+  margin: 4px 12px 20px 8px;
+  padding: 14px 4px;
+  border-radius: 8px 1px;
+  box-shadow: 4px 2px 5px rgba(209, 163, 117, 0.6);
+  transform: rotate(104deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box465 {
+  --cssA-v-465: 682335;
+  color: hsl(285, 45%, 35%);
+  background-color: hsl(105, 45%, 65%);
+  border: 1px solid hsl(15, 50%, 50%);
+  margin: 5px 15px 0px 15px;
+  padding: 0px 6px;
+  border-radius: 9px 3px;
+  box-shadow: 0px 3px 6px rgba(210, 165, 120, 0.7);
+  transform: rotate(105deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box466 {
+  --cssA-v-466: 690254;
+  color: hsl(322, 58%, 42%);
+  background-color: hsl(142, 58%, 58%);
+  border: 2px solid hsl(52, 50%, 50%);
+  margin: 6px 18px 5px 4px;
+  padding: 1px 8px;
+  border-radius: 10px 5px;
+  box-shadow: 1px 4px 7px rgba(211, 167, 123, 0.8);
+  transform: rotate(106deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box467 {
+  --cssA-v-467: 698173;
+  color: hsl(359, 71%, 49%);
+  background-color: hsl(179, 71%, 51%);
+  border: 3px solid hsl(89, 50%, 50%);
+  margin: 7px 21px 10px 11px;
+  padding: 2px 10px;
+  border-radius: 11px 7px;
+  box-shadow: 2px 5px 8px rgba(212, 169, 126, 0.9);
+  transform: rotate(107deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box468 {
+  --cssA-v-468: 706092;
+  color: hsl(36, 84%, 56%);
+  background-color: hsl(216, 84%, 44%);
+  border: 4px solid hsl(126, 50%, 50%);
+  margin: 8px 24px 15px 0px;
+  padding: 3px 12px;
+  border-radius: 0px 0px;
+  box-shadow: 3px 6px 0px rgba(213, 171, 129, 0.1);
+  transform: rotate(108deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box469 {
+  --cssA-v-469: 714011;
+  color: hsl(73, 97%, 63%);
+  background-color: hsl(253, 97%, 37%);
+  border: 5px solid hsl(163, 50%, 50%);
+  margin: 9px 27px 20px 7px;
+  padding: 4px 14px;
+  border-radius: 1px 2px;
+  box-shadow: 4px 0px 1px rgba(214, 173, 132, 0.2);
+  transform: rotate(109deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box470 {
+  --cssA-v-470: 721930;
+  color: hsl(110, 10%, 70%);
+  background-color: hsl(290, 10%, 30%);
+  border: 1px solid hsl(200, 50%, 50%);
+  margin: 10px 0px 0px 14px;
+  padding: 5px 16px;
+  border-radius: 2px 4px;
+  box-shadow: 0px 1px 2px rgba(215, 175, 135, 0.3);
+  transform: rotate(110deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box471 {
+  --cssA-v-471: 729849;
+  color: hsl(147, 23%, 77%);
+  background-color: hsl(327, 23%, 23%);
+  border: 2px solid hsl(237, 50%, 50%);
+  margin: 11px 3px 5px 3px;
+  padding: 6px 18px;
+  border-radius: 3px 6px;
+  box-shadow: 1px 2px 3px rgba(216, 177, 138, 0.4);
+  transform: rotate(111deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box472 {
+  --cssA-v-472: 737768;
+  color: hsl(184, 36%, 34%);
+  background-color: hsl(4, 36%, 66%);
+  border: 3px solid hsl(274, 50%, 50%);
+  margin: 12px 6px 10px 10px;
+  padding: 7px 20px;
+  border-radius: 4px 8px;
+  box-shadow: 2px 3px 4px rgba(217, 179, 141, 0.5);
+  transform: rotate(112deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box473 {
+  --cssA-v-473: 745687;
+  color: hsl(221, 49%, 41%);
+  background-color: hsl(41, 49%, 59%);
+  border: 4px solid hsl(311, 50%, 50%);
+  margin: 13px 9px 15px 17px;
+  padding: 8px 0px;
+  border-radius: 5px 1px;
+  box-shadow: 3px 4px 5px rgba(218, 181, 144, 0.6);
+  transform: rotate(113deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box474 {
+  --cssA-v-474: 753606;
+  color: hsl(258, 62%, 48%);
+  background-color: hsl(78, 62%, 52%);
+  border: 5px solid hsl(348, 50%, 50%);
+  margin: 14px 12px 20px 6px;
+  padding: 9px 2px;
+  border-radius: 6px 3px;
+  box-shadow: 4px 5px 6px rgba(219, 183, 147, 0.7);
+  transform: rotate(114deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box475 {
+  --cssA-v-475: 761525;
+  color: hsl(295, 75%, 55%);
+  background-color: hsl(115, 75%, 45%);
+  border: 1px solid hsl(25, 50%, 50%);
+  margin: 15px 15px 0px 13px;
+  padding: 10px 4px;
+  border-radius: 7px 5px;
+  box-shadow: 0px 6px 7px rgba(220, 185, 150, 0.8);
+  transform: rotate(115deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box476 {
+  --cssA-v-476: 769444;
+  color: hsl(332, 88%, 62%);
+  background-color: hsl(152, 88%, 38%);
+  border: 2px solid hsl(62, 50%, 50%);
+  margin: 16px 18px 5px 2px;
+  padding: 11px 6px;
+  border-radius: 8px 7px;
+  box-shadow: 1px 0px 8px rgba(221, 187, 153, 0.9);
+  transform: rotate(116deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box477 {
+  --cssA-v-477: 777363;
+  color: hsl(9, 1%, 69%);
+  background-color: hsl(189, 1%, 31%);
+  border: 3px solid hsl(99, 50%, 50%);
+  margin: 17px 21px 10px 9px;
+  padding: 12px 8px;
+  border-radius: 9px 0px;
+  box-shadow: 2px 1px 0px rgba(222, 189, 156, 0.1);
+  transform: rotate(117deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box478 {
+  --cssA-v-478: 785282;
+  color: hsl(46, 14%, 76%);
+  background-color: hsl(226, 14%, 24%);
+  border: 4px solid hsl(136, 50%, 50%);
+  margin: 18px 24px 15px 16px;
+  padding: 13px 10px;
+  border-radius: 10px 2px;
+  box-shadow: 3px 2px 1px rgba(223, 191, 159, 0.2);
+  transform: rotate(118deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box479 {
+  --cssA-v-479: 793201;
+  color: hsl(83, 27%, 33%);
+  background-color: hsl(263, 27%, 67%);
+  border: 5px solid hsl(173, 50%, 50%);
+  margin: 19px 27px 20px 5px;
+  padding: 14px 12px;
+  border-radius: 11px 4px;
+  box-shadow: 4px 3px 2px rgba(224, 193, 162, 0.3);
+  transform: rotate(119deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box480 {
+  --cssA-v-480: 801120;
+  color: hsl(120, 40%, 40%);
+  background-color: hsl(300, 40%, 60%);
+  border: 1px solid hsl(210, 50%, 50%);
+  margin: 0px 0px 0px 12px;
+  padding: 0px 14px;
+  border-radius: 0px 6px;
+  box-shadow: 0px 4px 3px rgba(225, 195, 165, 0.4);
+  transform: rotate(120deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box481 {
+  --cssA-v-481: 809039;
+  color: hsl(157, 53%, 47%);
+  background-color: hsl(337, 53%, 53%);
+  border: 2px solid hsl(247, 50%, 50%);
+  margin: 1px 3px 5px 1px;
+  padding: 1px 16px;
+  border-radius: 1px 8px;
+  box-shadow: 1px 5px 4px rgba(226, 197, 168, 0.5);
+  transform: rotate(121deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box482 {
+  --cssA-v-482: 816958;
+  color: hsl(194, 66%, 54%);
+  background-color: hsl(14, 66%, 46%);
+  border: 3px solid hsl(284, 50%, 50%);
+  margin: 2px 6px 10px 8px;
+  padding: 2px 18px;
+  border-radius: 2px 1px;
+  box-shadow: 2px 6px 5px rgba(227, 199, 171, 0.6);
+  transform: rotate(122deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box483 {
+  --cssA-v-483: 824877;
+  color: hsl(231, 79%, 61%);
+  background-color: hsl(51, 79%, 39%);
+  border: 4px solid hsl(321, 50%, 50%);
+  margin: 3px 9px 15px 15px;
+  padding: 3px 20px;
+  border-radius: 3px 3px;
+  box-shadow: 3px 0px 6px rgba(228, 201, 174, 0.7);
+  transform: rotate(123deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box484 {
+  --cssA-v-484: 832796;
+  color: hsl(268, 92%, 68%);
+  background-color: hsl(88, 92%, 32%);
+  border: 5px solid hsl(358, 50%, 50%);
+  margin: 4px 12px 20px 4px;
+  padding: 4px 0px;
+  border-radius: 4px 5px;
+  box-shadow: 4px 1px 7px rgba(229, 203, 177, 0.8);
+  transform: rotate(124deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box485 {
+  --cssA-v-485: 840715;
+  color: hsl(305, 5%, 75%);
+  background-color: hsl(125, 5%, 25%);
+  border: 1px solid hsl(35, 50%, 50%);
+  margin: 5px 15px 0px 11px;
+  padding: 5px 2px;
+  border-radius: 5px 7px;
+  box-shadow: 0px 2px 8px rgba(230, 205, 180, 0.9);
+  transform: rotate(125deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box486 {
+  --cssA-v-486: 848634;
+  color: hsl(342, 18%, 32%);
+  background-color: hsl(162, 18%, 68%);
+  border: 2px solid hsl(72, 50%, 50%);
+  margin: 6px 18px 5px 0px;
+  padding: 6px 4px;
+  border-radius: 6px 0px;
+  box-shadow: 1px 3px 0px rgba(231, 207, 183, 0.1);
+  transform: rotate(126deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box487 {
+  --cssA-v-487: 856553;
+  color: hsl(19, 31%, 39%);
+  background-color: hsl(199, 31%, 61%);
+  border: 3px solid hsl(109, 50%, 50%);
+  margin: 7px 21px 10px 7px;
+  padding: 7px 6px;
+  border-radius: 7px 2px;
+  box-shadow: 2px 4px 1px rgba(232, 209, 186, 0.2);
+  transform: rotate(127deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box488 {
+  --cssA-v-488: 864472;
+  color: hsl(56, 44%, 46%);
+  background-color: hsl(236, 44%, 54%);
+  border: 4px solid hsl(146, 50%, 50%);
+  margin: 8px 24px 15px 14px;
+  padding: 8px 8px;
+  border-radius: 8px 4px;
+  box-shadow: 3px 5px 2px rgba(233, 211, 189, 0.3);
+  transform: rotate(128deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box489 {
+  --cssA-v-489: 872391;
+  color: hsl(93, 57%, 53%);
+  background-color: hsl(273, 57%, 47%);
+  border: 5px solid hsl(183, 50%, 50%);
+  margin: 9px 27px 20px 3px;
+  padding: 9px 10px;
+  border-radius: 9px 6px;
+  box-shadow: 4px 6px 3px rgba(234, 213, 192, 0.4);
+  transform: rotate(129deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box490 {
+  --cssA-v-490: 880310;
+  color: hsl(130, 70%, 60%);
+  background-color: hsl(310, 70%, 40%);
+  border: 1px solid hsl(220, 50%, 50%);
+  margin: 10px 0px 0px 10px;
+  padding: 10px 12px;
+  border-radius: 10px 8px;
+  box-shadow: 0px 0px 4px rgba(235, 215, 195, 0.5);
+  transform: rotate(130deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box491 {
+  --cssA-v-491: 888229;
+  color: hsl(167, 83%, 67%);
+  background-color: hsl(347, 83%, 33%);
+  border: 2px solid hsl(257, 50%, 50%);
+  margin: 11px 3px 5px 17px;
+  padding: 11px 14px;
+  border-radius: 11px 1px;
+  box-shadow: 1px 1px 5px rgba(236, 217, 198, 0.6);
+  transform: rotate(131deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box492 {
+  --cssA-v-492: 896148;
+  color: hsl(204, 96%, 74%);
+  background-color: hsl(24, 96%, 26%);
+  border: 3px solid hsl(294, 50%, 50%);
+  margin: 12px 6px 10px 6px;
+  padding: 12px 16px;
+  border-radius: 0px 3px;
+  box-shadow: 2px 2px 6px rgba(237, 219, 201, 0.7);
+  transform: rotate(132deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box493 {
+  --cssA-v-493: 904067;
+  color: hsl(241, 9%, 31%);
+  background-color: hsl(61, 9%, 69%);
+  border: 4px solid hsl(331, 50%, 50%);
+  margin: 13px 9px 15px 13px;
+  padding: 13px 18px;
+  border-radius: 1px 5px;
+  box-shadow: 3px 3px 7px rgba(238, 221, 204, 0.8);
+  transform: rotate(133deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box494 {
+  --cssA-v-494: 911986;
+  color: hsl(278, 22%, 38%);
+  background-color: hsl(98, 22%, 62%);
+  border: 5px solid hsl(8, 50%, 50%);
+  margin: 14px 12px 20px 2px;
+  padding: 14px 20px;
+  border-radius: 2px 7px;
+  box-shadow: 4px 4px 8px rgba(239, 223, 207, 0.9);
+  transform: rotate(134deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box495 {
+  --cssA-v-495: 919905;
+  color: hsl(315, 35%, 45%);
+  background-color: hsl(135, 35%, 55%);
+  border: 1px solid hsl(45, 50%, 50%);
+  margin: 15px 15px 0px 9px;
+  padding: 0px 0px;
+  border-radius: 3px 0px;
+  box-shadow: 0px 5px 0px rgba(240, 225, 210, 0.1);
+  transform: rotate(135deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box496 {
+  --cssA-v-496: 927824;
+  color: hsl(352, 48%, 52%);
+  background-color: hsl(172, 48%, 48%);
+  border: 2px solid hsl(82, 50%, 50%);
+  margin: 16px 18px 5px 16px;
+  padding: 1px 2px;
+  border-radius: 4px 2px;
+  box-shadow: 1px 6px 1px rgba(241, 227, 213, 0.2);
+  transform: rotate(136deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box497 {
+  --cssA-v-497: 935743;
+  color: hsl(29, 61%, 59%);
+  background-color: hsl(209, 61%, 41%);
+  border: 3px solid hsl(119, 50%, 50%);
+  margin: 17px 21px 10px 5px;
+  padding: 2px 4px;
+  border-radius: 5px 4px;
+  box-shadow: 2px 0px 2px rgba(242, 229, 216, 0.3);
+  transform: rotate(137deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box498 {
+  --cssA-v-498: 943662;
+  color: hsl(66, 74%, 66%);
+  background-color: hsl(246, 74%, 34%);
+  border: 4px solid hsl(156, 50%, 50%);
+  margin: 18px 24px 15px 12px;
+  padding: 3px 6px;
+  border-radius: 6px 6px;
+  box-shadow: 3px 1px 3px rgba(243, 231, 219, 0.4);
+  transform: rotate(138deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box499 {
+  --cssA-v-499: 951581;
+  color: hsl(103, 87%, 73%);
+  background-color: hsl(283, 87%, 27%);
+  border: 5px solid hsl(193, 50%, 50%);
+  margin: 19px 27px 20px 1px;
+  padding: 4px 8px;
+  border-radius: 7px 8px;
+  box-shadow: 4px 2px 4px rgba(244, 233, 222, 0.5);
+  transform: rotate(139deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box500 {
+  --cssA-v-500: 959500;
+  color: hsl(140, 0%, 30%);
+  background-color: hsl(320, 0%, 70%);
+  border: 1px solid hsl(230, 50%, 50%);
+  margin: 0px 0px 0px 8px;
+  padding: 5px 10px;
+  border-radius: 8px 1px;
+  box-shadow: 0px 3px 5px rgba(245, 235, 225, 0.6);
+  transform: rotate(140deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box501 {
+  --cssA-v-501: 967419;
+  color: hsl(177, 13%, 37%);
+  background-color: hsl(357, 13%, 63%);
+  border: 2px solid hsl(267, 50%, 50%);
+  margin: 1px 3px 5px 15px;
+  padding: 6px 12px;
+  border-radius: 9px 3px;
+  box-shadow: 1px 4px 6px rgba(246, 237, 228, 0.7);
+  transform: rotate(141deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box502 {
+  --cssA-v-502: 975338;
+  color: hsl(214, 26%, 44%);
+  background-color: hsl(34, 26%, 56%);
+  border: 3px solid hsl(304, 50%, 50%);
+  margin: 2px 6px 10px 4px;
+  padding: 7px 14px;
+  border-radius: 10px 5px;
+  box-shadow: 2px 5px 7px rgba(247, 239, 231, 0.8);
+  transform: rotate(142deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box503 {
+  --cssA-v-503: 983257;
+  color: hsl(251, 39%, 51%);
+  background-color: hsl(71, 39%, 49%);
+  border: 4px solid hsl(341, 50%, 50%);
+  margin: 3px 9px 15px 11px;
+  padding: 8px 16px;
+  border-radius: 11px 7px;
+  box-shadow: 3px 6px 8px rgba(248, 241, 234, 0.9);
+  transform: rotate(143deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box504 {
+  --cssA-v-504: 991176;
+  color: hsl(288, 52%, 58%);
+  background-color: hsl(108, 52%, 42%);
+  border: 5px solid hsl(18, 50%, 50%);
+  margin: 4px 12px 20px 0px;
+  padding: 9px 18px;
+  border-radius: 0px 0px;
+  box-shadow: 4px 0px 0px rgba(249, 243, 237, 0.1);
+  transform: rotate(144deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box505 {
+  --cssA-v-505: 999095;
+  color: hsl(325, 65%, 65%);
+  background-color: hsl(145, 65%, 35%);
+  border: 1px solid hsl(55, 50%, 50%);
+  margin: 5px 15px 0px 7px;
+  padding: 10px 20px;
+  border-radius: 1px 2px;
+  box-shadow: 0px 1px 1px rgba(250, 245, 240, 0.2);
+  transform: rotate(145deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box506 {
+  --cssA-v-506: 7014;
+  color: hsl(2, 78%, 72%);
+  background-color: hsl(182, 78%, 28%);
+  border: 2px solid hsl(92, 50%, 50%);
+  margin: 6px 18px 5px 14px;
+  padding: 11px 0px;
+  border-radius: 2px 4px;
+  box-shadow: 1px 2px 2px rgba(251, 247, 243, 0.3);
+  transform: rotate(146deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box507 {
+  --cssA-v-507: 14933;
+  color: hsl(39, 91%, 79%);
+  background-color: hsl(219, 91%, 21%);
+  border: 3px solid hsl(129, 50%, 50%);
+  margin: 7px 21px 10px 3px;
+  padding: 12px 2px;
+  border-radius: 3px 6px;
+  box-shadow: 2px 3px 3px rgba(252, 249, 246, 0.4);
+  transform: rotate(147deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box508 {
+  --cssA-v-508: 22852;
+  color: hsl(76, 4%, 36%);
+  background-color: hsl(256, 4%, 64%);
+  border: 4px solid hsl(166, 50%, 50%);
+  margin: 8px 24px 15px 10px;
+  padding: 13px 4px;
+  border-radius: 4px 8px;
+  box-shadow: 3px 4px 4px rgba(253, 251, 249, 0.5);
+  transform: rotate(148deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box509 {
+  --cssA-v-509: 30771;
+  color: hsl(113, 17%, 43%);
+  background-color: hsl(293, 17%, 57%);
+  border: 5px solid hsl(203, 50%, 50%);
+  margin: 9px 27px 20px 17px;
+  padding: 14px 6px;
+  border-radius: 5px 1px;
+  box-shadow: 4px 5px 5px rgba(254, 253, 252, 0.6);
+  transform: rotate(149deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box510 {
+  --cssA-v-510: 38690;
+  color: hsl(150, 30%, 50%);
+  background-color: hsl(330, 30%, 50%);
+  border: 1px solid hsl(240, 50%, 50%);
+  margin: 10px 0px 0px 6px;
+  padding: 0px 8px;
+  border-radius: 6px 3px;
+  box-shadow: 0px 6px 6px rgba(0, 0, 0, 0.7);
+  transform: rotate(150deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box511 {
+  --cssA-v-511: 46609;
+  color: hsl(187, 43%, 57%);
+  background-color: hsl(7, 43%, 43%);
+  border: 2px solid hsl(277, 50%, 50%);
+  margin: 11px 3px 5px 13px;
+  padding: 1px 10px;
+  border-radius: 7px 5px;
+  box-shadow: 1px 0px 7px rgba(1, 2, 3, 0.8);
+  transform: rotate(151deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box512 {
+  --cssA-v-512: 54528;
+  color: hsl(224, 56%, 64%);
+  background-color: hsl(44, 56%, 36%);
+  border: 3px solid hsl(314, 50%, 50%);
+  margin: 12px 6px 10px 2px;
+  padding: 2px 12px;
+  border-radius: 8px 7px;
+  box-shadow: 2px 1px 8px rgba(2, 4, 6, 0.9);
+  transform: rotate(152deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box513 {
+  --cssA-v-513: 62447;
+  color: hsl(261, 69%, 71%);
+  background-color: hsl(81, 69%, 29%);
+  border: 4px solid hsl(351, 50%, 50%);
+  margin: 13px 9px 15px 9px;
+  padding: 3px 14px;
+  border-radius: 9px 0px;
+  box-shadow: 3px 2px 0px rgba(3, 6, 9, 0.1);
+  transform: rotate(153deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box514 {
+  --cssA-v-514: 70366;
+  color: hsl(298, 82%, 78%);
+  background-color: hsl(118, 82%, 22%);
+  border: 5px solid hsl(28, 50%, 50%);
+  margin: 14px 12px 20px 16px;
+  padding: 4px 16px;
+  border-radius: 10px 2px;
+  box-shadow: 4px 3px 1px rgba(4, 8, 12, 0.2);
+  transform: rotate(154deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box515 {
+  --cssA-v-515: 78285;
+  color: hsl(335, 95%, 35%);
+  background-color: hsl(155, 95%, 65%);
+  border: 1px solid hsl(65, 50%, 50%);
+  margin: 15px 15px 0px 5px;
+  padding: 5px 18px;
+  border-radius: 11px 4px;
+  box-shadow: 0px 4px 2px rgba(5, 10, 15, 0.3);
+  transform: rotate(155deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box516 {
+  --cssA-v-516: 86204;
+  color: hsl(12, 8%, 42%);
+  background-color: hsl(192, 8%, 58%);
+  border: 2px solid hsl(102, 50%, 50%);
+  margin: 16px 18px 5px 12px;
+  padding: 6px 20px;
+  border-radius: 0px 6px;
+  box-shadow: 1px 5px 3px rgba(6, 12, 18, 0.4);
+  transform: rotate(156deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box517 {
+  --cssA-v-517: 94123;
+  color: hsl(49, 21%, 49%);
+  background-color: hsl(229, 21%, 51%);
+  border: 3px solid hsl(139, 50%, 50%);
+  margin: 17px 21px 10px 1px;
+  padding: 7px 0px;
+  border-radius: 1px 8px;
+  box-shadow: 2px 6px 4px rgba(7, 14, 21, 0.5);
+  transform: rotate(157deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box518 {
+  --cssA-v-518: 102042;
+  color: hsl(86, 34%, 56%);
+  background-color: hsl(266, 34%, 44%);
+  border: 4px solid hsl(176, 50%, 50%);
+  margin: 18px 24px 15px 8px;
+  padding: 8px 2px;
+  border-radius: 2px 1px;
+  box-shadow: 3px 0px 5px rgba(8, 16, 24, 0.6);
+  transform: rotate(158deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box519 {
+  --cssA-v-519: 109961;
+  color: hsl(123, 47%, 63%);
+  background-color: hsl(303, 47%, 37%);
+  border: 5px solid hsl(213, 50%, 50%);
+  margin: 19px 27px 20px 15px;
+  padding: 9px 4px;
+  border-radius: 3px 3px;
+  box-shadow: 4px 1px 6px rgba(9, 18, 27, 0.7);
+  transform: rotate(159deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box520 {
+  --cssA-v-520: 117880;
+  color: hsl(160, 60%, 70%);
+  background-color: hsl(340, 60%, 30%);
+  border: 1px solid hsl(250, 50%, 50%);
+  margin: 0px 0px 0px 4px;
+  padding: 10px 6px;
+  border-radius: 4px 5px;
+  box-shadow: 0px 2px 7px rgba(10, 20, 30, 0.8);
+  transform: rotate(160deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box521 {
+  --cssA-v-521: 125799;
+  color: hsl(197, 73%, 77%);
+  background-color: hsl(17, 73%, 23%);
+  border: 2px solid hsl(287, 50%, 50%);
+  margin: 1px 3px 5px 11px;
+  padding: 11px 8px;
+  border-radius: 5px 7px;
+  box-shadow: 1px 3px 8px rgba(11, 22, 33, 0.9);
+  transform: rotate(161deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box522 {
+  --cssA-v-522: 133718;
+  color: hsl(234, 86%, 34%);
+  background-color: hsl(54, 86%, 66%);
+  border: 3px solid hsl(324, 50%, 50%);
+  margin: 2px 6px 10px 0px;
+  padding: 12px 10px;
+  border-radius: 6px 0px;
+  box-shadow: 2px 4px 0px rgba(12, 24, 36, 0.1);
+  transform: rotate(162deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box523 {
+  --cssA-v-523: 141637;
+  color: hsl(271, 99%, 41%);
+  background-color: hsl(91, 99%, 59%);
+  border: 4px solid hsl(1, 50%, 50%);
+  margin: 3px 9px 15px 7px;
+  padding: 13px 12px;
+  border-radius: 7px 2px;
+  box-shadow: 3px 5px 1px rgba(13, 26, 39, 0.2);
+  transform: rotate(163deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box524 {
+  --cssA-v-524: 149556;
+  color: hsl(308, 12%, 48%);
+  background-color: hsl(128, 12%, 52%);
+  border: 5px solid hsl(38, 50%, 50%);
+  margin: 4px 12px 20px 14px;
+  padding: 14px 14px;
+  border-radius: 8px 4px;
+  box-shadow: 4px 6px 2px rgba(14, 28, 42, 0.3);
+  transform: rotate(164deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box525 {
+  --cssA-v-525: 157475;
+  color: hsl(345, 25%, 55%);
+  background-color: hsl(165, 25%, 45%);
+  border: 1px solid hsl(75, 50%, 50%);
+  margin: 5px 15px 0px 3px;
+  padding: 0px 16px;
+  border-radius: 9px 6px;
+  box-shadow: 0px 0px 3px rgba(15, 30, 45, 0.4);
+  transform: rotate(165deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box526 {
+  --cssA-v-526: 165394;
+  color: hsl(22, 38%, 62%);
+  background-color: hsl(202, 38%, 38%);
+  border: 2px solid hsl(112, 50%, 50%);
+  margin: 6px 18px 5px 10px;
+  padding: 1px 18px;
+  border-radius: 10px 8px;
+  box-shadow: 1px 1px 4px rgba(16, 32, 48, 0.5);
+  transform: rotate(166deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box527 {
+  --cssA-v-527: 173313;
+  color: hsl(59, 51%, 69%);
+  background-color: hsl(239, 51%, 31%);
+  border: 3px solid hsl(149, 50%, 50%);
+  margin: 7px 21px 10px 17px;
+  padding: 2px 20px;
+  border-radius: 11px 1px;
+  box-shadow: 2px 2px 5px rgba(17, 34, 51, 0.6);
+  transform: rotate(167deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box528 {
+  --cssA-v-528: 181232;
+  color: hsl(96, 64%, 76%);
+  background-color: hsl(276, 64%, 24%);
+  border: 4px solid hsl(186, 50%, 50%);
+  margin: 8px 24px 15px 6px;
+  padding: 3px 0px;
+  border-radius: 0px 3px;
+  box-shadow: 3px 3px 6px rgba(18, 36, 54, 0.7);
+  transform: rotate(168deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box529 {
+  --cssA-v-529: 189151;
+  color: hsl(133, 77%, 33%);
+  background-color: hsl(313, 77%, 67%);
+  border: 5px solid hsl(223, 50%, 50%);
+  margin: 9px 27px 20px 13px;
+  padding: 4px 2px;
+  border-radius: 1px 5px;
+  box-shadow: 4px 4px 7px rgba(19, 38, 57, 0.8);
+  transform: rotate(169deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box530 {
+  --cssA-v-530: 197070;
+  color: hsl(170, 90%, 40%);
+  background-color: hsl(350, 90%, 60%);
+  border: 1px solid hsl(260, 50%, 50%);
+  margin: 10px 0px 0px 2px;
+  padding: 5px 4px;
+  border-radius: 2px 7px;
+  box-shadow: 0px 5px 8px rgba(20, 40, 60, 0.9);
+  transform: rotate(170deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box531 {
+  --cssA-v-531: 204989;
+  color: hsl(207, 3%, 47%);
+  background-color: hsl(27, 3%, 53%);
+  border: 2px solid hsl(297, 50%, 50%);
+  margin: 11px 3px 5px 9px;
+  padding: 6px 6px;
+  border-radius: 3px 0px;
+  box-shadow: 1px 6px 0px rgba(21, 42, 63, 0.1);
+  transform: rotate(171deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box532 {
+  --cssA-v-532: 212908;
+  color: hsl(244, 16%, 54%);
+  background-color: hsl(64, 16%, 46%);
+  border: 3px solid hsl(334, 50%, 50%);
+  margin: 12px 6px 10px 16px;
+  padding: 7px 8px;
+  border-radius: 4px 2px;
+  box-shadow: 2px 0px 1px rgba(22, 44, 66, 0.2);
+  transform: rotate(172deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box533 {
+  --cssA-v-533: 220827;
+  color: hsl(281, 29%, 61%);
+  background-color: hsl(101, 29%, 39%);
+  border: 4px solid hsl(11, 50%, 50%);
+  margin: 13px 9px 15px 5px;
+  padding: 8px 10px;
+  border-radius: 5px 4px;
+  box-shadow: 3px 1px 2px rgba(23, 46, 69, 0.3);
+  transform: rotate(173deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box534 {
+  --cssA-v-534: 228746;
+  color: hsl(318, 42%, 68%);
+  background-color: hsl(138, 42%, 32%);
+  border: 5px solid hsl(48, 50%, 50%);
+  margin: 14px 12px 20px 12px;
+  padding: 9px 12px;
+  border-radius: 6px 6px;
+  box-shadow: 4px 2px 3px rgba(24, 48, 72, 0.4);
+  transform: rotate(174deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box535 {
+  --cssA-v-535: 236665;
+  color: hsl(355, 55%, 75%);
+  background-color: hsl(175, 55%, 25%);
+  border: 1px solid hsl(85, 50%, 50%);
+  margin: 15px 15px 0px 1px;
+  padding: 10px 14px;
+  border-radius: 7px 8px;
+  box-shadow: 0px 3px 4px rgba(25, 50, 75, 0.5);
+  transform: rotate(175deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box536 {
+  --cssA-v-536: 244584;
+  color: hsl(32, 68%, 32%);
+  background-color: hsl(212, 68%, 68%);
+  border: 2px solid hsl(122, 50%, 50%);
+  margin: 16px 18px 5px 8px;
+  padding: 11px 16px;
+  border-radius: 8px 1px;
+  box-shadow: 1px 4px 5px rgba(26, 52, 78, 0.6);
+  transform: rotate(176deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box537 {
+  --cssA-v-537: 252503;
+  color: hsl(69, 81%, 39%);
+  background-color: hsl(249, 81%, 61%);
+  border: 3px solid hsl(159, 50%, 50%);
+  margin: 17px 21px 10px 15px;
+  padding: 12px 18px;
+  border-radius: 9px 3px;
+  box-shadow: 2px 5px 6px rgba(27, 54, 81, 0.7);
+  transform: rotate(177deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box538 {
+  --cssA-v-538: 260422;
+  color: hsl(106, 94%, 46%);
+  background-color: hsl(286, 94%, 54%);
+  border: 4px solid hsl(196, 50%, 50%);
+  margin: 18px 24px 15px 4px;
+  padding: 13px 20px;
+  border-radius: 10px 5px;
+  box-shadow: 3px 6px 7px rgba(28, 56, 84, 0.8);
+  transform: rotate(178deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box539 {
+  --cssA-v-539: 268341;
+  color: hsl(143, 7%, 53%);
+  background-color: hsl(323, 7%, 47%);
+  border: 5px solid hsl(233, 50%, 50%);
+  margin: 19px 27px 20px 11px;
+  padding: 14px 0px;
+  border-radius: 11px 7px;
+  box-shadow: 4px 0px 8px rgba(29, 58, 87, 0.9);
+  transform: rotate(179deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box540 {
+  --cssA-v-540: 276260;
+  color: hsl(180, 20%, 60%);
+  background-color: hsl(0, 20%, 40%);
+  border: 1px solid hsl(270, 50%, 50%);
+  margin: 0px 0px 0px 0px;
+  padding: 0px 2px;
+  border-radius: 0px 0px;
+  box-shadow: 0px 1px 0px rgba(30, 60, 90, 0.1);
+  transform: rotate(180deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box541 {
+  --cssA-v-541: 284179;
+  color: hsl(217, 33%, 67%);
+  background-color: hsl(37, 33%, 33%);
+  border: 2px solid hsl(307, 50%, 50%);
+  margin: 1px 3px 5px 7px;
+  padding: 1px 4px;
+  border-radius: 1px 2px;
+  box-shadow: 1px 2px 1px rgba(31, 62, 93, 0.2);
+  transform: rotate(181deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box542 {
+  --cssA-v-542: 292098;
+  color: hsl(254, 46%, 74%);
+  background-color: hsl(74, 46%, 26%);
+  border: 3px solid hsl(344, 50%, 50%);
+  margin: 2px 6px 10px 14px;
+  padding: 2px 6px;
+  border-radius: 2px 4px;
+  box-shadow: 2px 3px 2px rgba(32, 64, 96, 0.3);
+  transform: rotate(182deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box543 {
+  --cssA-v-543: 300017;
+  color: hsl(291, 59%, 31%);
+  background-color: hsl(111, 59%, 69%);
+  border: 4px solid hsl(21, 50%, 50%);
+  margin: 3px 9px 15px 3px;
+  padding: 3px 8px;
+  border-radius: 3px 6px;
+  box-shadow: 3px 4px 3px rgba(33, 66, 99, 0.4);
+  transform: rotate(183deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box544 {
+  --cssA-v-544: 307936;
+  color: hsl(328, 72%, 38%);
+  background-color: hsl(148, 72%, 62%);
+  border: 5px solid hsl(58, 50%, 50%);
+  margin: 4px 12px 20px 10px;
+  padding: 4px 10px;
+  border-radius: 4px 8px;
+  box-shadow: 4px 5px 4px rgba(34, 68, 102, 0.5);
+  transform: rotate(184deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box545 {
+  --cssA-v-545: 315855;
+  color: hsl(5, 85%, 45%);
+  background-color: hsl(185, 85%, 55%);
+  border: 1px solid hsl(95, 50%, 50%);
+  margin: 5px 15px 0px 17px;
+  padding: 5px 12px;
+  border-radius: 5px 1px;
+  box-shadow: 0px 6px 5px rgba(35, 70, 105, 0.6);
+  transform: rotate(185deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box546 {
+  --cssA-v-546: 323774;
+  color: hsl(42, 98%, 52%);
+  background-color: hsl(222, 98%, 48%);
+  border: 2px solid hsl(132, 50%, 50%);
+  margin: 6px 18px 5px 6px;
+  padding: 6px 14px;
+  border-radius: 6px 3px;
+  box-shadow: 1px 0px 6px rgba(36, 72, 108, 0.7);
+  transform: rotate(186deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box547 {
+  --cssA-v-547: 331693;
+  color: hsl(79, 11%, 59%);
+  background-color: hsl(259, 11%, 41%);
+  border: 3px solid hsl(169, 50%, 50%);
+  margin: 7px 21px 10px 13px;
+  padding: 7px 16px;
+  border-radius: 7px 5px;
+  box-shadow: 2px 1px 7px rgba(37, 74, 111, 0.8);
+  transform: rotate(187deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box548 {
+  --cssA-v-548: 339612;
+  color: hsl(116, 24%, 66%);
+  background-color: hsl(296, 24%, 34%);
+  border: 4px solid hsl(206, 50%, 50%);
+  margin: 8px 24px 15px 2px;
+  padding: 8px 18px;
+  border-radius: 8px 7px;
+  box-shadow: 3px 2px 8px rgba(38, 76, 114, 0.9);
+  transform: rotate(188deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box549 {
+  --cssA-v-549: 347531;
+  color: hsl(153, 37%, 73%);
+  background-color: hsl(333, 37%, 27%);
+  border: 5px solid hsl(243, 50%, 50%);
+  margin: 9px 27px 20px 9px;
+  padding: 9px 20px;
+  border-radius: 9px 0px;
+  box-shadow: 4px 3px 0px rgba(39, 78, 117, 0.1);
+  transform: rotate(189deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box550 {
+  --cssA-v-550: 355450;
+  color: hsl(190, 50%, 30%);
+  background-color: hsl(10, 50%, 70%);
+  border: 1px solid hsl(280, 50%, 50%);
+  margin: 10px 0px 0px 16px;
+  padding: 10px 0px;
+  border-radius: 10px 2px;
+  box-shadow: 0px 4px 1px rgba(40, 80, 120, 0.2);
+  transform: rotate(190deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box551 {
+  --cssA-v-551: 363369;
+  color: hsl(227, 63%, 37%);
+  background-color: hsl(47, 63%, 63%);
+  border: 2px solid hsl(317, 50%, 50%);
+  margin: 11px 3px 5px 5px;
+  padding: 11px 2px;
+  border-radius: 11px 4px;
+  box-shadow: 1px 5px 2px rgba(41, 82, 123, 0.3);
+  transform: rotate(191deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box552 {
+  --cssA-v-552: 371288;
+  color: hsl(264, 76%, 44%);
+  background-color: hsl(84, 76%, 56%);
+  border: 3px solid hsl(354, 50%, 50%);
+  margin: 12px 6px 10px 12px;
+  padding: 12px 4px;
+  border-radius: 0px 6px;
+  box-shadow: 2px 6px 3px rgba(42, 84, 126, 0.4);
+  transform: rotate(192deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box553 {
+  --cssA-v-553: 379207;
+  color: hsl(301, 89%, 51%);
+  background-color: hsl(121, 89%, 49%);
+  border: 4px solid hsl(31, 50%, 50%);
+  margin: 13px 9px 15px 1px;
+  padding: 13px 6px;
+  border-radius: 1px 8px;
+  box-shadow: 3px 0px 4px rgba(43, 86, 129, 0.5);
+  transform: rotate(193deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box554 {
+  --cssA-v-554: 387126;
+  color: hsl(338, 2%, 58%);
+  background-color: hsl(158, 2%, 42%);
+  border: 5px solid hsl(68, 50%, 50%);
+  margin: 14px 12px 20px 8px;
+  padding: 14px 8px;
+  border-radius: 2px 1px;
+  box-shadow: 4px 1px 5px rgba(44, 88, 132, 0.6);
+  transform: rotate(194deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box555 {
+  --cssA-v-555: 395045;
+  color: hsl(15, 15%, 65%);
+  background-color: hsl(195, 15%, 35%);
+  border: 1px solid hsl(105, 50%, 50%);
+  margin: 15px 15px 0px 15px;
+  padding: 0px 10px;
+  border-radius: 3px 3px;
+  box-shadow: 0px 2px 6px rgba(45, 90, 135, 0.7);
+  transform: rotate(195deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box556 {
+  --cssA-v-556: 402964;
+  color: hsl(52, 28%, 72%);
+  background-color: hsl(232, 28%, 28%);
+  border: 2px solid hsl(142, 50%, 50%);
+  margin: 16px 18px 5px 4px;
+  padding: 1px 12px;
+  border-radius: 4px 5px;
+  box-shadow: 1px 3px 7px rgba(46, 92, 138, 0.8);
+  transform: rotate(196deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box557 {
+  --cssA-v-557: 410883;
+  color: hsl(89, 41%, 79%);
+  background-color: hsl(269, 41%, 21%);
+  border: 3px solid hsl(179, 50%, 50%);
+  margin: 17px 21px 10px 11px;
+  padding: 2px 14px;
+  border-radius: 5px 7px;
+  box-shadow: 2px 4px 8px rgba(47, 94, 141, 0.9);
+  transform: rotate(197deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box558 {
+  --cssA-v-558: 418802;
+  color: hsl(126, 54%, 36%);
+  background-color: hsl(306, 54%, 64%);
+  border: 4px solid hsl(216, 50%, 50%);
+  margin: 18px 24px 15px 0px;
+  padding: 3px 16px;
+  border-radius: 6px 0px;
+  box-shadow: 3px 5px 0px rgba(48, 96, 144, 0.1);
+  transform: rotate(198deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box559 {
+  --cssA-v-559: 426721;
+  color: hsl(163, 67%, 43%);
+  background-color: hsl(343, 67%, 57%);
+  border: 5px solid hsl(253, 50%, 50%);
+  margin: 19px 27px 20px 7px;
+  padding: 4px 18px;
+  border-radius: 7px 2px;
+  box-shadow: 4px 6px 1px rgba(49, 98, 147, 0.2);
+  transform: rotate(199deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box560 {
+  --cssA-v-560: 434640;
+  color: hsl(200, 80%, 50%);
+  background-color: hsl(20, 80%, 50%);
+  border: 1px solid hsl(290, 50%, 50%);
+  margin: 0px 0px 0px 14px;
+  padding: 5px 20px;
+  border-radius: 8px 4px;
+  box-shadow: 0px 0px 2px rgba(50, 100, 150, 0.3);
+  transform: rotate(200deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box561 {
+  --cssA-v-561: 442559;
+  color: hsl(237, 93%, 57%);
+  background-color: hsl(57, 93%, 43%);
+  border: 2px solid hsl(327, 50%, 50%);
+  margin: 1px 3px 5px 3px;
+  padding: 6px 0px;
+  border-radius: 9px 6px;
+  box-shadow: 1px 1px 3px rgba(51, 102, 153, 0.4);
+  transform: rotate(201deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box562 {
+  --cssA-v-562: 450478;
+  color: hsl(274, 6%, 64%);
+  background-color: hsl(94, 6%, 36%);
+  border: 3px solid hsl(4, 50%, 50%);
+  margin: 2px 6px 10px 10px;
+  padding: 7px 2px;
+  border-radius: 10px 8px;
+  box-shadow: 2px 2px 4px rgba(52, 104, 156, 0.5);
+  transform: rotate(202deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box563 {
+  --cssA-v-563: 458397;
+  color: hsl(311, 19%, 71%);
+  background-color: hsl(131, 19%, 29%);
+  border: 4px solid hsl(41, 50%, 50%);
+  margin: 3px 9px 15px 17px;
+  padding: 8px 4px;
+  border-radius: 11px 1px;
+  box-shadow: 3px 3px 5px rgba(53, 106, 159, 0.6);
+  transform: rotate(203deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box564 {
+  --cssA-v-564: 466316;
+  color: hsl(348, 32%, 78%);
+  background-color: hsl(168, 32%, 22%);
+  border: 5px solid hsl(78, 50%, 50%);
+  margin: 4px 12px 20px 6px;
+  padding: 9px 6px;
+  border-radius: 0px 3px;
+  box-shadow: 4px 4px 6px rgba(54, 108, 162, 0.7);
+  transform: rotate(204deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box565 {
+  --cssA-v-565: 474235;
+  color: hsl(25, 45%, 35%);
+  background-color: hsl(205, 45%, 65%);
+  border: 1px solid hsl(115, 50%, 50%);
+  margin: 5px 15px 0px 13px;
+  padding: 10px 8px;
+  border-radius: 1px 5px;
+  box-shadow: 0px 5px 7px rgba(55, 110, 165, 0.8);
+  transform: rotate(205deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box566 {
+  --cssA-v-566: 482154;
+  color: hsl(62, 58%, 42%);
+  background-color: hsl(242, 58%, 58%);
+  border: 2px solid hsl(152, 50%, 50%);
+  margin: 6px 18px 5px 2px;
+  padding: 11px 10px;
+  border-radius: 2px 7px;
+  box-shadow: 1px 6px 8px rgba(56, 112, 168, 0.9);
+  transform: rotate(206deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box567 {
+  --cssA-v-567: 490073;
+  color: hsl(99, 71%, 49%);
+  background-color: hsl(279, 71%, 51%);
+  border: 3px solid hsl(189, 50%, 50%);
+  margin: 7px 21px 10px 9px;
+  padding: 12px 12px;
+  border-radius: 3px 0px;
+  box-shadow: 2px 0px 0px rgba(57, 114, 171, 0.1);
+  transform: rotate(207deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box568 {
+  --cssA-v-568: 497992;
+  color: hsl(136, 84%, 56%);
+  background-color: hsl(316, 84%, 44%);
+  border: 4px solid hsl(226, 50%, 50%);
+  margin: 8px 24px 15px 16px;
+  padding: 13px 14px;
+  border-radius: 4px 2px;
+  box-shadow: 3px 1px 1px rgba(58, 116, 174, 0.2);
+  transform: rotate(208deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box569 {
+  --cssA-v-569: 505911;
+  color: hsl(173, 97%, 63%);
+  background-color: hsl(353, 97%, 37%);
+  border: 5px solid hsl(263, 50%, 50%);
+  margin: 9px 27px 20px 5px;
+  padding: 14px 16px;
+  border-radius: 5px 4px;
+  box-shadow: 4px 2px 2px rgba(59, 118, 177, 0.3);
+  transform: rotate(209deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box570 {
+  --cssA-v-570: 513830;
+  color: hsl(210, 10%, 70%);
+  background-color: hsl(30, 10%, 30%);
+  border: 1px solid hsl(300, 50%, 50%);
+  margin: 10px 0px 0px 12px;
+  padding: 0px 18px;
+  border-radius: 6px 6px;
+  box-shadow: 0px 3px 3px rgba(60, 120, 180, 0.4);
+  transform: rotate(210deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box571 {
+  --cssA-v-571: 521749;
+  color: hsl(247, 23%, 77%);
+  background-color: hsl(67, 23%, 23%);
+  border: 2px solid hsl(337, 50%, 50%);
+  margin: 11px 3px 5px 1px;
+  padding: 1px 20px;
+  border-radius: 7px 8px;
+  box-shadow: 1px 4px 4px rgba(61, 122, 183, 0.5);
+  transform: rotate(211deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box572 {
+  --cssA-v-572: 529668;
+  color: hsl(284, 36%, 34%);
+  background-color: hsl(104, 36%, 66%);
+  border: 3px solid hsl(14, 50%, 50%);
+  margin: 12px 6px 10px 8px;
+  padding: 2px 0px;
+  border-radius: 8px 1px;
+  box-shadow: 2px 5px 5px rgba(62, 124, 186, 0.6);
+  transform: rotate(212deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box573 {
+  --cssA-v-573: 537587;
+  color: hsl(321, 49%, 41%);
+  background-color: hsl(141, 49%, 59%);
+  border: 4px solid hsl(51, 50%, 50%);
+  margin: 13px 9px 15px 15px;
+  padding: 3px 2px;
+  border-radius: 9px 3px;
+  box-shadow: 3px 6px 6px rgba(63, 126, 189, 0.7);
+  transform: rotate(213deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box574 {
+  --cssA-v-574: 545506;
+  color: hsl(358, 62%, 48%);
+  background-color: hsl(178, 62%, 52%);
+  border: 5px solid hsl(88, 50%, 50%);
+  margin: 14px 12px 20px 4px;
+  padding: 4px 4px;
+  border-radius: 10px 5px;
+  box-shadow: 4px 0px 7px rgba(64, 128, 192, 0.8);
+  transform: rotate(214deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box575 {
+  --cssA-v-575: 553425;
+  color: hsl(35, 75%, 55%);
+  background-color: hsl(215, 75%, 45%);
+  border: 1px solid hsl(125, 50%, 50%);
+  margin: 15px 15px 0px 11px;
+  padding: 5px 6px;
+  border-radius: 11px 7px;
+  box-shadow: 0px 1px 8px rgba(65, 130, 195, 0.9);
+  transform: rotate(215deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box576 {
+  --cssA-v-576: 561344;
+  color: hsl(72, 88%, 62%);
+  background-color: hsl(252, 88%, 38%);
+  border: 2px solid hsl(162, 50%, 50%);
+  margin: 16px 18px 5px 0px;
+  padding: 6px 8px;
+  border-radius: 0px 0px;
+  box-shadow: 1px 2px 0px rgba(66, 132, 198, 0.1);
+  transform: rotate(216deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box577 {
+  --cssA-v-577: 569263;
+  color: hsl(109, 1%, 69%);
+  background-color: hsl(289, 1%, 31%);
+  border: 3px solid hsl(199, 50%, 50%);
+  margin: 17px 21px 10px 7px;
+  padding: 7px 10px;
+  border-radius: 1px 2px;
+  box-shadow: 2px 3px 1px rgba(67, 134, 201, 0.2);
+  transform: rotate(217deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box578 {
+  --cssA-v-578: 577182;
+  color: hsl(146, 14%, 76%);
+  background-color: hsl(326, 14%, 24%);
+  border: 4px solid hsl(236, 50%, 50%);
+  margin: 18px 24px 15px 14px;
+  padding: 8px 12px;
+  border-radius: 2px 4px;
+  box-shadow: 3px 4px 2px rgba(68, 136, 204, 0.3);
+  transform: rotate(218deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box579 {
+  --cssA-v-579: 585101;
+  color: hsl(183, 27%, 33%);
+  background-color: hsl(3, 27%, 67%);
+  border: 5px solid hsl(273, 50%, 50%);
+  margin: 19px 27px 20px 3px;
+  padding: 9px 14px;
+  border-radius: 3px 6px;
+  box-shadow: 4px 5px 3px rgba(69, 138, 207, 0.4);
+  transform: rotate(219deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box580 {
+  --cssA-v-580: 593020;
+  color: hsl(220, 40%, 40%);
+  background-color: hsl(40, 40%, 60%);
+  border: 1px solid hsl(310, 50%, 50%);
+  margin: 0px 0px 0px 10px;
+  padding: 10px 16px;
+  border-radius: 4px 8px;
+  box-shadow: 0px 6px 4px rgba(70, 140, 210, 0.5);
+  transform: rotate(220deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box581 {
+  --cssA-v-581: 600939;
+  color: hsl(257, 53%, 47%);
+  background-color: hsl(77, 53%, 53%);
+  border: 2px solid hsl(347, 50%, 50%);
+  margin: 1px 3px 5px 17px;
+  padding: 11px 18px;
+  border-radius: 5px 1px;
+  box-shadow: 1px 0px 5px rgba(71, 142, 213, 0.6);
+  transform: rotate(221deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box582 {
+  --cssA-v-582: 608858;
+  color: hsl(294, 66%, 54%);
+  background-color: hsl(114, 66%, 46%);
+  border: 3px solid hsl(24, 50%, 50%);
+  margin: 2px 6px 10px 6px;
+  padding: 12px 20px;
+  border-radius: 6px 3px;
+  box-shadow: 2px 1px 6px rgba(72, 144, 216, 0.7);
+  transform: rotate(222deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box583 {
+  --cssA-v-583: 616777;
+  color: hsl(331, 79%, 61%);
+  background-color: hsl(151, 79%, 39%);
+  border: 4px solid hsl(61, 50%, 50%);
+  margin: 3px 9px 15px 13px;
+  padding: 13px 0px;
+  border-radius: 7px 5px;
+  box-shadow: 3px 2px 7px rgba(73, 146, 219, 0.8);
+  transform: rotate(223deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box584 {
+  --cssA-v-584: 624696;
+  color: hsl(8, 92%, 68%);
+  background-color: hsl(188, 92%, 32%);
+  border: 5px solid hsl(98, 50%, 50%);
+  margin: 4px 12px 20px 2px;
+  padding: 14px 2px;
+  border-radius: 8px 7px;
+  box-shadow: 4px 3px 8px rgba(74, 148, 222, 0.9);
+  transform: rotate(224deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box585 {
+  --cssA-v-585: 632615;
+  color: hsl(45, 5%, 75%);
+  background-color: hsl(225, 5%, 25%);
+  border: 1px solid hsl(135, 50%, 50%);
+  margin: 5px 15px 0px 9px;
+  padding: 0px 4px;
+  border-radius: 9px 0px;
+  box-shadow: 0px 4px 0px rgba(75, 150, 225, 0.1);
+  transform: rotate(225deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box586 {
+  --cssA-v-586: 640534;
+  color: hsl(82, 18%, 32%);
+  background-color: hsl(262, 18%, 68%);
+  border: 2px solid hsl(172, 50%, 50%);
+  margin: 6px 18px 5px 16px;
+  padding: 1px 6px;
+  border-radius: 10px 2px;
+  box-shadow: 1px 5px 1px rgba(76, 152, 228, 0.2);
+  transform: rotate(226deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box587 {
+  --cssA-v-587: 648453;
+  color: hsl(119, 31%, 39%);
+  background-color: hsl(299, 31%, 61%);
+  border: 3px solid hsl(209, 50%, 50%);
+  margin: 7px 21px 10px 5px;
+  padding: 2px 8px;
+  border-radius: 11px 4px;
+  box-shadow: 2px 6px 2px rgba(77, 154, 231, 0.3);
+  transform: rotate(227deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box588 {
+  --cssA-v-588: 656372;
+  color: hsl(156, 44%, 46%);
+  background-color: hsl(336, 44%, 54%);
+  border: 4px solid hsl(246, 50%, 50%);
+  margin: 8px 24px 15px 12px;
+  padding: 3px 10px;
+  border-radius: 0px 6px;
+  box-shadow: 3px 0px 3px rgba(78, 156, 234, 0.4);
+  transform: rotate(228deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box589 {
+  --cssA-v-589: 664291;
+  color: hsl(193, 57%, 53%);
+  background-color: hsl(13, 57%, 47%);
+  border: 5px solid hsl(283, 50%, 50%);
+  margin: 9px 27px 20px 1px;
+  padding: 4px 12px;
+  border-radius: 1px 8px;
+  box-shadow: 4px 1px 4px rgba(79, 158, 237, 0.5);
+  transform: rotate(229deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box590 {
+  --cssA-v-590: 672210;
+  color: hsl(230, 70%, 60%);
+  background-color: hsl(50, 70%, 40%);
+  border: 1px solid hsl(320, 50%, 50%);
+  margin: 10px 0px 0px 8px;
+  padding: 5px 14px;
+  border-radius: 2px 1px;
+  box-shadow: 0px 2px 5px rgba(80, 160, 240, 0.6);
+  transform: rotate(230deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box591 {
+  --cssA-v-591: 680129;
+  color: hsl(267, 83%, 67%);
+  background-color: hsl(87, 83%, 33%);
+  border: 2px solid hsl(357, 50%, 50%);
+  margin: 11px 3px 5px 15px;
+  padding: 6px 16px;
+  border-radius: 3px 3px;
+  box-shadow: 1px 3px 6px rgba(81, 162, 243, 0.7);
+  transform: rotate(231deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box592 {
+  --cssA-v-592: 688048;
+  color: hsl(304, 96%, 74%);
+  background-color: hsl(124, 96%, 26%);
+  border: 3px solid hsl(34, 50%, 50%);
+  margin: 12px 6px 10px 4px;
+  padding: 7px 18px;
+  border-radius: 4px 5px;
+  box-shadow: 2px 4px 7px rgba(82, 164, 246, 0.8);
+  transform: rotate(232deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box593 {
+  --cssA-v-593: 695967;
+  color: hsl(341, 9%, 31%);
+  background-color: hsl(161, 9%, 69%);
+  border: 4px solid hsl(71, 50%, 50%);
+  margin: 13px 9px 15px 11px;
+  padding: 8px 20px;
+  border-radius: 5px 7px;
+  box-shadow: 3px 5px 8px rgba(83, 166, 249, 0.9);
+  transform: rotate(233deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box594 {
+  --cssA-v-594: 703886;
+  color: hsl(18, 22%, 38%);
+  background-color: hsl(198, 22%, 62%);
+  border: 5px solid hsl(108, 50%, 50%);
+  margin: 14px 12px 20px 0px;
+  padding: 9px 0px;
+  border-radius: 6px 0px;
+  box-shadow: 4px 6px 0px rgba(84, 168, 252, 0.1);
+  transform: rotate(234deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box595 {
+  --cssA-v-595: 711805;
+  color: hsl(55, 35%, 45%);
+  background-color: hsl(235, 35%, 55%);
+  border: 1px solid hsl(145, 50%, 50%);
+  margin: 15px 15px 0px 7px;
+  padding: 10px 2px;
+  border-radius: 7px 2px;
+  box-shadow: 0px 0px 1px rgba(85, 170, 0, 0.2);
+  transform: rotate(235deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box596 {
+  --cssA-v-596: 719724;
+  color: hsl(92, 48%, 52%);
+  background-color: hsl(272, 48%, 48%);
+  border: 2px solid hsl(182, 50%, 50%);
+  margin: 16px 18px 5px 14px;
+  padding: 11px 4px;
+  border-radius: 8px 4px;
+  box-shadow: 1px 1px 2px rgba(86, 172, 3, 0.3);
+  transform: rotate(236deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box597 {
+  --cssA-v-597: 727643;
+  color: hsl(129, 61%, 59%);
+  background-color: hsl(309, 61%, 41%);
+  border: 3px solid hsl(219, 50%, 50%);
+  margin: 17px 21px 10px 3px;
+  padding: 12px 6px;
+  border-radius: 9px 6px;
+  box-shadow: 2px 2px 3px rgba(87, 174, 6, 0.4);
+  transform: rotate(237deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box598 {
+  --cssA-v-598: 735562;
+  color: hsl(166, 74%, 66%);
+  background-color: hsl(346, 74%, 34%);
+  border: 4px solid hsl(256, 50%, 50%);
+  margin: 18px 24px 15px 10px;
+  padding: 13px 8px;
+  border-radius: 10px 8px;
+  box-shadow: 3px 3px 4px rgba(88, 176, 9, 0.5);
+  transform: rotate(238deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box599 {
+  --cssA-v-599: 743481;
+  color: hsl(203, 87%, 73%);
+  background-color: hsl(23, 87%, 27%);
+  border: 5px solid hsl(293, 50%, 50%);
+  margin: 19px 27px 20px 17px;
+  padding: 14px 10px;
+  border-radius: 11px 1px;
+  box-shadow: 4px 4px 5px rgba(89, 178, 12, 0.6);
+  transform: rotate(239deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box600 {
+  --cssA-v-600: 751400;
+  color: hsl(240, 0%, 30%);
+  background-color: hsl(60, 0%, 70%);
+  border: 1px solid hsl(330, 50%, 50%);
+  margin: 0px 0px 0px 6px;
+  padding: 0px 12px;
+  border-radius: 0px 3px;
+  box-shadow: 0px 5px 6px rgba(90, 180, 15, 0.7);
+  transform: rotate(240deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box601 {
+  --cssA-v-601: 759319;
+  color: hsl(277, 13%, 37%);
+  background-color: hsl(97, 13%, 63%);
+  border: 2px solid hsl(7, 50%, 50%);
+  margin: 1px 3px 5px 13px;
+  padding: 1px 14px;
+  border-radius: 1px 5px;
+  box-shadow: 1px 6px 7px rgba(91, 182, 18, 0.8);
+  transform: rotate(241deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box602 {
+  --cssA-v-602: 767238;
+  color: hsl(314, 26%, 44%);
+  background-color: hsl(134, 26%, 56%);
+  border: 3px solid hsl(44, 50%, 50%);
+  margin: 2px 6px 10px 2px;
+  padding: 2px 16px;
+  border-radius: 2px 7px;
+  box-shadow: 2px 0px 8px rgba(92, 184, 21, 0.9);
+  transform: rotate(242deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box603 {
+  --cssA-v-603: 775157;
+  color: hsl(351, 39%, 51%);
+  background-color: hsl(171, 39%, 49%);
+  border: 4px solid hsl(81, 50%, 50%);
+  margin: 3px 9px 15px 9px;
+  padding: 3px 18px;
+  border-radius: 3px 0px;
+  box-shadow: 3px 1px 0px rgba(93, 186, 24, 0.1);
+  transform: rotate(243deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box604 {
+  --cssA-v-604: 783076;
+  color: hsl(28, 52%, 58%);
+  background-color: hsl(208, 52%, 42%);
+  border: 5px solid hsl(118, 50%, 50%);
+  margin: 4px 12px 20px 16px;
+  padding: 4px 20px;
+  border-radius: 4px 2px;
+  box-shadow: 4px 2px 1px rgba(94, 188, 27, 0.2);
+  transform: rotate(244deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box605 {
+  --cssA-v-605: 790995;
+  color: hsl(65, 65%, 65%);
+  background-color: hsl(245, 65%, 35%);
+  border: 1px solid hsl(155, 50%, 50%);
+  margin: 5px 15px 0px 5px;
+  padding: 5px 0px;
+  border-radius: 5px 4px;
+  box-shadow: 0px 3px 2px rgba(95, 190, 30, 0.3);
+  transform: rotate(245deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box606 {
+  --cssA-v-606: 798914;
+  color: hsl(102, 78%, 72%);
+  background-color: hsl(282, 78%, 28%);
+  border: 2px solid hsl(192, 50%, 50%);
+  margin: 6px 18px 5px 12px;
+  padding: 6px 2px;
+  border-radius: 6px 6px;
+  box-shadow: 1px 4px 3px rgba(96, 192, 33, 0.4);
+  transform: rotate(246deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box607 {
+  --cssA-v-607: 806833;
+  color: hsl(139, 91%, 79%);
+  background-color: hsl(319, 91%, 21%);
+  border: 3px solid hsl(229, 50%, 50%);
+  margin: 7px 21px 10px 1px;
+  padding: 7px 4px;
+  border-radius: 7px 8px;
+  box-shadow: 2px 5px 4px rgba(97, 194, 36, 0.5);
+  transform: rotate(247deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box608 {
+  --cssA-v-608: 814752;
+  color: hsl(176, 4%, 36%);
+  background-color: hsl(356, 4%, 64%);
+  border: 4px solid hsl(266, 50%, 50%);
+  margin: 8px 24px 15px 8px;
+  padding: 8px 6px;
+  border-radius: 8px 1px;
+  box-shadow: 3px 6px 5px rgba(98, 196, 39, 0.6);
+  transform: rotate(248deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box609 {
+  --cssA-v-609: 822671;
+  color: hsl(213, 17%, 43%);
+  background-color: hsl(33, 17%, 57%);
+  border: 5px solid hsl(303, 50%, 50%);
+  margin: 9px 27px 20px 15px;
+  padding: 9px 8px;
+  border-radius: 9px 3px;
+  box-shadow: 4px 0px 6px rgba(99, 198, 42, 0.7);
+  transform: rotate(249deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box610 {
+  --cssA-v-610: 830590;
+  color: hsl(250, 30%, 50%);
+  background-color: hsl(70, 30%, 50%);
+  border: 1px solid hsl(340, 50%, 50%);
+  margin: 10px 0px 0px 4px;
+  padding: 10px 10px;
+  border-radius: 10px 5px;
+  box-shadow: 0px 1px 7px rgba(100, 200, 45, 0.8);
+  transform: rotate(250deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box611 {
+  --cssA-v-611: 838509;
+  color: hsl(287, 43%, 57%);
+  background-color: hsl(107, 43%, 43%);
+  border: 2px solid hsl(17, 50%, 50%);
+  margin: 11px 3px 5px 11px;
+  padding: 11px 12px;
+  border-radius: 11px 7px;
+  box-shadow: 1px 2px 8px rgba(101, 202, 48, 0.9);
+  transform: rotate(251deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box612 {
+  --cssA-v-612: 846428;
+  color: hsl(324, 56%, 64%);
+  background-color: hsl(144, 56%, 36%);
+  border: 3px solid hsl(54, 50%, 50%);
+  margin: 12px 6px 10px 0px;
+  padding: 12px 14px;
+  border-radius: 0px 0px;
+  box-shadow: 2px 3px 0px rgba(102, 204, 51, 0.1);
+  transform: rotate(252deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box613 {
+  --cssA-v-613: 854347;
+  color: hsl(1, 69%, 71%);
+  background-color: hsl(181, 69%, 29%);
+  border: 4px solid hsl(91, 50%, 50%);
+  margin: 13px 9px 15px 7px;
+  padding: 13px 16px;
+  border-radius: 1px 2px;
+  box-shadow: 3px 4px 1px rgba(103, 206, 54, 0.2);
+  transform: rotate(253deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box614 {
+  --cssA-v-614: 862266;
+  color: hsl(38, 82%, 78%);
+  background-color: hsl(218, 82%, 22%);
+  border: 5px solid hsl(128, 50%, 50%);
+  margin: 14px 12px 20px 14px;
+  padding: 14px 18px;
+  border-radius: 2px 4px;
+  box-shadow: 4px 5px 2px rgba(104, 208, 57, 0.3);
+  transform: rotate(254deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box615 {
+  --cssA-v-615: 870185;
+  color: hsl(75, 95%, 35%);
+  background-color: hsl(255, 95%, 65%);
+  border: 1px solid hsl(165, 50%, 50%);
+  margin: 15px 15px 0px 3px;
+  padding: 0px 20px;
+  border-radius: 3px 6px;
+  box-shadow: 0px 6px 3px rgba(105, 210, 60, 0.4);
+  transform: rotate(255deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box616 {
+  --cssA-v-616: 878104;
+  color: hsl(112, 8%, 42%);
+  background-color: hsl(292, 8%, 58%);
+  border: 2px solid hsl(202, 50%, 50%);
+  margin: 16px 18px 5px 10px;
+  padding: 1px 0px;
+  border-radius: 4px 8px;
+  box-shadow: 1px 0px 4px rgba(106, 212, 63, 0.5);
+  transform: rotate(256deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box617 {
+  --cssA-v-617: 886023;
+  color: hsl(149, 21%, 49%);
+  background-color: hsl(329, 21%, 51%);
+  border: 3px solid hsl(239, 50%, 50%);
+  margin: 17px 21px 10px 17px;
+  padding: 2px 2px;
+  border-radius: 5px 1px;
+  box-shadow: 2px 1px 5px rgba(107, 214, 66, 0.6);
+  transform: rotate(257deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box618 {
+  --cssA-v-618: 893942;
+  color: hsl(186, 34%, 56%);
+  background-color: hsl(6, 34%, 44%);
+  border: 4px solid hsl(276, 50%, 50%);
+  margin: 18px 24px 15px 6px;
+  padding: 3px 4px;
+  border-radius: 6px 3px;
+  box-shadow: 3px 2px 6px rgba(108, 216, 69, 0.7);
+  transform: rotate(258deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box619 {
+  --cssA-v-619: 901861;
+  color: hsl(223, 47%, 63%);
+  background-color: hsl(43, 47%, 37%);
+  border: 5px solid hsl(313, 50%, 50%);
+  margin: 19px 27px 20px 13px;
+  padding: 4px 6px;
+  border-radius: 7px 5px;
+  box-shadow: 4px 3px 7px rgba(109, 218, 72, 0.8);
+  transform: rotate(259deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box620 {
+  --cssA-v-620: 909780;
+  color: hsl(260, 60%, 70%);
+  background-color: hsl(80, 60%, 30%);
+  border: 1px solid hsl(350, 50%, 50%);
+  margin: 0px 0px 0px 2px;
+  padding: 5px 8px;
+  border-radius: 8px 7px;
+  box-shadow: 0px 4px 8px rgba(110, 220, 75, 0.9);
+  transform: rotate(260deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box621 {
+  --cssA-v-621: 917699;
+  color: hsl(297, 73%, 77%);
+  background-color: hsl(117, 73%, 23%);
+  border: 2px solid hsl(27, 50%, 50%);
+  margin: 1px 3px 5px 9px;
+  padding: 6px 10px;
+  border-radius: 9px 0px;
+  box-shadow: 1px 5px 0px rgba(111, 222, 78, 0.1);
+  transform: rotate(261deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box622 {
+  --cssA-v-622: 925618;
+  color: hsl(334, 86%, 34%);
+  background-color: hsl(154, 86%, 66%);
+  border: 3px solid hsl(64, 50%, 50%);
+  margin: 2px 6px 10px 16px;
+  padding: 7px 12px;
+  border-radius: 10px 2px;
+  box-shadow: 2px 6px 1px rgba(112, 224, 81, 0.2);
+  transform: rotate(262deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box623 {
+  --cssA-v-623: 933537;
+  color: hsl(11, 99%, 41%);
+  background-color: hsl(191, 99%, 59%);
+  border: 4px solid hsl(101, 50%, 50%);
+  margin: 3px 9px 15px 5px;
+  padding: 8px 14px;
+  border-radius: 11px 4px;
+  box-shadow: 3px 0px 2px rgba(113, 226, 84, 0.3);
+  transform: rotate(263deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box624 {
+  --cssA-v-624: 941456;
+  color: hsl(48, 12%, 48%);
+  background-color: hsl(228, 12%, 52%);
+  border: 5px solid hsl(138, 50%, 50%);
+  margin: 4px 12px 20px 12px;
+  padding: 9px 16px;
+  border-radius: 0px 6px;
+  box-shadow: 4px 1px 3px rgba(114, 228, 87, 0.4);
+  transform: rotate(264deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box625 {
+  --cssA-v-625: 949375;
+  color: hsl(85, 25%, 55%);
+  background-color: hsl(265, 25%, 45%);
+  border: 1px solid hsl(175, 50%, 50%);
+  margin: 5px 15px 0px 1px;
+  padding: 10px 18px;
+  border-radius: 1px 8px;
+  box-shadow: 0px 2px 4px rgba(115, 230, 90, 0.5);
+  transform: rotate(265deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box626 {
+  --cssA-v-626: 957294;
+  color: hsl(122, 38%, 62%);
+  background-color: hsl(302, 38%, 38%);
+  border: 2px solid hsl(212, 50%, 50%);
+  margin: 6px 18px 5px 8px;
+  padding: 11px 20px;
+  border-radius: 2px 1px;
+  box-shadow: 1px 3px 5px rgba(116, 232, 93, 0.6);
+  transform: rotate(266deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box627 {
+  --cssA-v-627: 965213;
+  color: hsl(159, 51%, 69%);
+  background-color: hsl(339, 51%, 31%);
+  border: 3px solid hsl(249, 50%, 50%);
+  margin: 7px 21px 10px 15px;
+  padding: 12px 0px;
+  border-radius: 3px 3px;
+  box-shadow: 2px 4px 6px rgba(117, 234, 96, 0.7);
+  transform: rotate(267deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box628 {
+  --cssA-v-628: 973132;
+  color: hsl(196, 64%, 76%);
+  background-color: hsl(16, 64%, 24%);
+  border: 4px solid hsl(286, 50%, 50%);
+  margin: 8px 24px 15px 4px;
+  padding: 13px 2px;
+  border-radius: 4px 5px;
+  box-shadow: 3px 5px 7px rgba(118, 236, 99, 0.8);
+  transform: rotate(268deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box629 {
+  --cssA-v-629: 981051;
+  color: hsl(233, 77%, 33%);
+  background-color: hsl(53, 77%, 67%);
+  border: 5px solid hsl(323, 50%, 50%);
+  margin: 9px 27px 20px 11px;
+  padding: 14px 4px;
+  border-radius: 5px 7px;
+  box-shadow: 4px 6px 8px rgba(119, 238, 102, 0.9);
+  transform: rotate(269deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box630 {
+  --cssA-v-630: 988970;
+  color: hsl(270, 90%, 40%);
+  background-color: hsl(90, 90%, 60%);
+  border: 1px solid hsl(0, 50%, 50%);
+  margin: 10px 0px 0px 0px;
+  padding: 0px 6px;
+  border-radius: 6px 0px;
+  box-shadow: 0px 0px 0px rgba(120, 240, 105, 0.1);
+  transform: rotate(270deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box631 {
+  --cssA-v-631: 996889;
+  color: hsl(307, 3%, 47%);
+  background-color: hsl(127, 3%, 53%);
+  border: 2px solid hsl(37, 50%, 50%);
+  margin: 11px 3px 5px 7px;
+  padding: 1px 8px;
+  border-radius: 7px 2px;
+  box-shadow: 1px 1px 1px rgba(121, 242, 108, 0.2);
+  transform: rotate(271deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box632 {
+  --cssA-v-632: 4808;
+  color: hsl(344, 16%, 54%);
+  background-color: hsl(164, 16%, 46%);
+  border: 3px solid hsl(74, 50%, 50%);
+  margin: 12px 6px 10px 14px;
+  padding: 2px 10px;
+  border-radius: 8px 4px;
+  box-shadow: 2px 2px 2px rgba(122, 244, 111, 0.3);
+  transform: rotate(272deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box633 {
+  --cssA-v-633: 12727;
+  color: hsl(21, 29%, 61%);
+  background-color: hsl(201, 29%, 39%);
+  border: 4px solid hsl(111, 50%, 50%);
+  margin: 13px 9px 15px 3px;
+  padding: 3px 12px;
+  border-radius: 9px 6px;
+  box-shadow: 3px 3px 3px rgba(123, 246, 114, 0.4);
+  transform: rotate(273deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box634 {
+  --cssA-v-634: 20646;
+  color: hsl(58, 42%, 68%);
+  background-color: hsl(238, 42%, 32%);
+  border: 5px solid hsl(148, 50%, 50%);
+  margin: 14px 12px 20px 10px;
+  padding: 4px 14px;
+  border-radius: 10px 8px;
+  box-shadow: 4px 4px 4px rgba(124, 248, 117, 0.5);
+  transform: rotate(274deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box635 {
+  --cssA-v-635: 28565;
+  color: hsl(95, 55%, 75%);
+  background-color: hsl(275, 55%, 25%);
+  border: 1px solid hsl(185, 50%, 50%);
+  margin: 15px 15px 0px 17px;
+  padding: 5px 16px;
+  border-radius: 11px 1px;
+  box-shadow: 0px 5px 5px rgba(125, 250, 120, 0.6);
+  transform: rotate(275deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box636 {
+  --cssA-v-636: 36484;
+  color: hsl(132, 68%, 32%);
+  background-color: hsl(312, 68%, 68%);
+  border: 2px solid hsl(222, 50%, 50%);
+  margin: 16px 18px 5px 6px;
+  padding: 6px 18px;
+  border-radius: 0px 3px;
+  box-shadow: 1px 6px 6px rgba(126, 252, 123, 0.7);
+  transform: rotate(276deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box637 {
+  --cssA-v-637: 44403;
+  color: hsl(169, 81%, 39%);
+  background-color: hsl(349, 81%, 61%);
+  border: 3px solid hsl(259, 50%, 50%);
+  margin: 17px 21px 10px 13px;
+  padding: 7px 20px;
+  border-radius: 1px 5px;
+  box-shadow: 2px 0px 7px rgba(127, 254, 126, 0.8);
+  transform: rotate(277deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box638 {
+  --cssA-v-638: 52322;
+  color: hsl(206, 94%, 46%);
+  background-color: hsl(26, 94%, 54%);
+  border: 4px solid hsl(296, 50%, 50%);
+  margin: 18px 24px 15px 2px;
+  padding: 8px 0px;
+  border-radius: 2px 7px;
+  box-shadow: 3px 1px 8px rgba(128, 1, 129, 0.9);
+  transform: rotate(278deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box639 {
+  --cssA-v-639: 60241;
+  color: hsl(243, 7%, 53%);
+  background-color: hsl(63, 7%, 47%);
+  border: 5px solid hsl(333, 50%, 50%);
+  margin: 19px 27px 20px 9px;
+  padding: 9px 2px;
+  border-radius: 3px 0px;
+  box-shadow: 4px 2px 0px rgba(129, 3, 132, 0.1);
+  transform: rotate(279deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box640 {
+  --cssA-v-640: 68160;
+  color: hsl(280, 20%, 60%);
+  background-color: hsl(100, 20%, 40%);
+  border: 1px solid hsl(10, 50%, 50%);
+  margin: 0px 0px 0px 16px;
+  padding: 10px 4px;
+  border-radius: 4px 2px;
+  box-shadow: 0px 3px 1px rgba(130, 5, 135, 0.2);
+  transform: rotate(280deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box641 {
+  --cssA-v-641: 76079;
+  color: hsl(317, 33%, 67%);
+  background-color: hsl(137, 33%, 33%);
+  border: 2px solid hsl(47, 50%, 50%);
+  margin: 1px 3px 5px 5px;
+  padding: 11px 6px;
+  border-radius: 5px 4px;
+  box-shadow: 1px 4px 2px rgba(131, 7, 138, 0.3);
+  transform: rotate(281deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box642 {
+  --cssA-v-642: 83998;
+  color: hsl(354, 46%, 74%);
+  background-color: hsl(174, 46%, 26%);
+  border: 3px solid hsl(84, 50%, 50%);
+  margin: 2px 6px 10px 12px;
+  padding: 12px 8px;
+  border-radius: 6px 6px;
+  box-shadow: 2px 5px 3px rgba(132, 9, 141, 0.4);
+  transform: rotate(282deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box643 {
+  --cssA-v-643: 91917;
+  color: hsl(31, 59%, 31%);
+  background-color: hsl(211, 59%, 69%);
+  border: 4px solid hsl(121, 50%, 50%);
+  margin: 3px 9px 15px 1px;
+  padding: 13px 10px;
+  border-radius: 7px 8px;
+  box-shadow: 3px 6px 4px rgba(133, 11, 144, 0.5);
+  transform: rotate(283deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box644 {
+  --cssA-v-644: 99836;
+  color: hsl(68, 72%, 38%);
+  background-color: hsl(248, 72%, 62%);
+  border: 5px solid hsl(158, 50%, 50%);
+  margin: 4px 12px 20px 8px;
+  padding: 14px 12px;
+  border-radius: 8px 1px;
+  box-shadow: 4px 0px 5px rgba(134, 13, 147, 0.6);
+  transform: rotate(284deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box645 {
+  --cssA-v-645: 107755;
+  color: hsl(105, 85%, 45%);
+  background-color: hsl(285, 85%, 55%);
+  border: 1px solid hsl(195, 50%, 50%);
+  margin: 5px 15px 0px 15px;
+  padding: 0px 14px;
+  border-radius: 9px 3px;
+  box-shadow: 0px 1px 6px rgba(135, 15, 150, 0.7);
+  transform: rotate(285deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box646 {
+  --cssA-v-646: 115674;
+  color: hsl(142, 98%, 52%);
+  background-color: hsl(322, 98%, 48%);
+  border: 2px solid hsl(232, 50%, 50%);
+  margin: 6px 18px 5px 4px;
+  padding: 1px 16px;
+  border-radius: 10px 5px;
+  box-shadow: 1px 2px 7px rgba(136, 17, 153, 0.8);
+  transform: rotate(286deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box647 {
+  --cssA-v-647: 123593;
+  color: hsl(179, 11%, 59%);
+  background-color: hsl(359, 11%, 41%);
+  border: 3px solid hsl(269, 50%, 50%);
+  margin: 7px 21px 10px 11px;
+  padding: 2px 18px;
+  border-radius: 11px 7px;
+  box-shadow: 2px 3px 8px rgba(137, 19, 156, 0.9);
+  transform: rotate(287deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box648 {
+  --cssA-v-648: 131512;
+  color: hsl(216, 24%, 66%);
+  background-color: hsl(36, 24%, 34%);
+  border: 4px solid hsl(306, 50%, 50%);
+  margin: 8px 24px 15px 0px;
+  padding: 3px 20px;
+  border-radius: 0px 0px;
+  box-shadow: 3px 4px 0px rgba(138, 21, 159, 0.1);
+  transform: rotate(288deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box649 {
+  --cssA-v-649: 139431;
+  color: hsl(253, 37%, 73%);
+  background-color: hsl(73, 37%, 27%);
+  border: 5px solid hsl(343, 50%, 50%);
+  margin: 9px 27px 20px 7px;
+  padding: 4px 0px;
+  border-radius: 1px 2px;
+  box-shadow: 4px 5px 1px rgba(139, 23, 162, 0.2);
+  transform: rotate(289deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box650 {
+  --cssA-v-650: 147350;
+  color: hsl(290, 50%, 30%);
+  background-color: hsl(110, 50%, 70%);
+  border: 1px solid hsl(20, 50%, 50%);
+  margin: 10px 0px 0px 14px;
+  padding: 5px 2px;
+  border-radius: 2px 4px;
+  box-shadow: 0px 6px 2px rgba(140, 25, 165, 0.3);
+  transform: rotate(290deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box651 {
+  --cssA-v-651: 155269;
+  color: hsl(327, 63%, 37%);
+  background-color: hsl(147, 63%, 63%);
+  border: 2px solid hsl(57, 50%, 50%);
+  margin: 11px 3px 5px 3px;
+  padding: 6px 4px;
+  border-radius: 3px 6px;
+  box-shadow: 1px 0px 3px rgba(141, 27, 168, 0.4);
+  transform: rotate(291deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box652 {
+  --cssA-v-652: 163188;
+  color: hsl(4, 76%, 44%);
+  background-color: hsl(184, 76%, 56%);
+  border: 3px solid hsl(94, 50%, 50%);
+  margin: 12px 6px 10px 10px;
+  padding: 7px 6px;
+  border-radius: 4px 8px;
+  box-shadow: 2px 1px 4px rgba(142, 29, 171, 0.5);
+  transform: rotate(292deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box653 {
+  --cssA-v-653: 171107;
+  color: hsl(41, 89%, 51%);
+  background-color: hsl(221, 89%, 49%);
+  border: 4px solid hsl(131, 50%, 50%);
+  margin: 13px 9px 15px 17px;
+  padding: 8px 8px;
+  border-radius: 5px 1px;
+  box-shadow: 3px 2px 5px rgba(143, 31, 174, 0.6);
+  transform: rotate(293deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box654 {
+  --cssA-v-654: 179026;
+  color: hsl(78, 2%, 58%);
+  background-color: hsl(258, 2%, 42%);
+  border: 5px solid hsl(168, 50%, 50%);
+  margin: 14px 12px 20px 6px;
+  padding: 9px 10px;
+  border-radius: 6px 3px;
+  box-shadow: 4px 3px 6px rgba(144, 33, 177, 0.7);
+  transform: rotate(294deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box655 {
+  --cssA-v-655: 186945;
+  color: hsl(115, 15%, 65%);
+  background-color: hsl(295, 15%, 35%);
+  border: 1px solid hsl(205, 50%, 50%);
+  margin: 15px 15px 0px 13px;
+  padding: 10px 12px;
+  border-radius: 7px 5px;
+  box-shadow: 0px 4px 7px rgba(145, 35, 180, 0.8);
+  transform: rotate(295deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box656 {
+  --cssA-v-656: 194864;
+  color: hsl(152, 28%, 72%);
+  background-color: hsl(332, 28%, 28%);
+  border: 2px solid hsl(242, 50%, 50%);
+  margin: 16px 18px 5px 2px;
+  padding: 11px 14px;
+  border-radius: 8px 7px;
+  box-shadow: 1px 5px 8px rgba(146, 37, 183, 0.9);
+  transform: rotate(296deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box657 {
+  --cssA-v-657: 202783;
+  color: hsl(189, 41%, 79%);
+  background-color: hsl(9, 41%, 21%);
+  border: 3px solid hsl(279, 50%, 50%);
+  margin: 17px 21px 10px 9px;
+  padding: 12px 16px;
+  border-radius: 9px 0px;
+  box-shadow: 2px 6px 0px rgba(147, 39, 186, 0.1);
+  transform: rotate(297deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box658 {
+  --cssA-v-658: 210702;
+  color: hsl(226, 54%, 36%);
+  background-color: hsl(46, 54%, 64%);
+  border: 4px solid hsl(316, 50%, 50%);
+  margin: 18px 24px 15px 16px;
+  padding: 13px 18px;
+  border-radius: 10px 2px;
+  box-shadow: 3px 0px 1px rgba(148, 41, 189, 0.2);
+  transform: rotate(298deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box659 {
+  --cssA-v-659: 218621;
+  color: hsl(263, 67%, 43%);
+  background-color: hsl(83, 67%, 57%);
+  border: 5px solid hsl(353, 50%, 50%);
+  margin: 19px 27px 20px 5px;
+  padding: 14px 20px;
+  border-radius: 11px 4px;
+  box-shadow: 4px 1px 2px rgba(149, 43, 192, 0.3);
+  transform: rotate(299deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box660 {
+  --cssA-v-660: 226540;
+  color: hsl(300, 80%, 50%);
+  background-color: hsl(120, 80%, 50%);
+  border: 1px solid hsl(30, 50%, 50%);
+  margin: 0px 0px 0px 12px;
+  padding: 0px 0px;
+  border-radius: 0px 6px;
+  box-shadow: 0px 2px 3px rgba(150, 45, 195, 0.4);
+  transform: rotate(300deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box661 {
+  --cssA-v-661: 234459;
+  color: hsl(337, 93%, 57%);
+  background-color: hsl(157, 93%, 43%);
+  border: 2px solid hsl(67, 50%, 50%);
+  margin: 1px 3px 5px 1px;
+  padding: 1px 2px;
+  border-radius: 1px 8px;
+  box-shadow: 1px 3px 4px rgba(151, 47, 198, 0.5);
+  transform: rotate(301deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box662 {
+  --cssA-v-662: 242378;
+  color: hsl(14, 6%, 64%);
+  background-color: hsl(194, 6%, 36%);
+  border: 3px solid hsl(104, 50%, 50%);
+  margin: 2px 6px 10px 8px;
+  padding: 2px 4px;
+  border-radius: 2px 1px;
+  box-shadow: 2px 4px 5px rgba(152, 49, 201, 0.6);
+  transform: rotate(302deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box663 {
+  --cssA-v-663: 250297;
+  color: hsl(51, 19%, 71%);
+  background-color: hsl(231, 19%, 29%);
+  border: 4px solid hsl(141, 50%, 50%);
+  margin: 3px 9px 15px 15px;
+  padding: 3px 6px;
+  border-radius: 3px 3px;
+  box-shadow: 3px 5px 6px rgba(153, 51, 204, 0.7);
+  transform: rotate(303deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box664 {
+  --cssA-v-664: 258216;
+  color: hsl(88, 32%, 78%);
+  background-color: hsl(268, 32%, 22%);
+  border: 5px solid hsl(178, 50%, 50%);
+  margin: 4px 12px 20px 4px;
+  padding: 4px 8px;
+  border-radius: 4px 5px;
+  box-shadow: 4px 6px 7px rgba(154, 53, 207, 0.8);
+  transform: rotate(304deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box665 {
+  --cssA-v-665: 266135;
+  color: hsl(125, 45%, 35%);
+  background-color: hsl(305, 45%, 65%);
+  border: 1px solid hsl(215, 50%, 50%);
+  margin: 5px 15px 0px 11px;
+  padding: 5px 10px;
+  border-radius: 5px 7px;
+  box-shadow: 0px 0px 8px rgba(155, 55, 210, 0.9);
+  transform: rotate(305deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box666 {
+  --cssA-v-666: 274054;
+  color: hsl(162, 58%, 42%);
+  background-color: hsl(342, 58%, 58%);
+  border: 2px solid hsl(252, 50%, 50%);
+  margin: 6px 18px 5px 0px;
+  padding: 6px 12px;
+  border-radius: 6px 0px;
+  box-shadow: 1px 1px 0px rgba(156, 57, 213, 0.1);
+  transform: rotate(306deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box667 {
+  --cssA-v-667: 281973;
+  color: hsl(199, 71%, 49%);
+  background-color: hsl(19, 71%, 51%);
+  border: 3px solid hsl(289, 50%, 50%);
+  margin: 7px 21px 10px 7px;
+  padding: 7px 14px;
+  border-radius: 7px 2px;
+  box-shadow: 2px 2px 1px rgba(157, 59, 216, 0.2);
+  transform: rotate(307deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box668 {
+  --cssA-v-668: 289892;
+  color: hsl(236, 84%, 56%);
+  background-color: hsl(56, 84%, 44%);
+  border: 4px solid hsl(326, 50%, 50%);
+  margin: 8px 24px 15px 14px;
+  padding: 8px 16px;
+  border-radius: 8px 4px;
+  box-shadow: 3px 3px 2px rgba(158, 61, 219, 0.3);
+  transform: rotate(308deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box669 {
+  --cssA-v-669: 297811;
+  color: hsl(273, 97%, 63%);
+  background-color: hsl(93, 97%, 37%);
+  border: 5px solid hsl(3, 50%, 50%);
+  margin: 9px 27px 20px 3px;
+  padding: 9px 18px;
+  border-radius: 9px 6px;
+  box-shadow: 4px 4px 3px rgba(159, 63, 222, 0.4);
+  transform: rotate(309deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box670 {
+  --cssA-v-670: 305730;
+  color: hsl(310, 10%, 70%);
+  background-color: hsl(130, 10%, 30%);
+  border: 1px solid hsl(40, 50%, 50%);
+  margin: 10px 0px 0px 10px;
+  padding: 10px 20px;
+  border-radius: 10px 8px;
+  box-shadow: 0px 5px 4px rgba(160, 65, 225, 0.5);
+  transform: rotate(310deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box671 {
+  --cssA-v-671: 313649;
+  color: hsl(347, 23%, 77%);
+  background-color: hsl(167, 23%, 23%);
+  border: 2px solid hsl(77, 50%, 50%);
+  margin: 11px 3px 5px 17px;
+  padding: 11px 0px;
+  border-radius: 11px 1px;
+  box-shadow: 1px 6px 5px rgba(161, 67, 228, 0.6);
+  transform: rotate(311deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box672 {
+  --cssA-v-672: 321568;
+  color: hsl(24, 36%, 34%);
+  background-color: hsl(204, 36%, 66%);
+  border: 3px solid hsl(114, 50%, 50%);
+  margin: 12px 6px 10px 6px;
+  padding: 12px 2px;
+  border-radius: 0px 3px;
+  box-shadow: 2px 0px 6px rgba(162, 69, 231, 0.7);
+  transform: rotate(312deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box673 {
+  --cssA-v-673: 329487;
+  color: hsl(61, 49%, 41%);
+  background-color: hsl(241, 49%, 59%);
+  border: 4px solid hsl(151, 50%, 50%);
+  margin: 13px 9px 15px 13px;
+  padding: 13px 4px;
+  border-radius: 1px 5px;
+  box-shadow: 3px 1px 7px rgba(163, 71, 234, 0.8);
+  transform: rotate(313deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box674 {
+  --cssA-v-674: 337406;
+  color: hsl(98, 62%, 48%);
+  background-color: hsl(278, 62%, 52%);
+  border: 5px solid hsl(188, 50%, 50%);
+  margin: 14px 12px 20px 2px;
+  padding: 14px 6px;
+  border-radius: 2px 7px;
+  box-shadow: 4px 2px 8px rgba(164, 73, 237, 0.9);
+  transform: rotate(314deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box675 {
+  --cssA-v-675: 345325;
+  color: hsl(135, 75%, 55%);
+  background-color: hsl(315, 75%, 45%);
+  border: 1px solid hsl(225, 50%, 50%);
+  margin: 15px 15px 0px 9px;
+  padding: 0px 8px;
+  border-radius: 3px 0px;
+  box-shadow: 0px 3px 0px rgba(165, 75, 240, 0.1);
+  transform: rotate(315deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box676 {
+  --cssA-v-676: 353244;
+  color: hsl(172, 88%, 62%);
+  background-color: hsl(352, 88%, 38%);
+  border: 2px solid hsl(262, 50%, 50%);
+  margin: 16px 18px 5px 16px;
+  padding: 1px 10px;
+  border-radius: 4px 2px;
+  box-shadow: 1px 4px 1px rgba(166, 77, 243, 0.2);
+  transform: rotate(316deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box677 {
+  --cssA-v-677: 361163;
+  color: hsl(209, 1%, 69%);
+  background-color: hsl(29, 1%, 31%);
+  border: 3px solid hsl(299, 50%, 50%);
+  margin: 17px 21px 10px 5px;
+  padding: 2px 12px;
+  border-radius: 5px 4px;
+  box-shadow: 2px 5px 2px rgba(167, 79, 246, 0.3);
+  transform: rotate(317deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box678 {
+  --cssA-v-678: 369082;
+  color: hsl(246, 14%, 76%);
+  background-color: hsl(66, 14%, 24%);
+  border: 4px solid hsl(336, 50%, 50%);
+  margin: 18px 24px 15px 12px;
+  padding: 3px 14px;
+  border-radius: 6px 6px;
+  box-shadow: 3px 6px 3px rgba(168, 81, 249, 0.4);
+  transform: rotate(318deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box679 {
+  --cssA-v-679: 377001;
+  color: hsl(283, 27%, 33%);
+  background-color: hsl(103, 27%, 67%);
+  border: 5px solid hsl(13, 50%, 50%);
+  margin: 19px 27px 20px 1px;
+  padding: 4px 16px;
+  border-radius: 7px 8px;
+  box-shadow: 4px 0px 4px rgba(169, 83, 252, 0.5);
+  transform: rotate(319deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box680 {
+  --cssA-v-680: 384920;
+  color: hsl(320, 40%, 40%);
+  background-color: hsl(140, 40%, 60%);
+  border: 1px solid hsl(50, 50%, 50%);
+  margin: 0px 0px 0px 8px;
+  padding: 5px 18px;
+  border-radius: 8px 1px;
+  box-shadow: 0px 1px 5px rgba(170, 85, 0, 0.6);
+  transform: rotate(320deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box681 {
+  --cssA-v-681: 392839;
+  color: hsl(357, 53%, 47%);
+  background-color: hsl(177, 53%, 53%);
+  border: 2px solid hsl(87, 50%, 50%);
+  margin: 1px 3px 5px 15px;
+  padding: 6px 20px;
+  border-radius: 9px 3px;
+  box-shadow: 1px 2px 6px rgba(171, 87, 3, 0.7);
+  transform: rotate(321deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box682 {
+  --cssA-v-682: 400758;
+  color: hsl(34, 66%, 54%);
+  background-color: hsl(214, 66%, 46%);
+  border: 3px solid hsl(124, 50%, 50%);
+  margin: 2px 6px 10px 4px;
+  padding: 7px 0px;
+  border-radius: 10px 5px;
+  box-shadow: 2px 3px 7px rgba(172, 89, 6, 0.8);
+  transform: rotate(322deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box683 {
+  --cssA-v-683: 408677;
+  color: hsl(71, 79%, 61%);
+  background-color: hsl(251, 79%, 39%);
+  border: 4px solid hsl(161, 50%, 50%);
+  margin: 3px 9px 15px 11px;
+  padding: 8px 2px;
+  border-radius: 11px 7px;
+  box-shadow: 3px 4px 8px rgba(173, 91, 9, 0.9);
+  transform: rotate(323deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box684 {
+  --cssA-v-684: 416596;
+  color: hsl(108, 92%, 68%);
+  background-color: hsl(288, 92%, 32%);
+  border: 5px solid hsl(198, 50%, 50%);
+  margin: 4px 12px 20px 0px;
+  padding: 9px 4px;
+  border-radius: 0px 0px;
+  box-shadow: 4px 5px 0px rgba(174, 93, 12, 0.1);
+  transform: rotate(324deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box685 {
+  --cssA-v-685: 424515;
+  color: hsl(145, 5%, 75%);
+  background-color: hsl(325, 5%, 25%);
+  border: 1px solid hsl(235, 50%, 50%);
+  margin: 5px 15px 0px 7px;
+  padding: 10px 6px;
+  border-radius: 1px 2px;
+  box-shadow: 0px 6px 1px rgba(175, 95, 15, 0.2);
+  transform: rotate(325deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box686 {
+  --cssA-v-686: 432434;
+  color: hsl(182, 18%, 32%);
+  background-color: hsl(2, 18%, 68%);
+  border: 2px solid hsl(272, 50%, 50%);
+  margin: 6px 18px 5px 14px;
+  padding: 11px 8px;
+  border-radius: 2px 4px;
+  box-shadow: 1px 0px 2px rgba(176, 97, 18, 0.3);
+  transform: rotate(326deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box687 {
+  --cssA-v-687: 440353;
+  color: hsl(219, 31%, 39%);
+  background-color: hsl(39, 31%, 61%);
+  border: 3px solid hsl(309, 50%, 50%);
+  margin: 7px 21px 10px 3px;
+  padding: 12px 10px;
+  border-radius: 3px 6px;
+  box-shadow: 2px 1px 3px rgba(177, 99, 21, 0.4);
+  transform: rotate(327deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box688 {
+  --cssA-v-688: 448272;
+  color: hsl(256, 44%, 46%);
+  background-color: hsl(76, 44%, 54%);
+  border: 4px solid hsl(346, 50%, 50%);
+  margin: 8px 24px 15px 10px;
+  padding: 13px 12px;
+  border-radius: 4px 8px;
+  box-shadow: 3px 2px 4px rgba(178, 101, 24, 0.5);
+  transform: rotate(328deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box689 {
+  --cssA-v-689: 456191;
+  color: hsl(293, 57%, 53%);
+  background-color: hsl(113, 57%, 47%);
+  border: 5px solid hsl(23, 50%, 50%);
+  margin: 9px 27px 20px 17px;
+  padding: 14px 14px;
+  border-radius: 5px 1px;
+  box-shadow: 4px 3px 5px rgba(179, 103, 27, 0.6);
+  transform: rotate(329deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box690 {
+  --cssA-v-690: 464110;
+  color: hsl(330, 70%, 60%);
+  background-color: hsl(150, 70%, 40%);
+  border: 1px solid hsl(60, 50%, 50%);
+  margin: 10px 0px 0px 6px;
+  padding: 0px 16px;
+  border-radius: 6px 3px;
+  box-shadow: 0px 4px 6px rgba(180, 105, 30, 0.7);
+  transform: rotate(330deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box691 {
+  --cssA-v-691: 472029;
+  color: hsl(7, 83%, 67%);
+  background-color: hsl(187, 83%, 33%);
+  border: 2px solid hsl(97, 50%, 50%);
+  margin: 11px 3px 5px 13px;
+  padding: 1px 18px;
+  border-radius: 7px 5px;
+  box-shadow: 1px 5px 7px rgba(181, 107, 33, 0.8);
+  transform: rotate(331deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box692 {
+  --cssA-v-692: 479948;
+  color: hsl(44, 96%, 74%);
+  background-color: hsl(224, 96%, 26%);
+  border: 3px solid hsl(134, 50%, 50%);
+  margin: 12px 6px 10px 2px;
+  padding: 2px 20px;
+  border-radius: 8px 7px;
+  box-shadow: 2px 6px 8px rgba(182, 109, 36, 0.9);
+  transform: rotate(332deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box693 {
+  --cssA-v-693: 487867;
+  color: hsl(81, 9%, 31%);
+  background-color: hsl(261, 9%, 69%);
+  border: 4px solid hsl(171, 50%, 50%);
+  margin: 13px 9px 15px 9px;
+  padding: 3px 0px;
+  border-radius: 9px 0px;
+  box-shadow: 3px 0px 0px rgba(183, 111, 39, 0.1);
+  transform: rotate(333deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box694 {
+  --cssA-v-694: 495786;
+  color: hsl(118, 22%, 38%);
+  background-color: hsl(298, 22%, 62%);
+  border: 5px solid hsl(208, 50%, 50%);
+  margin: 14px 12px 20px 16px;
+  padding: 4px 2px;
+  border-radius: 10px 2px;
+  box-shadow: 4px 1px 1px rgba(184, 113, 42, 0.2);
+  transform: rotate(334deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box695 {
+  --cssA-v-695: 503705;
+  color: hsl(155, 35%, 45%);
+  background-color: hsl(335, 35%, 55%);
+  border: 1px solid hsl(245, 50%, 50%);
+  margin: 15px 15px 0px 5px;
+  padding: 5px 4px;
+  border-radius: 11px 4px;
+  box-shadow: 0px 2px 2px rgba(185, 115, 45, 0.3);
+  transform: rotate(335deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box696 {
+  --cssA-v-696: 511624;
+  color: hsl(192, 48%, 52%);
+  background-color: hsl(12, 48%, 48%);
+  border: 2px solid hsl(282, 50%, 50%);
+  margin: 16px 18px 5px 12px;
+  padding: 6px 6px;
+  border-radius: 0px 6px;
+  box-shadow: 1px 3px 3px rgba(186, 117, 48, 0.4);
+  transform: rotate(336deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box697 {
+  --cssA-v-697: 519543;
+  color: hsl(229, 61%, 59%);
+  background-color: hsl(49, 61%, 41%);
+  border: 3px solid hsl(319, 50%, 50%);
+  margin: 17px 21px 10px 1px;
+  padding: 7px 8px;
+  border-radius: 1px 8px;
+  box-shadow: 2px 4px 4px rgba(187, 119, 51, 0.5);
+  transform: rotate(337deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box698 {
+  --cssA-v-698: 527462;
+  color: hsl(266, 74%, 66%);
+  background-color: hsl(86, 74%, 34%);
+  border: 4px solid hsl(356, 50%, 50%);
+  margin: 18px 24px 15px 8px;
+  padding: 8px 10px;
+  border-radius: 2px 1px;
+  box-shadow: 3px 5px 5px rgba(188, 121, 54, 0.6);
+  transform: rotate(338deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box699 {
+  --cssA-v-699: 535381;
+  color: hsl(303, 87%, 73%);
+  background-color: hsl(123, 87%, 27%);
+  border: 5px solid hsl(33, 50%, 50%);
+  margin: 19px 27px 20px 15px;
+  padding: 9px 12px;
+  border-radius: 3px 3px;
+  box-shadow: 4px 6px 6px rgba(189, 123, 57, 0.7);
+  transform: rotate(339deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box700 {
+  --cssA-v-700: 543300;
+  color: hsl(340, 0%, 30%);
+  background-color: hsl(160, 0%, 70%);
+  border: 1px solid hsl(70, 50%, 50%);
+  margin: 0px 0px 0px 4px;
+  padding: 10px 14px;
+  border-radius: 4px 5px;
+  box-shadow: 0px 0px 7px rgba(190, 125, 60, 0.8);
+  transform: rotate(340deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box701 {
+  --cssA-v-701: 551219;
+  color: hsl(17, 13%, 37%);
+  background-color: hsl(197, 13%, 63%);
+  border: 2px solid hsl(107, 50%, 50%);
+  margin: 1px 3px 5px 11px;
+  padding: 11px 16px;
+  border-radius: 5px 7px;
+  box-shadow: 1px 1px 8px rgba(191, 127, 63, 0.9);
+  transform: rotate(341deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box702 {
+  --cssA-v-702: 559138;
+  color: hsl(54, 26%, 44%);
+  background-color: hsl(234, 26%, 56%);
+  border: 3px solid hsl(144, 50%, 50%);
+  margin: 2px 6px 10px 0px;
+  padding: 12px 18px;
+  border-radius: 6px 0px;
+  box-shadow: 2px 2px 0px rgba(192, 129, 66, 0.1);
+  transform: rotate(342deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box703 {
+  --cssA-v-703: 567057;
+  color: hsl(91, 39%, 51%);
+  background-color: hsl(271, 39%, 49%);
+  border: 4px solid hsl(181, 50%, 50%);
+  margin: 3px 9px 15px 7px;
+  padding: 13px 20px;
+  border-radius: 7px 2px;
+  box-shadow: 3px 3px 1px rgba(193, 131, 69, 0.2);
+  transform: rotate(343deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box704 {
+  --cssA-v-704: 574976;
+  color: hsl(128, 52%, 58%);
+  background-color: hsl(308, 52%, 42%);
+  border: 5px solid hsl(218, 50%, 50%);
+  margin: 4px 12px 20px 14px;
+  padding: 14px 0px;
+  border-radius: 8px 4px;
+  box-shadow: 4px 4px 2px rgba(194, 133, 72, 0.3);
+  transform: rotate(344deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box705 {
+  --cssA-v-705: 582895;
+  color: hsl(165, 65%, 65%);
+  background-color: hsl(345, 65%, 35%);
+  border: 1px solid hsl(255, 50%, 50%);
+  margin: 5px 15px 0px 3px;
+  padding: 0px 2px;
+  border-radius: 9px 6px;
+  box-shadow: 0px 5px 3px rgba(195, 135, 75, 0.4);
+  transform: rotate(345deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box706 {
+  --cssA-v-706: 590814;
+  color: hsl(202, 78%, 72%);
+  background-color: hsl(22, 78%, 28%);
+  border: 2px solid hsl(292, 50%, 50%);
+  margin: 6px 18px 5px 10px;
+  padding: 1px 4px;
+  border-radius: 10px 8px;
+  box-shadow: 1px 6px 4px rgba(196, 137, 78, 0.5);
+  transform: rotate(346deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box707 {
+  --cssA-v-707: 598733;
+  color: hsl(239, 91%, 79%);
+  background-color: hsl(59, 91%, 21%);
+  border: 3px solid hsl(329, 50%, 50%);
+  margin: 7px 21px 10px 17px;
+  padding: 2px 6px;
+  border-radius: 11px 1px;
+  box-shadow: 2px 0px 5px rgba(197, 139, 81, 0.6);
+  transform: rotate(347deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box708 {
+  --cssA-v-708: 606652;
+  color: hsl(276, 4%, 36%);
+  background-color: hsl(96, 4%, 64%);
+  border: 4px solid hsl(6, 50%, 50%);
+  margin: 8px 24px 15px 6px;
+  padding: 3px 8px;
+  border-radius: 0px 3px;
+  box-shadow: 3px 1px 6px rgba(198, 141, 84, 0.7);
+  transform: rotate(348deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box709 {
+  --cssA-v-709: 614571;
+  color: hsl(313, 17%, 43%);
+  background-color: hsl(133, 17%, 57%);
+  border: 5px solid hsl(43, 50%, 50%);
+  margin: 9px 27px 20px 13px;
+  padding: 4px 10px;
+  border-radius: 1px 5px;
+  box-shadow: 4px 2px 7px rgba(199, 143, 87, 0.8);
+  transform: rotate(349deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box710 {
+  --cssA-v-710: 622490;
+  color: hsl(350, 30%, 50%);
+  background-color: hsl(170, 30%, 50%);
+  border: 1px solid hsl(80, 50%, 50%);
+  margin: 10px 0px 0px 2px;
+  padding: 5px 12px;
+  border-radius: 2px 7px;
+  box-shadow: 0px 3px 8px rgba(200, 145, 90, 0.9);
+  transform: rotate(350deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box711 {
+  --cssA-v-711: 630409;
+  color: hsl(27, 43%, 57%);
+  background-color: hsl(207, 43%, 43%);
+  border: 2px solid hsl(117, 50%, 50%);
+  margin: 11px 3px 5px 9px;
+  padding: 6px 14px;
+  border-radius: 3px 0px;
+  box-shadow: 1px 4px 0px rgba(201, 147, 93, 0.1);
+  transform: rotate(351deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box712 {
+  --cssA-v-712: 638328;
+  color: hsl(64, 56%, 64%);
+  background-color: hsl(244, 56%, 36%);
+  border: 3px solid hsl(154, 50%, 50%);
+  margin: 12px 6px 10px 16px;
+  padding: 7px 16px;
+  border-radius: 4px 2px;
+  box-shadow: 2px 5px 1px rgba(202, 149, 96, 0.2);
+  transform: rotate(352deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box713 {
+  --cssA-v-713: 646247;
+  color: hsl(101, 69%, 71%);
+  background-color: hsl(281, 69%, 29%);
+  border: 4px solid hsl(191, 50%, 50%);
+  margin: 13px 9px 15px 5px;
+  padding: 8px 18px;
+  border-radius: 5px 4px;
+  box-shadow: 3px 6px 2px rgba(203, 151, 99, 0.3);
+  transform: rotate(353deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box714 {
+  --cssA-v-714: 654166;
+  color: hsl(138, 82%, 78%);
+  background-color: hsl(318, 82%, 22%);
+  border: 5px solid hsl(228, 50%, 50%);
+  margin: 14px 12px 20px 12px;
+  padding: 9px 20px;
+  border-radius: 6px 6px;
+  box-shadow: 4px 0px 3px rgba(204, 153, 102, 0.4);
+  transform: rotate(354deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box715 {
+  --cssA-v-715: 662085;
+  color: hsl(175, 95%, 35%);
+  background-color: hsl(355, 95%, 65%);
+  border: 1px solid hsl(265, 50%, 50%);
+  margin: 15px 15px 0px 1px;
+  padding: 10px 0px;
+  border-radius: 7px 8px;
+  box-shadow: 0px 1px 4px rgba(205, 155, 105, 0.5);
+  transform: rotate(355deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box716 {
+  --cssA-v-716: 670004;
+  color: hsl(212, 8%, 42%);
+  background-color: hsl(32, 8%, 58%);
+  border: 2px solid hsl(302, 50%, 50%);
+  margin: 16px 18px 5px 8px;
+  padding: 11px 2px;
+  border-radius: 8px 1px;
+  box-shadow: 1px 2px 5px rgba(206, 157, 108, 0.6);
+  transform: rotate(356deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box717 {
+  --cssA-v-717: 677923;
+  color: hsl(249, 21%, 49%);
+  background-color: hsl(69, 21%, 51%);
+  border: 3px solid hsl(339, 50%, 50%);
+  margin: 17px 21px 10px 15px;
+  padding: 12px 4px;
+  border-radius: 9px 3px;
+  box-shadow: 2px 3px 6px rgba(207, 159, 111, 0.7);
+  transform: rotate(357deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box718 {
+  --cssA-v-718: 685842;
+  color: hsl(286, 34%, 56%);
+  background-color: hsl(106, 34%, 44%);
+  border: 4px solid hsl(16, 50%, 50%);
+  margin: 18px 24px 15px 4px;
+  padding: 13px 6px;
+  border-radius: 10px 5px;
+  box-shadow: 3px 4px 7px rgba(208, 161, 114, 0.8);
+  transform: rotate(358deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box719 {
+  --cssA-v-719: 693761;
+  color: hsl(323, 47%, 63%);
+  background-color: hsl(143, 47%, 37%);
+  border: 5px solid hsl(53, 50%, 50%);
+  margin: 19px 27px 20px 11px;
+  padding: 14px 8px;
+  border-radius: 11px 7px;
+  box-shadow: 4px 5px 8px rgba(209, 163, 117, 0.9);
+  transform: rotate(359deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box720 {
+  --cssA-v-720: 701680;
+  color: hsl(0, 60%, 70%);
+  background-color: hsl(180, 60%, 30%);
+  border: 1px solid hsl(90, 50%, 50%);
+  margin: 0px 0px 0px 0px;
+  padding: 0px 10px;
+  border-radius: 0px 0px;
+  box-shadow: 0px 6px 0px rgba(210, 165, 120, 0.1);
+  transform: rotate(0deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box721 {
+  --cssA-v-721: 709599;
+  color: hsl(37, 73%, 77%);
+  background-color: hsl(217, 73%, 23%);
+  border: 2px solid hsl(127, 50%, 50%);
+  margin: 1px 3px 5px 7px;
+  padding: 1px 12px;
+  border-radius: 1px 2px;
+  box-shadow: 1px 0px 1px rgba(211, 167, 123, 0.2);
+  transform: rotate(1deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box722 {
+  --cssA-v-722: 717518;
+  color: hsl(74, 86%, 34%);
+  background-color: hsl(254, 86%, 66%);
+  border: 3px solid hsl(164, 50%, 50%);
+  margin: 2px 6px 10px 14px;
+  padding: 2px 14px;
+  border-radius: 2px 4px;
+  box-shadow: 2px 1px 2px rgba(212, 169, 126, 0.3);
+  transform: rotate(2deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box723 {
+  --cssA-v-723: 725437;
+  color: hsl(111, 99%, 41%);
+  background-color: hsl(291, 99%, 59%);
+  border: 4px solid hsl(201, 50%, 50%);
+  margin: 3px 9px 15px 3px;
+  padding: 3px 16px;
+  border-radius: 3px 6px;
+  box-shadow: 3px 2px 3px rgba(213, 171, 129, 0.4);
+  transform: rotate(3deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box724 {
+  --cssA-v-724: 733356;
+  color: hsl(148, 12%, 48%);
+  background-color: hsl(328, 12%, 52%);
+  border: 5px solid hsl(238, 50%, 50%);
+  margin: 4px 12px 20px 10px;
+  padding: 4px 18px;
+  border-radius: 4px 8px;
+  box-shadow: 4px 3px 4px rgba(214, 173, 132, 0.5);
+  transform: rotate(4deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box725 {
+  --cssA-v-725: 741275;
+  color: hsl(185, 25%, 55%);
+  background-color: hsl(5, 25%, 45%);
+  border: 1px solid hsl(275, 50%, 50%);
+  margin: 5px 15px 0px 17px;
+  padding: 5px 20px;
+  border-radius: 5px 1px;
+  box-shadow: 0px 4px 5px rgba(215, 175, 135, 0.6);
+  transform: rotate(5deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box726 {
+  --cssA-v-726: 749194;
+  color: hsl(222, 38%, 62%);
+  background-color: hsl(42, 38%, 38%);
+  border: 2px solid hsl(312, 50%, 50%);
+  margin: 6px 18px 5px 6px;
+  padding: 6px 0px;
+  border-radius: 6px 3px;
+  box-shadow: 1px 5px 6px rgba(216, 177, 138, 0.7);
+  transform: rotate(6deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box727 {
+  --cssA-v-727: 757113;
+  color: hsl(259, 51%, 69%);
+  background-color: hsl(79, 51%, 31%);
+  border: 3px solid hsl(349, 50%, 50%);
+  margin: 7px 21px 10px 13px;
+  padding: 7px 2px;
+  border-radius: 7px 5px;
+  box-shadow: 2px 6px 7px rgba(217, 179, 141, 0.8);
+  transform: rotate(7deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box728 {
+  --cssA-v-728: 765032;
+  color: hsl(296, 64%, 76%);
+  background-color: hsl(116, 64%, 24%);
+  border: 4px solid hsl(26, 50%, 50%);
+  margin: 8px 24px 15px 2px;
+  padding: 8px 4px;
+  border-radius: 8px 7px;
+  box-shadow: 3px 0px 8px rgba(218, 181, 144, 0.9);
+  transform: rotate(8deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box729 {
+  --cssA-v-729: 772951;
+  color: hsl(333, 77%, 33%);
+  background-color: hsl(153, 77%, 67%);
+  border: 5px solid hsl(63, 50%, 50%);
+  margin: 9px 27px 20px 9px;
+  padding: 9px 6px;
+  border-radius: 9px 0px;
+  box-shadow: 4px 1px 0px rgba(219, 183, 147, 0.1);
+  transform: rotate(9deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box730 {
+  --cssA-v-730: 780870;
+  color: hsl(10, 90%, 40%);
+  background-color: hsl(190, 90%, 60%);
+  border: 1px solid hsl(100, 50%, 50%);
+  margin: 10px 0px 0px 16px;
+  padding: 10px 8px;
+  border-radius: 10px 2px;
+  box-shadow: 0px 2px 1px rgba(220, 185, 150, 0.2);
+  transform: rotate(10deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box731 {
+  --cssA-v-731: 788789;
+  color: hsl(47, 3%, 47%);
+  background-color: hsl(227, 3%, 53%);
+  border: 2px solid hsl(137, 50%, 50%);
+  margin: 11px 3px 5px 5px;
+  padding: 11px 10px;
+  border-radius: 11px 4px;
+  box-shadow: 1px 3px 2px rgba(221, 187, 153, 0.3);
+  transform: rotate(11deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box732 {
+  --cssA-v-732: 796708;
+  color: hsl(84, 16%, 54%);
+  background-color: hsl(264, 16%, 46%);
+  border: 3px solid hsl(174, 50%, 50%);
+  margin: 12px 6px 10px 12px;
+  padding: 12px 12px;
+  border-radius: 0px 6px;
+  box-shadow: 2px 4px 3px rgba(222, 189, 156, 0.4);
+  transform: rotate(12deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box733 {
+  --cssA-v-733: 804627;
+  color: hsl(121, 29%, 61%);
+  background-color: hsl(301, 29%, 39%);
+  border: 4px solid hsl(211, 50%, 50%);
+  margin: 13px 9px 15px 1px;
+  padding: 13px 14px;
+  border-radius: 1px 8px;
+  box-shadow: 3px 5px 4px rgba(223, 191, 159, 0.5);
+  transform: rotate(13deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box734 {
+  --cssA-v-734: 812546;
+  color: hsl(158, 42%, 68%);
+  background-color: hsl(338, 42%, 32%);
+  border: 5px solid hsl(248, 50%, 50%);
+  margin: 14px 12px 20px 8px;
+  padding: 14px 16px;
+  border-radius: 2px 1px;
+  box-shadow: 4px 6px 5px rgba(224, 193, 162, 0.6);
+  transform: rotate(14deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box735 {
+  --cssA-v-735: 820465;
+  color: hsl(195, 55%, 75%);
+  background-color: hsl(15, 55%, 25%);
+  border: 1px solid hsl(285, 50%, 50%);
+  margin: 15px 15px 0px 15px;
+  padding: 0px 18px;
+  border-radius: 3px 3px;
+  box-shadow: 0px 0px 6px rgba(225, 195, 165, 0.7);
+  transform: rotate(15deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box736 {
+  --cssA-v-736: 828384;
+  color: hsl(232, 68%, 32%);
+  background-color: hsl(52, 68%, 68%);
+  border: 2px solid hsl(322, 50%, 50%);
+  margin: 16px 18px 5px 4px;
+  padding: 1px 20px;
+  border-radius: 4px 5px;
+  box-shadow: 1px 1px 7px rgba(226, 197, 168, 0.8);
+  transform: rotate(16deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box737 {
+  --cssA-v-737: 836303;
+  color: hsl(269, 81%, 39%);
+  background-color: hsl(89, 81%, 61%);
+  border: 3px solid hsl(359, 50%, 50%);
+  margin: 17px 21px 10px 11px;
+  padding: 2px 0px;
+  border-radius: 5px 7px;
+  box-shadow: 2px 2px 8px rgba(227, 199, 171, 0.9);
+  transform: rotate(17deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box738 {
+  --cssA-v-738: 844222;
+  color: hsl(306, 94%, 46%);
+  background-color: hsl(126, 94%, 54%);
+  border: 4px solid hsl(36, 50%, 50%);
+  margin: 18px 24px 15px 0px;
+  padding: 3px 2px;
+  border-radius: 6px 0px;
+  box-shadow: 3px 3px 0px rgba(228, 201, 174, 0.1);
+  transform: rotate(18deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box739 {
+  --cssA-v-739: 852141;
+  color: hsl(343, 7%, 53%);
+  background-color: hsl(163, 7%, 47%);
+  border: 5px solid hsl(73, 50%, 50%);
+  margin: 19px 27px 20px 7px;
+  padding: 4px 4px;
+  border-radius: 7px 2px;
+  box-shadow: 4px 4px 1px rgba(229, 203, 177, 0.2);
+  transform: rotate(19deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box740 {
+  --cssA-v-740: 860060;
+  color: hsl(20, 20%, 60%);
+  background-color: hsl(200, 20%, 40%);
+  border: 1px solid hsl(110, 50%, 50%);
+  margin: 0px 0px 0px 14px;
+  padding: 5px 6px;
+  border-radius: 8px 4px;
+  box-shadow: 0px 5px 2px rgba(230, 205, 180, 0.3);
+  transform: rotate(20deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box741 {
+  --cssA-v-741: 867979;
+  color: hsl(57, 33%, 67%);
+  background-color: hsl(237, 33%, 33%);
+  border: 2px solid hsl(147, 50%, 50%);
+  margin: 1px 3px 5px 3px;
+  padding: 6px 8px;
+  border-radius: 9px 6px;
+  box-shadow: 1px 6px 3px rgba(231, 207, 183, 0.4);
+  transform: rotate(21deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box742 {
+  --cssA-v-742: 875898;
+  color: hsl(94, 46%, 74%);
+  background-color: hsl(274, 46%, 26%);
+  border: 3px solid hsl(184, 50%, 50%);
+  margin: 2px 6px 10px 10px;
+  padding: 7px 10px;
+  border-radius: 10px 8px;
+  box-shadow: 2px 0px 4px rgba(232, 209, 186, 0.5);
+  transform: rotate(22deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box743 {
+  --cssA-v-743: 883817;
+  color: hsl(131, 59%, 31%);
+  background-color: hsl(311, 59%, 69%);
+  border: 4px solid hsl(221, 50%, 50%);
+  margin: 3px 9px 15px 17px;
+  padding: 8px 12px;
+  border-radius: 11px 1px;
+  box-shadow: 3px 1px 5px rgba(233, 211, 189, 0.6);
+  transform: rotate(23deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box744 {
+  --cssA-v-744: 891736;
+  color: hsl(168, 72%, 38%);
+  background-color: hsl(348, 72%, 62%);
+  border: 5px solid hsl(258, 50%, 50%);
+  margin: 4px 12px 20px 6px;
+  padding: 9px 14px;
+  border-radius: 0px 3px;
+  box-shadow: 4px 2px 6px rgba(234, 213, 192, 0.7);
+  transform: rotate(24deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box745 {
+  --cssA-v-745: 899655;
+  color: hsl(205, 85%, 45%);
+  background-color: hsl(25, 85%, 55%);
+  border: 1px solid hsl(295, 50%, 50%);
+  margin: 5px 15px 0px 13px;
+  padding: 10px 16px;
+  border-radius: 1px 5px;
+  box-shadow: 0px 3px 7px rgba(235, 215, 195, 0.8);
+  transform: rotate(25deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box746 {
+  --cssA-v-746: 907574;
+  color: hsl(242, 98%, 52%);
+  background-color: hsl(62, 98%, 48%);
+  border: 2px solid hsl(332, 50%, 50%);
+  margin: 6px 18px 5px 2px;
+  padding: 11px 18px;
+  border-radius: 2px 7px;
+  box-shadow: 1px 4px 8px rgba(236, 217, 198, 0.9);
+  transform: rotate(26deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box747 {
+  --cssA-v-747: 915493;
+  color: hsl(279, 11%, 59%);
+  background-color: hsl(99, 11%, 41%);
+  border: 3px solid hsl(9, 50%, 50%);
+  margin: 7px 21px 10px 9px;
+  padding: 12px 20px;
+  border-radius: 3px 0px;
+  box-shadow: 2px 5px 0px rgba(237, 219, 201, 0.1);
+  transform: rotate(27deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box748 {
+  --cssA-v-748: 923412;
+  color: hsl(316, 24%, 66%);
+  background-color: hsl(136, 24%, 34%);
+  border: 4px solid hsl(46, 50%, 50%);
+  margin: 8px 24px 15px 16px;
+  padding: 13px 0px;
+  border-radius: 4px 2px;
+  box-shadow: 3px 6px 1px rgba(238, 221, 204, 0.2);
+  transform: rotate(28deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box749 {
+  --cssA-v-749: 931331;
+  color: hsl(353, 37%, 73%);
+  background-color: hsl(173, 37%, 27%);
+  border: 5px solid hsl(83, 50%, 50%);
+  margin: 9px 27px 20px 5px;
+  padding: 14px 2px;
+  border-radius: 5px 4px;
+  box-shadow: 4px 0px 2px rgba(239, 223, 207, 0.3);
+  transform: rotate(29deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box750 {
+  --cssA-v-750: 939250;
+  color: hsl(30, 50%, 30%);
+  background-color: hsl(210, 50%, 70%);
+  border: 1px solid hsl(120, 50%, 50%);
+  margin: 10px 0px 0px 12px;
+  padding: 0px 4px;
+  border-radius: 6px 6px;
+  box-shadow: 0px 1px 3px rgba(240, 225, 210, 0.4);
+  transform: rotate(30deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box751 {
+  --cssA-v-751: 947169;
+  color: hsl(67, 63%, 37%);
+  background-color: hsl(247, 63%, 63%);
+  border: 2px solid hsl(157, 50%, 50%);
+  margin: 11px 3px 5px 1px;
+  padding: 1px 6px;
+  border-radius: 7px 8px;
+  box-shadow: 1px 2px 4px rgba(241, 227, 213, 0.5);
+  transform: rotate(31deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box752 {
+  --cssA-v-752: 955088;
+  color: hsl(104, 76%, 44%);
+  background-color: hsl(284, 76%, 56%);
+  border: 3px solid hsl(194, 50%, 50%);
+  margin: 12px 6px 10px 8px;
+  padding: 2px 8px;
+  border-radius: 8px 1px;
+  box-shadow: 2px 3px 5px rgba(242, 229, 216, 0.6);
+  transform: rotate(32deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box753 {
+  --cssA-v-753: 963007;
+  color: hsl(141, 89%, 51%);
+  background-color: hsl(321, 89%, 49%);
+  border: 4px solid hsl(231, 50%, 50%);
+  margin: 13px 9px 15px 15px;
+  padding: 3px 10px;
+  border-radius: 9px 3px;
+  box-shadow: 3px 4px 6px rgba(243, 231, 219, 0.7);
+  transform: rotate(33deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box754 {
+  --cssA-v-754: 970926;
+  color: hsl(178, 2%, 58%);
+  background-color: hsl(358, 2%, 42%);
+  border: 5px solid hsl(268, 50%, 50%);
+  margin: 14px 12px 20px 4px;
+  padding: 4px 12px;
+  border-radius: 10px 5px;
+  box-shadow: 4px 5px 7px rgba(244, 233, 222, 0.8);
+  transform: rotate(34deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box755 {
+  --cssA-v-755: 978845;
+  color: hsl(215, 15%, 65%);
+  background-color: hsl(35, 15%, 35%);
+  border: 1px solid hsl(305, 50%, 50%);
+  margin: 15px 15px 0px 11px;
+  padding: 5px 14px;
+  border-radius: 11px 7px;
+  box-shadow: 0px 6px 8px rgba(245, 235, 225, 0.9);
+  transform: rotate(35deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box756 {
+  --cssA-v-756: 986764;
+  color: hsl(252, 28%, 72%);
+  background-color: hsl(72, 28%, 28%);
+  border: 2px solid hsl(342, 50%, 50%);
+  margin: 16px 18px 5px 0px;
+  padding: 6px 16px;
+  border-radius: 0px 0px;
+  box-shadow: 1px 0px 0px rgba(246, 237, 228, 0.1);
+  transform: rotate(36deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box757 {
+  --cssA-v-757: 994683;
+  color: hsl(289, 41%, 79%);
+  background-color: hsl(109, 41%, 21%);
+  border: 3px solid hsl(19, 50%, 50%);
+  margin: 17px 21px 10px 7px;
+  padding: 7px 18px;
+  border-radius: 1px 2px;
+  box-shadow: 2px 1px 1px rgba(247, 239, 231, 0.2);
+  transform: rotate(37deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box758 {
+  --cssA-v-758: 2602;
+  color: hsl(326, 54%, 36%);
+  background-color: hsl(146, 54%, 64%);
+  border: 4px solid hsl(56, 50%, 50%);
+  margin: 18px 24px 15px 14px;
+  padding: 8px 20px;
+  border-radius: 2px 4px;
+  box-shadow: 3px 2px 2px rgba(248, 241, 234, 0.3);
+  transform: rotate(38deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box759 {
+  --cssA-v-759: 10521;
+  color: hsl(3, 67%, 43%);
+  background-color: hsl(183, 67%, 57%);
+  border: 5px solid hsl(93, 50%, 50%);
+  margin: 19px 27px 20px 3px;
+  padding: 9px 0px;
+  border-radius: 3px 6px;
+  box-shadow: 4px 3px 3px rgba(249, 243, 237, 0.4);
+  transform: rotate(39deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box760 {
+  --cssA-v-760: 18440;
+  color: hsl(40, 80%, 50%);
+  background-color: hsl(220, 80%, 50%);
+  border: 1px solid hsl(130, 50%, 50%);
+  margin: 0px 0px 0px 10px;
+  padding: 10px 2px;
+  border-radius: 4px 8px;
+  box-shadow: 0px 4px 4px rgba(250, 245, 240, 0.5);
+  transform: rotate(40deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box761 {
+  --cssA-v-761: 26359;
+  color: hsl(77, 93%, 57%);
+  background-color: hsl(257, 93%, 43%);
+  border: 2px solid hsl(167, 50%, 50%);
+  margin: 1px 3px 5px 17px;
+  padding: 11px 4px;
+  border-radius: 5px 1px;
+  box-shadow: 1px 5px 5px rgba(251, 247, 243, 0.6);
+  transform: rotate(41deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box762 {
+  --cssA-v-762: 34278;
+  color: hsl(114, 6%, 64%);
+  background-color: hsl(294, 6%, 36%);
+  border: 3px solid hsl(204, 50%, 50%);
+  margin: 2px 6px 10px 6px;
+  padding: 12px 6px;
+  border-radius: 6px 3px;
+  box-shadow: 2px 6px 6px rgba(252, 249, 246, 0.7);
+  transform: rotate(42deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box763 {
+  --cssA-v-763: 42197;
+  color: hsl(151, 19%, 71%);
+  background-color: hsl(331, 19%, 29%);
+  border: 4px solid hsl(241, 50%, 50%);
+  margin: 3px 9px 15px 13px;
+  padding: 13px 8px;
+  border-radius: 7px 5px;
+  box-shadow: 3px 0px 7px rgba(253, 251, 249, 0.8);
+  transform: rotate(43deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box764 {
+  --cssA-v-764: 50116;
+  color: hsl(188, 32%, 78%);
+  background-color: hsl(8, 32%, 22%);
+  border: 5px solid hsl(278, 50%, 50%);
+  margin: 4px 12px 20px 2px;
+  padding: 14px 10px;
+  border-radius: 8px 7px;
+  box-shadow: 4px 1px 8px rgba(254, 253, 252, 0.9);
+  transform: rotate(44deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box765 {
+  --cssA-v-765: 58035;
+  color: hsl(225, 45%, 35%);
+  background-color: hsl(45, 45%, 65%);
+  border: 1px solid hsl(315, 50%, 50%);
+  margin: 5px 15px 0px 9px;
+  padding: 0px 12px;
+  border-radius: 9px 0px;
+  box-shadow: 0px 2px 0px rgba(0, 0, 0, 0.1);
+  transform: rotate(45deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box766 {
+  --cssA-v-766: 65954;
+  color: hsl(262, 58%, 42%);
+  background-color: hsl(82, 58%, 58%);
+  border: 2px solid hsl(352, 50%, 50%);
+  margin: 6px 18px 5px 16px;
+  padding: 1px 14px;
+  border-radius: 10px 2px;
+  box-shadow: 1px 3px 1px rgba(1, 2, 3, 0.2);
+  transform: rotate(46deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssA_box767 {
+  --cssA-v-767: 73873;
+  color: hsl(299, 71%, 49%);
+  background-color: hsl(119, 71%, 51%);
+  border: 3px solid hsl(29, 50%, 50%);
+  margin: 7px 21px 10px 5px;
+  padding: 2px 16px;
+  border-radius: 11px 4px;
+  box-shadow: 2px 4px 2px rgba(2, 4, 6, 0.3);
+  transform: rotate(47deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssA_box768 {
+  --cssA-v-768: 81792;
+  color: hsl(336, 84%, 56%);
+  background-color: hsl(156, 84%, 44%);
+  border: 4px solid hsl(66, 50%, 50%);
+  margin: 8px 24px 15px 12px;
+  padding: 3px 18px;
+  border-radius: 0px 6px;
+  box-shadow: 3px 5px 3px rgba(3, 6, 9, 0.4);
+  transform: rotate(48deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssA_box769 {
+  --cssA-v-769: 89711;
+  color: hsl(13, 97%, 63%);
+  background-color: hsl(193, 97%, 37%);
+  border: 5px solid hsl(103, 50%, 50%);
+  margin: 9px 27px 20px 1px;
+  padding: 4px 20px;
+  border-radius: 1px 8px;
+  box-shadow: 4px 6px 4px rgba(4, 8, 12, 0.5);
+  transform: rotate(49deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssA_box770 {
+  --cssA-v-770: 97630;
+  color: hsl(50, 10%, 70%);
+  background-color: hsl(230, 10%, 30%);
+  border: 1px solid hsl(140, 50%, 50%);
+  margin: 10px 0px 0px 8px;
+  padding: 5px 0px;
+  border-radius: 2px 1px;
+  box-shadow: 0px 0px 5px rgba(5, 10, 15, 0.6);
+  transform: rotate(50deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssA_box771 {
+  --cssA-v-771: 105549;
+  color: hsl(87, 23%, 77%);
+  background-color: hsl(267, 23%, 23%);
+  border: 2px solid hsl(177, 50%, 50%);
+  margin: 11px 3px 5px 15px;
+  padding: 6px 2px;
+  border-radius: 3px 3px;
+  box-shadow: 1px 1px 6px rgba(6, 12, 18, 0.7);
+  transform: rotate(51deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssA_box772 {
+  --cssA-v-772: 113468;
+  color: hsl(124, 36%, 34%);
+  background-color: hsl(304, 36%, 66%);
+  border: 3px solid hsl(214, 50%, 50%);
+  margin: 12px 6px 10px 4px;
+  padding: 7px 4px;
+  border-radius: 4px 5px;
+  box-shadow: 2px 2px 7px rgba(7, 14, 21, 0.8);
+  transform: rotate(52deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssA_box773 {
+  --cssA-v-773: 121387;
+  color: hsl(161, 49%, 41%);
+  background-color: hsl(341, 49%, 59%);
+  border: 4px solid hsl(251, 50%, 50%);
+  margin: 13px 9px 15px 11px;
+  padding: 8px 6px;
+  border-radius: 5px 7px;
+  box-shadow: 3px 3px 8px rgba(8, 16, 24, 0.9);
+  transform: rotate(53deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssA_box774 {
+  --cssA-v-774: 129306;
+  color: hsl(198, 62%, 48%);
+  background-color: hsl(18, 62%, 52%);
+  border: 5px solid hsl(288, 50%, 50%);
+  margin: 14px 12px 20px 0px;
+  padding: 9px 8px;
+  border-radius: 6px 0px;
+  box-shadow: 4px 4px 0px rgba(9, 18, 27, 0.1);
+  transform: rotate(54deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssA_box775 {
+  --cssA-v-775: 137225;
+  color: hsl(235, 75%, 55%);
+  background-color: hsl(55, 75%, 45%);
+  border: 1px solid hsl(325, 50%, 50%);
+  margin: 15px 15px 0px 7px;
+  padding: 10px 10px;
+  border-radius: 7px 2px;
+  box-shadow: 0px 5px 1px rgba(10, 20, 30, 0.2);
+  transform: rotate(55deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}

--- a/app/javascript/components/css-demo/cssB.css
+++ b/app/javascript/components/css-demo/cssB.css
@@ -1,0 +1,11643 @@
+/* cssB ~300KB */
+.cssB_sentinel::after { content: "SENTINEL_CSSB"; }
+.cssB_marker { outline-style: solid; outline-width: 13px; outline-color: hsl(221,80%,40%); }
+.cssB_box0 {
+  --cssB-v-0: 0;
+  color: hsl(0, 0%, 30%);
+  background-color: hsl(180, 0%, 70%);
+  border: 1px solid hsl(90, 50%, 50%);
+  margin: 0px 0px 0px 0px;
+  padding: 0px 0px;
+  border-radius: 0px 0px;
+  box-shadow: 0px 0px 0px rgba(0, 0, 0, 0.1);
+  transform: rotate(0deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box1 {
+  --cssB-v-1: 7919;
+  color: hsl(37, 13%, 37%);
+  background-color: hsl(217, 13%, 63%);
+  border: 2px solid hsl(127, 50%, 50%);
+  margin: 1px 3px 5px 7px;
+  padding: 1px 2px;
+  border-radius: 1px 2px;
+  box-shadow: 1px 1px 1px rgba(1, 2, 3, 0.2);
+  transform: rotate(1deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box2 {
+  --cssB-v-2: 15838;
+  color: hsl(74, 26%, 44%);
+  background-color: hsl(254, 26%, 56%);
+  border: 3px solid hsl(164, 50%, 50%);
+  margin: 2px 6px 10px 14px;
+  padding: 2px 4px;
+  border-radius: 2px 4px;
+  box-shadow: 2px 2px 2px rgba(2, 4, 6, 0.3);
+  transform: rotate(2deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box3 {
+  --cssB-v-3: 23757;
+  color: hsl(111, 39%, 51%);
+  background-color: hsl(291, 39%, 49%);
+  border: 4px solid hsl(201, 50%, 50%);
+  margin: 3px 9px 15px 3px;
+  padding: 3px 6px;
+  border-radius: 3px 6px;
+  box-shadow: 3px 3px 3px rgba(3, 6, 9, 0.4);
+  transform: rotate(3deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box4 {
+  --cssB-v-4: 31676;
+  color: hsl(148, 52%, 58%);
+  background-color: hsl(328, 52%, 42%);
+  border: 5px solid hsl(238, 50%, 50%);
+  margin: 4px 12px 20px 10px;
+  padding: 4px 8px;
+  border-radius: 4px 8px;
+  box-shadow: 4px 4px 4px rgba(4, 8, 12, 0.5);
+  transform: rotate(4deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box5 {
+  --cssB-v-5: 39595;
+  color: hsl(185, 65%, 65%);
+  background-color: hsl(5, 65%, 35%);
+  border: 1px solid hsl(275, 50%, 50%);
+  margin: 5px 15px 0px 17px;
+  padding: 5px 10px;
+  border-radius: 5px 1px;
+  box-shadow: 0px 5px 5px rgba(5, 10, 15, 0.6);
+  transform: rotate(5deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box6 {
+  --cssB-v-6: 47514;
+  color: hsl(222, 78%, 72%);
+  background-color: hsl(42, 78%, 28%);
+  border: 2px solid hsl(312, 50%, 50%);
+  margin: 6px 18px 5px 6px;
+  padding: 6px 12px;
+  border-radius: 6px 3px;
+  box-shadow: 1px 6px 6px rgba(6, 12, 18, 0.7);
+  transform: rotate(6deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box7 {
+  --cssB-v-7: 55433;
+  color: hsl(259, 91%, 79%);
+  background-color: hsl(79, 91%, 21%);
+  border: 3px solid hsl(349, 50%, 50%);
+  margin: 7px 21px 10px 13px;
+  padding: 7px 14px;
+  border-radius: 7px 5px;
+  box-shadow: 2px 0px 7px rgba(7, 14, 21, 0.8);
+  transform: rotate(7deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box8 {
+  --cssB-v-8: 63352;
+  color: hsl(296, 4%, 36%);
+  background-color: hsl(116, 4%, 64%);
+  border: 4px solid hsl(26, 50%, 50%);
+  margin: 8px 24px 15px 2px;
+  padding: 8px 16px;
+  border-radius: 8px 7px;
+  box-shadow: 3px 1px 8px rgba(8, 16, 24, 0.9);
+  transform: rotate(8deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box9 {
+  --cssB-v-9: 71271;
+  color: hsl(333, 17%, 43%);
+  background-color: hsl(153, 17%, 57%);
+  border: 5px solid hsl(63, 50%, 50%);
+  margin: 9px 27px 20px 9px;
+  padding: 9px 18px;
+  border-radius: 9px 0px;
+  box-shadow: 4px 2px 0px rgba(9, 18, 27, 0.1);
+  transform: rotate(9deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box10 {
+  --cssB-v-10: 79190;
+  color: hsl(10, 30%, 50%);
+  background-color: hsl(190, 30%, 50%);
+  border: 1px solid hsl(100, 50%, 50%);
+  margin: 10px 0px 0px 16px;
+  padding: 10px 20px;
+  border-radius: 10px 2px;
+  box-shadow: 0px 3px 1px rgba(10, 20, 30, 0.2);
+  transform: rotate(10deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box11 {
+  --cssB-v-11: 87109;
+  color: hsl(47, 43%, 57%);
+  background-color: hsl(227, 43%, 43%);
+  border: 2px solid hsl(137, 50%, 50%);
+  margin: 11px 3px 5px 5px;
+  padding: 11px 0px;
+  border-radius: 11px 4px;
+  box-shadow: 1px 4px 2px rgba(11, 22, 33, 0.3);
+  transform: rotate(11deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box12 {
+  --cssB-v-12: 95028;
+  color: hsl(84, 56%, 64%);
+  background-color: hsl(264, 56%, 36%);
+  border: 3px solid hsl(174, 50%, 50%);
+  margin: 12px 6px 10px 12px;
+  padding: 12px 2px;
+  border-radius: 0px 6px;
+  box-shadow: 2px 5px 3px rgba(12, 24, 36, 0.4);
+  transform: rotate(12deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box13 {
+  --cssB-v-13: 102947;
+  color: hsl(121, 69%, 71%);
+  background-color: hsl(301, 69%, 29%);
+  border: 4px solid hsl(211, 50%, 50%);
+  margin: 13px 9px 15px 1px;
+  padding: 13px 4px;
+  border-radius: 1px 8px;
+  box-shadow: 3px 6px 4px rgba(13, 26, 39, 0.5);
+  transform: rotate(13deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box14 {
+  --cssB-v-14: 110866;
+  color: hsl(158, 82%, 78%);
+  background-color: hsl(338, 82%, 22%);
+  border: 5px solid hsl(248, 50%, 50%);
+  margin: 14px 12px 20px 8px;
+  padding: 14px 6px;
+  border-radius: 2px 1px;
+  box-shadow: 4px 0px 5px rgba(14, 28, 42, 0.6);
+  transform: rotate(14deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box15 {
+  --cssB-v-15: 118785;
+  color: hsl(195, 95%, 35%);
+  background-color: hsl(15, 95%, 65%);
+  border: 1px solid hsl(285, 50%, 50%);
+  margin: 15px 15px 0px 15px;
+  padding: 0px 8px;
+  border-radius: 3px 3px;
+  box-shadow: 0px 1px 6px rgba(15, 30, 45, 0.7);
+  transform: rotate(15deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box16 {
+  --cssB-v-16: 126704;
+  color: hsl(232, 8%, 42%);
+  background-color: hsl(52, 8%, 58%);
+  border: 2px solid hsl(322, 50%, 50%);
+  margin: 16px 18px 5px 4px;
+  padding: 1px 10px;
+  border-radius: 4px 5px;
+  box-shadow: 1px 2px 7px rgba(16, 32, 48, 0.8);
+  transform: rotate(16deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box17 {
+  --cssB-v-17: 134623;
+  color: hsl(269, 21%, 49%);
+  background-color: hsl(89, 21%, 51%);
+  border: 3px solid hsl(359, 50%, 50%);
+  margin: 17px 21px 10px 11px;
+  padding: 2px 12px;
+  border-radius: 5px 7px;
+  box-shadow: 2px 3px 8px rgba(17, 34, 51, 0.9);
+  transform: rotate(17deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box18 {
+  --cssB-v-18: 142542;
+  color: hsl(306, 34%, 56%);
+  background-color: hsl(126, 34%, 44%);
+  border: 4px solid hsl(36, 50%, 50%);
+  margin: 18px 24px 15px 0px;
+  padding: 3px 14px;
+  border-radius: 6px 0px;
+  box-shadow: 3px 4px 0px rgba(18, 36, 54, 0.1);
+  transform: rotate(18deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box19 {
+  --cssB-v-19: 150461;
+  color: hsl(343, 47%, 63%);
+  background-color: hsl(163, 47%, 37%);
+  border: 5px solid hsl(73, 50%, 50%);
+  margin: 19px 27px 20px 7px;
+  padding: 4px 16px;
+  border-radius: 7px 2px;
+  box-shadow: 4px 5px 1px rgba(19, 38, 57, 0.2);
+  transform: rotate(19deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box20 {
+  --cssB-v-20: 158380;
+  color: hsl(20, 60%, 70%);
+  background-color: hsl(200, 60%, 30%);
+  border: 1px solid hsl(110, 50%, 50%);
+  margin: 0px 0px 0px 14px;
+  padding: 5px 18px;
+  border-radius: 8px 4px;
+  box-shadow: 0px 6px 2px rgba(20, 40, 60, 0.3);
+  transform: rotate(20deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box21 {
+  --cssB-v-21: 166299;
+  color: hsl(57, 73%, 77%);
+  background-color: hsl(237, 73%, 23%);
+  border: 2px solid hsl(147, 50%, 50%);
+  margin: 1px 3px 5px 3px;
+  padding: 6px 20px;
+  border-radius: 9px 6px;
+  box-shadow: 1px 0px 3px rgba(21, 42, 63, 0.4);
+  transform: rotate(21deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box22 {
+  --cssB-v-22: 174218;
+  color: hsl(94, 86%, 34%);
+  background-color: hsl(274, 86%, 66%);
+  border: 3px solid hsl(184, 50%, 50%);
+  margin: 2px 6px 10px 10px;
+  padding: 7px 0px;
+  border-radius: 10px 8px;
+  box-shadow: 2px 1px 4px rgba(22, 44, 66, 0.5);
+  transform: rotate(22deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box23 {
+  --cssB-v-23: 182137;
+  color: hsl(131, 99%, 41%);
+  background-color: hsl(311, 99%, 59%);
+  border: 4px solid hsl(221, 50%, 50%);
+  margin: 3px 9px 15px 17px;
+  padding: 8px 2px;
+  border-radius: 11px 1px;
+  box-shadow: 3px 2px 5px rgba(23, 46, 69, 0.6);
+  transform: rotate(23deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box24 {
+  --cssB-v-24: 190056;
+  color: hsl(168, 12%, 48%);
+  background-color: hsl(348, 12%, 52%);
+  border: 5px solid hsl(258, 50%, 50%);
+  margin: 4px 12px 20px 6px;
+  padding: 9px 4px;
+  border-radius: 0px 3px;
+  box-shadow: 4px 3px 6px rgba(24, 48, 72, 0.7);
+  transform: rotate(24deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box25 {
+  --cssB-v-25: 197975;
+  color: hsl(205, 25%, 55%);
+  background-color: hsl(25, 25%, 45%);
+  border: 1px solid hsl(295, 50%, 50%);
+  margin: 5px 15px 0px 13px;
+  padding: 10px 6px;
+  border-radius: 1px 5px;
+  box-shadow: 0px 4px 7px rgba(25, 50, 75, 0.8);
+  transform: rotate(25deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box26 {
+  --cssB-v-26: 205894;
+  color: hsl(242, 38%, 62%);
+  background-color: hsl(62, 38%, 38%);
+  border: 2px solid hsl(332, 50%, 50%);
+  margin: 6px 18px 5px 2px;
+  padding: 11px 8px;
+  border-radius: 2px 7px;
+  box-shadow: 1px 5px 8px rgba(26, 52, 78, 0.9);
+  transform: rotate(26deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box27 {
+  --cssB-v-27: 213813;
+  color: hsl(279, 51%, 69%);
+  background-color: hsl(99, 51%, 31%);
+  border: 3px solid hsl(9, 50%, 50%);
+  margin: 7px 21px 10px 9px;
+  padding: 12px 10px;
+  border-radius: 3px 0px;
+  box-shadow: 2px 6px 0px rgba(27, 54, 81, 0.1);
+  transform: rotate(27deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box28 {
+  --cssB-v-28: 221732;
+  color: hsl(316, 64%, 76%);
+  background-color: hsl(136, 64%, 24%);
+  border: 4px solid hsl(46, 50%, 50%);
+  margin: 8px 24px 15px 16px;
+  padding: 13px 12px;
+  border-radius: 4px 2px;
+  box-shadow: 3px 0px 1px rgba(28, 56, 84, 0.2);
+  transform: rotate(28deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box29 {
+  --cssB-v-29: 229651;
+  color: hsl(353, 77%, 33%);
+  background-color: hsl(173, 77%, 67%);
+  border: 5px solid hsl(83, 50%, 50%);
+  margin: 9px 27px 20px 5px;
+  padding: 14px 14px;
+  border-radius: 5px 4px;
+  box-shadow: 4px 1px 2px rgba(29, 58, 87, 0.3);
+  transform: rotate(29deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box30 {
+  --cssB-v-30: 237570;
+  color: hsl(30, 90%, 40%);
+  background-color: hsl(210, 90%, 60%);
+  border: 1px solid hsl(120, 50%, 50%);
+  margin: 10px 0px 0px 12px;
+  padding: 0px 16px;
+  border-radius: 6px 6px;
+  box-shadow: 0px 2px 3px rgba(30, 60, 90, 0.4);
+  transform: rotate(30deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box31 {
+  --cssB-v-31: 245489;
+  color: hsl(67, 3%, 47%);
+  background-color: hsl(247, 3%, 53%);
+  border: 2px solid hsl(157, 50%, 50%);
+  margin: 11px 3px 5px 1px;
+  padding: 1px 18px;
+  border-radius: 7px 8px;
+  box-shadow: 1px 3px 4px rgba(31, 62, 93, 0.5);
+  transform: rotate(31deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box32 {
+  --cssB-v-32: 253408;
+  color: hsl(104, 16%, 54%);
+  background-color: hsl(284, 16%, 46%);
+  border: 3px solid hsl(194, 50%, 50%);
+  margin: 12px 6px 10px 8px;
+  padding: 2px 20px;
+  border-radius: 8px 1px;
+  box-shadow: 2px 4px 5px rgba(32, 64, 96, 0.6);
+  transform: rotate(32deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box33 {
+  --cssB-v-33: 261327;
+  color: hsl(141, 29%, 61%);
+  background-color: hsl(321, 29%, 39%);
+  border: 4px solid hsl(231, 50%, 50%);
+  margin: 13px 9px 15px 15px;
+  padding: 3px 0px;
+  border-radius: 9px 3px;
+  box-shadow: 3px 5px 6px rgba(33, 66, 99, 0.7);
+  transform: rotate(33deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box34 {
+  --cssB-v-34: 269246;
+  color: hsl(178, 42%, 68%);
+  background-color: hsl(358, 42%, 32%);
+  border: 5px solid hsl(268, 50%, 50%);
+  margin: 14px 12px 20px 4px;
+  padding: 4px 2px;
+  border-radius: 10px 5px;
+  box-shadow: 4px 6px 7px rgba(34, 68, 102, 0.8);
+  transform: rotate(34deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box35 {
+  --cssB-v-35: 277165;
+  color: hsl(215, 55%, 75%);
+  background-color: hsl(35, 55%, 25%);
+  border: 1px solid hsl(305, 50%, 50%);
+  margin: 15px 15px 0px 11px;
+  padding: 5px 4px;
+  border-radius: 11px 7px;
+  box-shadow: 0px 0px 8px rgba(35, 70, 105, 0.9);
+  transform: rotate(35deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box36 {
+  --cssB-v-36: 285084;
+  color: hsl(252, 68%, 32%);
+  background-color: hsl(72, 68%, 68%);
+  border: 2px solid hsl(342, 50%, 50%);
+  margin: 16px 18px 5px 0px;
+  padding: 6px 6px;
+  border-radius: 0px 0px;
+  box-shadow: 1px 1px 0px rgba(36, 72, 108, 0.1);
+  transform: rotate(36deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box37 {
+  --cssB-v-37: 293003;
+  color: hsl(289, 81%, 39%);
+  background-color: hsl(109, 81%, 61%);
+  border: 3px solid hsl(19, 50%, 50%);
+  margin: 17px 21px 10px 7px;
+  padding: 7px 8px;
+  border-radius: 1px 2px;
+  box-shadow: 2px 2px 1px rgba(37, 74, 111, 0.2);
+  transform: rotate(37deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box38 {
+  --cssB-v-38: 300922;
+  color: hsl(326, 94%, 46%);
+  background-color: hsl(146, 94%, 54%);
+  border: 4px solid hsl(56, 50%, 50%);
+  margin: 18px 24px 15px 14px;
+  padding: 8px 10px;
+  border-radius: 2px 4px;
+  box-shadow: 3px 3px 2px rgba(38, 76, 114, 0.3);
+  transform: rotate(38deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box39 {
+  --cssB-v-39: 308841;
+  color: hsl(3, 7%, 53%);
+  background-color: hsl(183, 7%, 47%);
+  border: 5px solid hsl(93, 50%, 50%);
+  margin: 19px 27px 20px 3px;
+  padding: 9px 12px;
+  border-radius: 3px 6px;
+  box-shadow: 4px 4px 3px rgba(39, 78, 117, 0.4);
+  transform: rotate(39deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box40 {
+  --cssB-v-40: 316760;
+  color: hsl(40, 20%, 60%);
+  background-color: hsl(220, 20%, 40%);
+  border: 1px solid hsl(130, 50%, 50%);
+  margin: 0px 0px 0px 10px;
+  padding: 10px 14px;
+  border-radius: 4px 8px;
+  box-shadow: 0px 5px 4px rgba(40, 80, 120, 0.5);
+  transform: rotate(40deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box41 {
+  --cssB-v-41: 324679;
+  color: hsl(77, 33%, 67%);
+  background-color: hsl(257, 33%, 33%);
+  border: 2px solid hsl(167, 50%, 50%);
+  margin: 1px 3px 5px 17px;
+  padding: 11px 16px;
+  border-radius: 5px 1px;
+  box-shadow: 1px 6px 5px rgba(41, 82, 123, 0.6);
+  transform: rotate(41deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box42 {
+  --cssB-v-42: 332598;
+  color: hsl(114, 46%, 74%);
+  background-color: hsl(294, 46%, 26%);
+  border: 3px solid hsl(204, 50%, 50%);
+  margin: 2px 6px 10px 6px;
+  padding: 12px 18px;
+  border-radius: 6px 3px;
+  box-shadow: 2px 0px 6px rgba(42, 84, 126, 0.7);
+  transform: rotate(42deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box43 {
+  --cssB-v-43: 340517;
+  color: hsl(151, 59%, 31%);
+  background-color: hsl(331, 59%, 69%);
+  border: 4px solid hsl(241, 50%, 50%);
+  margin: 3px 9px 15px 13px;
+  padding: 13px 20px;
+  border-radius: 7px 5px;
+  box-shadow: 3px 1px 7px rgba(43, 86, 129, 0.8);
+  transform: rotate(43deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box44 {
+  --cssB-v-44: 348436;
+  color: hsl(188, 72%, 38%);
+  background-color: hsl(8, 72%, 62%);
+  border: 5px solid hsl(278, 50%, 50%);
+  margin: 4px 12px 20px 2px;
+  padding: 14px 0px;
+  border-radius: 8px 7px;
+  box-shadow: 4px 2px 8px rgba(44, 88, 132, 0.9);
+  transform: rotate(44deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box45 {
+  --cssB-v-45: 356355;
+  color: hsl(225, 85%, 45%);
+  background-color: hsl(45, 85%, 55%);
+  border: 1px solid hsl(315, 50%, 50%);
+  margin: 5px 15px 0px 9px;
+  padding: 0px 2px;
+  border-radius: 9px 0px;
+  box-shadow: 0px 3px 0px rgba(45, 90, 135, 0.1);
+  transform: rotate(45deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box46 {
+  --cssB-v-46: 364274;
+  color: hsl(262, 98%, 52%);
+  background-color: hsl(82, 98%, 48%);
+  border: 2px solid hsl(352, 50%, 50%);
+  margin: 6px 18px 5px 16px;
+  padding: 1px 4px;
+  border-radius: 10px 2px;
+  box-shadow: 1px 4px 1px rgba(46, 92, 138, 0.2);
+  transform: rotate(46deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box47 {
+  --cssB-v-47: 372193;
+  color: hsl(299, 11%, 59%);
+  background-color: hsl(119, 11%, 41%);
+  border: 3px solid hsl(29, 50%, 50%);
+  margin: 7px 21px 10px 5px;
+  padding: 2px 6px;
+  border-radius: 11px 4px;
+  box-shadow: 2px 5px 2px rgba(47, 94, 141, 0.3);
+  transform: rotate(47deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box48 {
+  --cssB-v-48: 380112;
+  color: hsl(336, 24%, 66%);
+  background-color: hsl(156, 24%, 34%);
+  border: 4px solid hsl(66, 50%, 50%);
+  margin: 8px 24px 15px 12px;
+  padding: 3px 8px;
+  border-radius: 0px 6px;
+  box-shadow: 3px 6px 3px rgba(48, 96, 144, 0.4);
+  transform: rotate(48deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box49 {
+  --cssB-v-49: 388031;
+  color: hsl(13, 37%, 73%);
+  background-color: hsl(193, 37%, 27%);
+  border: 5px solid hsl(103, 50%, 50%);
+  margin: 9px 27px 20px 1px;
+  padding: 4px 10px;
+  border-radius: 1px 8px;
+  box-shadow: 4px 0px 4px rgba(49, 98, 147, 0.5);
+  transform: rotate(49deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box50 {
+  --cssB-v-50: 395950;
+  color: hsl(50, 50%, 30%);
+  background-color: hsl(230, 50%, 70%);
+  border: 1px solid hsl(140, 50%, 50%);
+  margin: 10px 0px 0px 8px;
+  padding: 5px 12px;
+  border-radius: 2px 1px;
+  box-shadow: 0px 1px 5px rgba(50, 100, 150, 0.6);
+  transform: rotate(50deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box51 {
+  --cssB-v-51: 403869;
+  color: hsl(87, 63%, 37%);
+  background-color: hsl(267, 63%, 63%);
+  border: 2px solid hsl(177, 50%, 50%);
+  margin: 11px 3px 5px 15px;
+  padding: 6px 14px;
+  border-radius: 3px 3px;
+  box-shadow: 1px 2px 6px rgba(51, 102, 153, 0.7);
+  transform: rotate(51deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box52 {
+  --cssB-v-52: 411788;
+  color: hsl(124, 76%, 44%);
+  background-color: hsl(304, 76%, 56%);
+  border: 3px solid hsl(214, 50%, 50%);
+  margin: 12px 6px 10px 4px;
+  padding: 7px 16px;
+  border-radius: 4px 5px;
+  box-shadow: 2px 3px 7px rgba(52, 104, 156, 0.8);
+  transform: rotate(52deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box53 {
+  --cssB-v-53: 419707;
+  color: hsl(161, 89%, 51%);
+  background-color: hsl(341, 89%, 49%);
+  border: 4px solid hsl(251, 50%, 50%);
+  margin: 13px 9px 15px 11px;
+  padding: 8px 18px;
+  border-radius: 5px 7px;
+  box-shadow: 3px 4px 8px rgba(53, 106, 159, 0.9);
+  transform: rotate(53deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box54 {
+  --cssB-v-54: 427626;
+  color: hsl(198, 2%, 58%);
+  background-color: hsl(18, 2%, 42%);
+  border: 5px solid hsl(288, 50%, 50%);
+  margin: 14px 12px 20px 0px;
+  padding: 9px 20px;
+  border-radius: 6px 0px;
+  box-shadow: 4px 5px 0px rgba(54, 108, 162, 0.1);
+  transform: rotate(54deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box55 {
+  --cssB-v-55: 435545;
+  color: hsl(235, 15%, 65%);
+  background-color: hsl(55, 15%, 35%);
+  border: 1px solid hsl(325, 50%, 50%);
+  margin: 15px 15px 0px 7px;
+  padding: 10px 0px;
+  border-radius: 7px 2px;
+  box-shadow: 0px 6px 1px rgba(55, 110, 165, 0.2);
+  transform: rotate(55deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box56 {
+  --cssB-v-56: 443464;
+  color: hsl(272, 28%, 72%);
+  background-color: hsl(92, 28%, 28%);
+  border: 2px solid hsl(2, 50%, 50%);
+  margin: 16px 18px 5px 14px;
+  padding: 11px 2px;
+  border-radius: 8px 4px;
+  box-shadow: 1px 0px 2px rgba(56, 112, 168, 0.3);
+  transform: rotate(56deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box57 {
+  --cssB-v-57: 451383;
+  color: hsl(309, 41%, 79%);
+  background-color: hsl(129, 41%, 21%);
+  border: 3px solid hsl(39, 50%, 50%);
+  margin: 17px 21px 10px 3px;
+  padding: 12px 4px;
+  border-radius: 9px 6px;
+  box-shadow: 2px 1px 3px rgba(57, 114, 171, 0.4);
+  transform: rotate(57deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box58 {
+  --cssB-v-58: 459302;
+  color: hsl(346, 54%, 36%);
+  background-color: hsl(166, 54%, 64%);
+  border: 4px solid hsl(76, 50%, 50%);
+  margin: 18px 24px 15px 10px;
+  padding: 13px 6px;
+  border-radius: 10px 8px;
+  box-shadow: 3px 2px 4px rgba(58, 116, 174, 0.5);
+  transform: rotate(58deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box59 {
+  --cssB-v-59: 467221;
+  color: hsl(23, 67%, 43%);
+  background-color: hsl(203, 67%, 57%);
+  border: 5px solid hsl(113, 50%, 50%);
+  margin: 19px 27px 20px 17px;
+  padding: 14px 8px;
+  border-radius: 11px 1px;
+  box-shadow: 4px 3px 5px rgba(59, 118, 177, 0.6);
+  transform: rotate(59deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box60 {
+  --cssB-v-60: 475140;
+  color: hsl(60, 80%, 50%);
+  background-color: hsl(240, 80%, 50%);
+  border: 1px solid hsl(150, 50%, 50%);
+  margin: 0px 0px 0px 6px;
+  padding: 0px 10px;
+  border-radius: 0px 3px;
+  box-shadow: 0px 4px 6px rgba(60, 120, 180, 0.7);
+  transform: rotate(60deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box61 {
+  --cssB-v-61: 483059;
+  color: hsl(97, 93%, 57%);
+  background-color: hsl(277, 93%, 43%);
+  border: 2px solid hsl(187, 50%, 50%);
+  margin: 1px 3px 5px 13px;
+  padding: 1px 12px;
+  border-radius: 1px 5px;
+  box-shadow: 1px 5px 7px rgba(61, 122, 183, 0.8);
+  transform: rotate(61deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box62 {
+  --cssB-v-62: 490978;
+  color: hsl(134, 6%, 64%);
+  background-color: hsl(314, 6%, 36%);
+  border: 3px solid hsl(224, 50%, 50%);
+  margin: 2px 6px 10px 2px;
+  padding: 2px 14px;
+  border-radius: 2px 7px;
+  box-shadow: 2px 6px 8px rgba(62, 124, 186, 0.9);
+  transform: rotate(62deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box63 {
+  --cssB-v-63: 498897;
+  color: hsl(171, 19%, 71%);
+  background-color: hsl(351, 19%, 29%);
+  border: 4px solid hsl(261, 50%, 50%);
+  margin: 3px 9px 15px 9px;
+  padding: 3px 16px;
+  border-radius: 3px 0px;
+  box-shadow: 3px 0px 0px rgba(63, 126, 189, 0.1);
+  transform: rotate(63deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box64 {
+  --cssB-v-64: 506816;
+  color: hsl(208, 32%, 78%);
+  background-color: hsl(28, 32%, 22%);
+  border: 5px solid hsl(298, 50%, 50%);
+  margin: 4px 12px 20px 16px;
+  padding: 4px 18px;
+  border-radius: 4px 2px;
+  box-shadow: 4px 1px 1px rgba(64, 128, 192, 0.2);
+  transform: rotate(64deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box65 {
+  --cssB-v-65: 514735;
+  color: hsl(245, 45%, 35%);
+  background-color: hsl(65, 45%, 65%);
+  border: 1px solid hsl(335, 50%, 50%);
+  margin: 5px 15px 0px 5px;
+  padding: 5px 20px;
+  border-radius: 5px 4px;
+  box-shadow: 0px 2px 2px rgba(65, 130, 195, 0.3);
+  transform: rotate(65deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box66 {
+  --cssB-v-66: 522654;
+  color: hsl(282, 58%, 42%);
+  background-color: hsl(102, 58%, 58%);
+  border: 2px solid hsl(12, 50%, 50%);
+  margin: 6px 18px 5px 12px;
+  padding: 6px 0px;
+  border-radius: 6px 6px;
+  box-shadow: 1px 3px 3px rgba(66, 132, 198, 0.4);
+  transform: rotate(66deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box67 {
+  --cssB-v-67: 530573;
+  color: hsl(319, 71%, 49%);
+  background-color: hsl(139, 71%, 51%);
+  border: 3px solid hsl(49, 50%, 50%);
+  margin: 7px 21px 10px 1px;
+  padding: 7px 2px;
+  border-radius: 7px 8px;
+  box-shadow: 2px 4px 4px rgba(67, 134, 201, 0.5);
+  transform: rotate(67deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box68 {
+  --cssB-v-68: 538492;
+  color: hsl(356, 84%, 56%);
+  background-color: hsl(176, 84%, 44%);
+  border: 4px solid hsl(86, 50%, 50%);
+  margin: 8px 24px 15px 8px;
+  padding: 8px 4px;
+  border-radius: 8px 1px;
+  box-shadow: 3px 5px 5px rgba(68, 136, 204, 0.6);
+  transform: rotate(68deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box69 {
+  --cssB-v-69: 546411;
+  color: hsl(33, 97%, 63%);
+  background-color: hsl(213, 97%, 37%);
+  border: 5px solid hsl(123, 50%, 50%);
+  margin: 9px 27px 20px 15px;
+  padding: 9px 6px;
+  border-radius: 9px 3px;
+  box-shadow: 4px 6px 6px rgba(69, 138, 207, 0.7);
+  transform: rotate(69deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box70 {
+  --cssB-v-70: 554330;
+  color: hsl(70, 10%, 70%);
+  background-color: hsl(250, 10%, 30%);
+  border: 1px solid hsl(160, 50%, 50%);
+  margin: 10px 0px 0px 4px;
+  padding: 10px 8px;
+  border-radius: 10px 5px;
+  box-shadow: 0px 0px 7px rgba(70, 140, 210, 0.8);
+  transform: rotate(70deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box71 {
+  --cssB-v-71: 562249;
+  color: hsl(107, 23%, 77%);
+  background-color: hsl(287, 23%, 23%);
+  border: 2px solid hsl(197, 50%, 50%);
+  margin: 11px 3px 5px 11px;
+  padding: 11px 10px;
+  border-radius: 11px 7px;
+  box-shadow: 1px 1px 8px rgba(71, 142, 213, 0.9);
+  transform: rotate(71deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box72 {
+  --cssB-v-72: 570168;
+  color: hsl(144, 36%, 34%);
+  background-color: hsl(324, 36%, 66%);
+  border: 3px solid hsl(234, 50%, 50%);
+  margin: 12px 6px 10px 0px;
+  padding: 12px 12px;
+  border-radius: 0px 0px;
+  box-shadow: 2px 2px 0px rgba(72, 144, 216, 0.1);
+  transform: rotate(72deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box73 {
+  --cssB-v-73: 578087;
+  color: hsl(181, 49%, 41%);
+  background-color: hsl(1, 49%, 59%);
+  border: 4px solid hsl(271, 50%, 50%);
+  margin: 13px 9px 15px 7px;
+  padding: 13px 14px;
+  border-radius: 1px 2px;
+  box-shadow: 3px 3px 1px rgba(73, 146, 219, 0.2);
+  transform: rotate(73deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box74 {
+  --cssB-v-74: 586006;
+  color: hsl(218, 62%, 48%);
+  background-color: hsl(38, 62%, 52%);
+  border: 5px solid hsl(308, 50%, 50%);
+  margin: 14px 12px 20px 14px;
+  padding: 14px 16px;
+  border-radius: 2px 4px;
+  box-shadow: 4px 4px 2px rgba(74, 148, 222, 0.3);
+  transform: rotate(74deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box75 {
+  --cssB-v-75: 593925;
+  color: hsl(255, 75%, 55%);
+  background-color: hsl(75, 75%, 45%);
+  border: 1px solid hsl(345, 50%, 50%);
+  margin: 15px 15px 0px 3px;
+  padding: 0px 18px;
+  border-radius: 3px 6px;
+  box-shadow: 0px 5px 3px rgba(75, 150, 225, 0.4);
+  transform: rotate(75deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box76 {
+  --cssB-v-76: 601844;
+  color: hsl(292, 88%, 62%);
+  background-color: hsl(112, 88%, 38%);
+  border: 2px solid hsl(22, 50%, 50%);
+  margin: 16px 18px 5px 10px;
+  padding: 1px 20px;
+  border-radius: 4px 8px;
+  box-shadow: 1px 6px 4px rgba(76, 152, 228, 0.5);
+  transform: rotate(76deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box77 {
+  --cssB-v-77: 609763;
+  color: hsl(329, 1%, 69%);
+  background-color: hsl(149, 1%, 31%);
+  border: 3px solid hsl(59, 50%, 50%);
+  margin: 17px 21px 10px 17px;
+  padding: 2px 0px;
+  border-radius: 5px 1px;
+  box-shadow: 2px 0px 5px rgba(77, 154, 231, 0.6);
+  transform: rotate(77deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box78 {
+  --cssB-v-78: 617682;
+  color: hsl(6, 14%, 76%);
+  background-color: hsl(186, 14%, 24%);
+  border: 4px solid hsl(96, 50%, 50%);
+  margin: 18px 24px 15px 6px;
+  padding: 3px 2px;
+  border-radius: 6px 3px;
+  box-shadow: 3px 1px 6px rgba(78, 156, 234, 0.7);
+  transform: rotate(78deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box79 {
+  --cssB-v-79: 625601;
+  color: hsl(43, 27%, 33%);
+  background-color: hsl(223, 27%, 67%);
+  border: 5px solid hsl(133, 50%, 50%);
+  margin: 19px 27px 20px 13px;
+  padding: 4px 4px;
+  border-radius: 7px 5px;
+  box-shadow: 4px 2px 7px rgba(79, 158, 237, 0.8);
+  transform: rotate(79deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box80 {
+  --cssB-v-80: 633520;
+  color: hsl(80, 40%, 40%);
+  background-color: hsl(260, 40%, 60%);
+  border: 1px solid hsl(170, 50%, 50%);
+  margin: 0px 0px 0px 2px;
+  padding: 5px 6px;
+  border-radius: 8px 7px;
+  box-shadow: 0px 3px 8px rgba(80, 160, 240, 0.9);
+  transform: rotate(80deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box81 {
+  --cssB-v-81: 641439;
+  color: hsl(117, 53%, 47%);
+  background-color: hsl(297, 53%, 53%);
+  border: 2px solid hsl(207, 50%, 50%);
+  margin: 1px 3px 5px 9px;
+  padding: 6px 8px;
+  border-radius: 9px 0px;
+  box-shadow: 1px 4px 0px rgba(81, 162, 243, 0.1);
+  transform: rotate(81deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box82 {
+  --cssB-v-82: 649358;
+  color: hsl(154, 66%, 54%);
+  background-color: hsl(334, 66%, 46%);
+  border: 3px solid hsl(244, 50%, 50%);
+  margin: 2px 6px 10px 16px;
+  padding: 7px 10px;
+  border-radius: 10px 2px;
+  box-shadow: 2px 5px 1px rgba(82, 164, 246, 0.2);
+  transform: rotate(82deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box83 {
+  --cssB-v-83: 657277;
+  color: hsl(191, 79%, 61%);
+  background-color: hsl(11, 79%, 39%);
+  border: 4px solid hsl(281, 50%, 50%);
+  margin: 3px 9px 15px 5px;
+  padding: 8px 12px;
+  border-radius: 11px 4px;
+  box-shadow: 3px 6px 2px rgba(83, 166, 249, 0.3);
+  transform: rotate(83deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box84 {
+  --cssB-v-84: 665196;
+  color: hsl(228, 92%, 68%);
+  background-color: hsl(48, 92%, 32%);
+  border: 5px solid hsl(318, 50%, 50%);
+  margin: 4px 12px 20px 12px;
+  padding: 9px 14px;
+  border-radius: 0px 6px;
+  box-shadow: 4px 0px 3px rgba(84, 168, 252, 0.4);
+  transform: rotate(84deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box85 {
+  --cssB-v-85: 673115;
+  color: hsl(265, 5%, 75%);
+  background-color: hsl(85, 5%, 25%);
+  border: 1px solid hsl(355, 50%, 50%);
+  margin: 5px 15px 0px 1px;
+  padding: 10px 16px;
+  border-radius: 1px 8px;
+  box-shadow: 0px 1px 4px rgba(85, 170, 0, 0.5);
+  transform: rotate(85deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box86 {
+  --cssB-v-86: 681034;
+  color: hsl(302, 18%, 32%);
+  background-color: hsl(122, 18%, 68%);
+  border: 2px solid hsl(32, 50%, 50%);
+  margin: 6px 18px 5px 8px;
+  padding: 11px 18px;
+  border-radius: 2px 1px;
+  box-shadow: 1px 2px 5px rgba(86, 172, 3, 0.6);
+  transform: rotate(86deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box87 {
+  --cssB-v-87: 688953;
+  color: hsl(339, 31%, 39%);
+  background-color: hsl(159, 31%, 61%);
+  border: 3px solid hsl(69, 50%, 50%);
+  margin: 7px 21px 10px 15px;
+  padding: 12px 20px;
+  border-radius: 3px 3px;
+  box-shadow: 2px 3px 6px rgba(87, 174, 6, 0.7);
+  transform: rotate(87deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box88 {
+  --cssB-v-88: 696872;
+  color: hsl(16, 44%, 46%);
+  background-color: hsl(196, 44%, 54%);
+  border: 4px solid hsl(106, 50%, 50%);
+  margin: 8px 24px 15px 4px;
+  padding: 13px 0px;
+  border-radius: 4px 5px;
+  box-shadow: 3px 4px 7px rgba(88, 176, 9, 0.8);
+  transform: rotate(88deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box89 {
+  --cssB-v-89: 704791;
+  color: hsl(53, 57%, 53%);
+  background-color: hsl(233, 57%, 47%);
+  border: 5px solid hsl(143, 50%, 50%);
+  margin: 9px 27px 20px 11px;
+  padding: 14px 2px;
+  border-radius: 5px 7px;
+  box-shadow: 4px 5px 8px rgba(89, 178, 12, 0.9);
+  transform: rotate(89deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box90 {
+  --cssB-v-90: 712710;
+  color: hsl(90, 70%, 60%);
+  background-color: hsl(270, 70%, 40%);
+  border: 1px solid hsl(180, 50%, 50%);
+  margin: 10px 0px 0px 0px;
+  padding: 0px 4px;
+  border-radius: 6px 0px;
+  box-shadow: 0px 6px 0px rgba(90, 180, 15, 0.1);
+  transform: rotate(90deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box91 {
+  --cssB-v-91: 720629;
+  color: hsl(127, 83%, 67%);
+  background-color: hsl(307, 83%, 33%);
+  border: 2px solid hsl(217, 50%, 50%);
+  margin: 11px 3px 5px 7px;
+  padding: 1px 6px;
+  border-radius: 7px 2px;
+  box-shadow: 1px 0px 1px rgba(91, 182, 18, 0.2);
+  transform: rotate(91deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box92 {
+  --cssB-v-92: 728548;
+  color: hsl(164, 96%, 74%);
+  background-color: hsl(344, 96%, 26%);
+  border: 3px solid hsl(254, 50%, 50%);
+  margin: 12px 6px 10px 14px;
+  padding: 2px 8px;
+  border-radius: 8px 4px;
+  box-shadow: 2px 1px 2px rgba(92, 184, 21, 0.3);
+  transform: rotate(92deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box93 {
+  --cssB-v-93: 736467;
+  color: hsl(201, 9%, 31%);
+  background-color: hsl(21, 9%, 69%);
+  border: 4px solid hsl(291, 50%, 50%);
+  margin: 13px 9px 15px 3px;
+  padding: 3px 10px;
+  border-radius: 9px 6px;
+  box-shadow: 3px 2px 3px rgba(93, 186, 24, 0.4);
+  transform: rotate(93deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box94 {
+  --cssB-v-94: 744386;
+  color: hsl(238, 22%, 38%);
+  background-color: hsl(58, 22%, 62%);
+  border: 5px solid hsl(328, 50%, 50%);
+  margin: 14px 12px 20px 10px;
+  padding: 4px 12px;
+  border-radius: 10px 8px;
+  box-shadow: 4px 3px 4px rgba(94, 188, 27, 0.5);
+  transform: rotate(94deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box95 {
+  --cssB-v-95: 752305;
+  color: hsl(275, 35%, 45%);
+  background-color: hsl(95, 35%, 55%);
+  border: 1px solid hsl(5, 50%, 50%);
+  margin: 15px 15px 0px 17px;
+  padding: 5px 14px;
+  border-radius: 11px 1px;
+  box-shadow: 0px 4px 5px rgba(95, 190, 30, 0.6);
+  transform: rotate(95deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box96 {
+  --cssB-v-96: 760224;
+  color: hsl(312, 48%, 52%);
+  background-color: hsl(132, 48%, 48%);
+  border: 2px solid hsl(42, 50%, 50%);
+  margin: 16px 18px 5px 6px;
+  padding: 6px 16px;
+  border-radius: 0px 3px;
+  box-shadow: 1px 5px 6px rgba(96, 192, 33, 0.7);
+  transform: rotate(96deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box97 {
+  --cssB-v-97: 768143;
+  color: hsl(349, 61%, 59%);
+  background-color: hsl(169, 61%, 41%);
+  border: 3px solid hsl(79, 50%, 50%);
+  margin: 17px 21px 10px 13px;
+  padding: 7px 18px;
+  border-radius: 1px 5px;
+  box-shadow: 2px 6px 7px rgba(97, 194, 36, 0.8);
+  transform: rotate(97deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box98 {
+  --cssB-v-98: 776062;
+  color: hsl(26, 74%, 66%);
+  background-color: hsl(206, 74%, 34%);
+  border: 4px solid hsl(116, 50%, 50%);
+  margin: 18px 24px 15px 2px;
+  padding: 8px 20px;
+  border-radius: 2px 7px;
+  box-shadow: 3px 0px 8px rgba(98, 196, 39, 0.9);
+  transform: rotate(98deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box99 {
+  --cssB-v-99: 783981;
+  color: hsl(63, 87%, 73%);
+  background-color: hsl(243, 87%, 27%);
+  border: 5px solid hsl(153, 50%, 50%);
+  margin: 19px 27px 20px 9px;
+  padding: 9px 0px;
+  border-radius: 3px 0px;
+  box-shadow: 4px 1px 0px rgba(99, 198, 42, 0.1);
+  transform: rotate(99deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box100 {
+  --cssB-v-100: 791900;
+  color: hsl(100, 0%, 30%);
+  background-color: hsl(280, 0%, 70%);
+  border: 1px solid hsl(190, 50%, 50%);
+  margin: 0px 0px 0px 16px;
+  padding: 10px 2px;
+  border-radius: 4px 2px;
+  box-shadow: 0px 2px 1px rgba(100, 200, 45, 0.2);
+  transform: rotate(100deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box101 {
+  --cssB-v-101: 799819;
+  color: hsl(137, 13%, 37%);
+  background-color: hsl(317, 13%, 63%);
+  border: 2px solid hsl(227, 50%, 50%);
+  margin: 1px 3px 5px 5px;
+  padding: 11px 4px;
+  border-radius: 5px 4px;
+  box-shadow: 1px 3px 2px rgba(101, 202, 48, 0.3);
+  transform: rotate(101deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box102 {
+  --cssB-v-102: 807738;
+  color: hsl(174, 26%, 44%);
+  background-color: hsl(354, 26%, 56%);
+  border: 3px solid hsl(264, 50%, 50%);
+  margin: 2px 6px 10px 12px;
+  padding: 12px 6px;
+  border-radius: 6px 6px;
+  box-shadow: 2px 4px 3px rgba(102, 204, 51, 0.4);
+  transform: rotate(102deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box103 {
+  --cssB-v-103: 815657;
+  color: hsl(211, 39%, 51%);
+  background-color: hsl(31, 39%, 49%);
+  border: 4px solid hsl(301, 50%, 50%);
+  margin: 3px 9px 15px 1px;
+  padding: 13px 8px;
+  border-radius: 7px 8px;
+  box-shadow: 3px 5px 4px rgba(103, 206, 54, 0.5);
+  transform: rotate(103deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box104 {
+  --cssB-v-104: 823576;
+  color: hsl(248, 52%, 58%);
+  background-color: hsl(68, 52%, 42%);
+  border: 5px solid hsl(338, 50%, 50%);
+  margin: 4px 12px 20px 8px;
+  padding: 14px 10px;
+  border-radius: 8px 1px;
+  box-shadow: 4px 6px 5px rgba(104, 208, 57, 0.6);
+  transform: rotate(104deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box105 {
+  --cssB-v-105: 831495;
+  color: hsl(285, 65%, 65%);
+  background-color: hsl(105, 65%, 35%);
+  border: 1px solid hsl(15, 50%, 50%);
+  margin: 5px 15px 0px 15px;
+  padding: 0px 12px;
+  border-radius: 9px 3px;
+  box-shadow: 0px 0px 6px rgba(105, 210, 60, 0.7);
+  transform: rotate(105deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box106 {
+  --cssB-v-106: 839414;
+  color: hsl(322, 78%, 72%);
+  background-color: hsl(142, 78%, 28%);
+  border: 2px solid hsl(52, 50%, 50%);
+  margin: 6px 18px 5px 4px;
+  padding: 1px 14px;
+  border-radius: 10px 5px;
+  box-shadow: 1px 1px 7px rgba(106, 212, 63, 0.8);
+  transform: rotate(106deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box107 {
+  --cssB-v-107: 847333;
+  color: hsl(359, 91%, 79%);
+  background-color: hsl(179, 91%, 21%);
+  border: 3px solid hsl(89, 50%, 50%);
+  margin: 7px 21px 10px 11px;
+  padding: 2px 16px;
+  border-radius: 11px 7px;
+  box-shadow: 2px 2px 8px rgba(107, 214, 66, 0.9);
+  transform: rotate(107deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box108 {
+  --cssB-v-108: 855252;
+  color: hsl(36, 4%, 36%);
+  background-color: hsl(216, 4%, 64%);
+  border: 4px solid hsl(126, 50%, 50%);
+  margin: 8px 24px 15px 0px;
+  padding: 3px 18px;
+  border-radius: 0px 0px;
+  box-shadow: 3px 3px 0px rgba(108, 216, 69, 0.1);
+  transform: rotate(108deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box109 {
+  --cssB-v-109: 863171;
+  color: hsl(73, 17%, 43%);
+  background-color: hsl(253, 17%, 57%);
+  border: 5px solid hsl(163, 50%, 50%);
+  margin: 9px 27px 20px 7px;
+  padding: 4px 20px;
+  border-radius: 1px 2px;
+  box-shadow: 4px 4px 1px rgba(109, 218, 72, 0.2);
+  transform: rotate(109deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box110 {
+  --cssB-v-110: 871090;
+  color: hsl(110, 30%, 50%);
+  background-color: hsl(290, 30%, 50%);
+  border: 1px solid hsl(200, 50%, 50%);
+  margin: 10px 0px 0px 14px;
+  padding: 5px 0px;
+  border-radius: 2px 4px;
+  box-shadow: 0px 5px 2px rgba(110, 220, 75, 0.3);
+  transform: rotate(110deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box111 {
+  --cssB-v-111: 879009;
+  color: hsl(147, 43%, 57%);
+  background-color: hsl(327, 43%, 43%);
+  border: 2px solid hsl(237, 50%, 50%);
+  margin: 11px 3px 5px 3px;
+  padding: 6px 2px;
+  border-radius: 3px 6px;
+  box-shadow: 1px 6px 3px rgba(111, 222, 78, 0.4);
+  transform: rotate(111deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box112 {
+  --cssB-v-112: 886928;
+  color: hsl(184, 56%, 64%);
+  background-color: hsl(4, 56%, 36%);
+  border: 3px solid hsl(274, 50%, 50%);
+  margin: 12px 6px 10px 10px;
+  padding: 7px 4px;
+  border-radius: 4px 8px;
+  box-shadow: 2px 0px 4px rgba(112, 224, 81, 0.5);
+  transform: rotate(112deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box113 {
+  --cssB-v-113: 894847;
+  color: hsl(221, 69%, 71%);
+  background-color: hsl(41, 69%, 29%);
+  border: 4px solid hsl(311, 50%, 50%);
+  margin: 13px 9px 15px 17px;
+  padding: 8px 6px;
+  border-radius: 5px 1px;
+  box-shadow: 3px 1px 5px rgba(113, 226, 84, 0.6);
+  transform: rotate(113deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box114 {
+  --cssB-v-114: 902766;
+  color: hsl(258, 82%, 78%);
+  background-color: hsl(78, 82%, 22%);
+  border: 5px solid hsl(348, 50%, 50%);
+  margin: 14px 12px 20px 6px;
+  padding: 9px 8px;
+  border-radius: 6px 3px;
+  box-shadow: 4px 2px 6px rgba(114, 228, 87, 0.7);
+  transform: rotate(114deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box115 {
+  --cssB-v-115: 910685;
+  color: hsl(295, 95%, 35%);
+  background-color: hsl(115, 95%, 65%);
+  border: 1px solid hsl(25, 50%, 50%);
+  margin: 15px 15px 0px 13px;
+  padding: 10px 10px;
+  border-radius: 7px 5px;
+  box-shadow: 0px 3px 7px rgba(115, 230, 90, 0.8);
+  transform: rotate(115deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box116 {
+  --cssB-v-116: 918604;
+  color: hsl(332, 8%, 42%);
+  background-color: hsl(152, 8%, 58%);
+  border: 2px solid hsl(62, 50%, 50%);
+  margin: 16px 18px 5px 2px;
+  padding: 11px 12px;
+  border-radius: 8px 7px;
+  box-shadow: 1px 4px 8px rgba(116, 232, 93, 0.9);
+  transform: rotate(116deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box117 {
+  --cssB-v-117: 926523;
+  color: hsl(9, 21%, 49%);
+  background-color: hsl(189, 21%, 51%);
+  border: 3px solid hsl(99, 50%, 50%);
+  margin: 17px 21px 10px 9px;
+  padding: 12px 14px;
+  border-radius: 9px 0px;
+  box-shadow: 2px 5px 0px rgba(117, 234, 96, 0.1);
+  transform: rotate(117deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box118 {
+  --cssB-v-118: 934442;
+  color: hsl(46, 34%, 56%);
+  background-color: hsl(226, 34%, 44%);
+  border: 4px solid hsl(136, 50%, 50%);
+  margin: 18px 24px 15px 16px;
+  padding: 13px 16px;
+  border-radius: 10px 2px;
+  box-shadow: 3px 6px 1px rgba(118, 236, 99, 0.2);
+  transform: rotate(118deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box119 {
+  --cssB-v-119: 942361;
+  color: hsl(83, 47%, 63%);
+  background-color: hsl(263, 47%, 37%);
+  border: 5px solid hsl(173, 50%, 50%);
+  margin: 19px 27px 20px 5px;
+  padding: 14px 18px;
+  border-radius: 11px 4px;
+  box-shadow: 4px 0px 2px rgba(119, 238, 102, 0.3);
+  transform: rotate(119deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box120 {
+  --cssB-v-120: 950280;
+  color: hsl(120, 60%, 70%);
+  background-color: hsl(300, 60%, 30%);
+  border: 1px solid hsl(210, 50%, 50%);
+  margin: 0px 0px 0px 12px;
+  padding: 0px 20px;
+  border-radius: 0px 6px;
+  box-shadow: 0px 1px 3px rgba(120, 240, 105, 0.4);
+  transform: rotate(120deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box121 {
+  --cssB-v-121: 958199;
+  color: hsl(157, 73%, 77%);
+  background-color: hsl(337, 73%, 23%);
+  border: 2px solid hsl(247, 50%, 50%);
+  margin: 1px 3px 5px 1px;
+  padding: 1px 0px;
+  border-radius: 1px 8px;
+  box-shadow: 1px 2px 4px rgba(121, 242, 108, 0.5);
+  transform: rotate(121deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box122 {
+  --cssB-v-122: 966118;
+  color: hsl(194, 86%, 34%);
+  background-color: hsl(14, 86%, 66%);
+  border: 3px solid hsl(284, 50%, 50%);
+  margin: 2px 6px 10px 8px;
+  padding: 2px 2px;
+  border-radius: 2px 1px;
+  box-shadow: 2px 3px 5px rgba(122, 244, 111, 0.6);
+  transform: rotate(122deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box123 {
+  --cssB-v-123: 974037;
+  color: hsl(231, 99%, 41%);
+  background-color: hsl(51, 99%, 59%);
+  border: 4px solid hsl(321, 50%, 50%);
+  margin: 3px 9px 15px 15px;
+  padding: 3px 4px;
+  border-radius: 3px 3px;
+  box-shadow: 3px 4px 6px rgba(123, 246, 114, 0.7);
+  transform: rotate(123deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box124 {
+  --cssB-v-124: 981956;
+  color: hsl(268, 12%, 48%);
+  background-color: hsl(88, 12%, 52%);
+  border: 5px solid hsl(358, 50%, 50%);
+  margin: 4px 12px 20px 4px;
+  padding: 4px 6px;
+  border-radius: 4px 5px;
+  box-shadow: 4px 5px 7px rgba(124, 248, 117, 0.8);
+  transform: rotate(124deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box125 {
+  --cssB-v-125: 989875;
+  color: hsl(305, 25%, 55%);
+  background-color: hsl(125, 25%, 45%);
+  border: 1px solid hsl(35, 50%, 50%);
+  margin: 5px 15px 0px 11px;
+  padding: 5px 8px;
+  border-radius: 5px 7px;
+  box-shadow: 0px 6px 8px rgba(125, 250, 120, 0.9);
+  transform: rotate(125deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box126 {
+  --cssB-v-126: 997794;
+  color: hsl(342, 38%, 62%);
+  background-color: hsl(162, 38%, 38%);
+  border: 2px solid hsl(72, 50%, 50%);
+  margin: 6px 18px 5px 0px;
+  padding: 6px 10px;
+  border-radius: 6px 0px;
+  box-shadow: 1px 0px 0px rgba(126, 252, 123, 0.1);
+  transform: rotate(126deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box127 {
+  --cssB-v-127: 5713;
+  color: hsl(19, 51%, 69%);
+  background-color: hsl(199, 51%, 31%);
+  border: 3px solid hsl(109, 50%, 50%);
+  margin: 7px 21px 10px 7px;
+  padding: 7px 12px;
+  border-radius: 7px 2px;
+  box-shadow: 2px 1px 1px rgba(127, 254, 126, 0.2);
+  transform: rotate(127deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box128 {
+  --cssB-v-128: 13632;
+  color: hsl(56, 64%, 76%);
+  background-color: hsl(236, 64%, 24%);
+  border: 4px solid hsl(146, 50%, 50%);
+  margin: 8px 24px 15px 14px;
+  padding: 8px 14px;
+  border-radius: 8px 4px;
+  box-shadow: 3px 2px 2px rgba(128, 1, 129, 0.3);
+  transform: rotate(128deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box129 {
+  --cssB-v-129: 21551;
+  color: hsl(93, 77%, 33%);
+  background-color: hsl(273, 77%, 67%);
+  border: 5px solid hsl(183, 50%, 50%);
+  margin: 9px 27px 20px 3px;
+  padding: 9px 16px;
+  border-radius: 9px 6px;
+  box-shadow: 4px 3px 3px rgba(129, 3, 132, 0.4);
+  transform: rotate(129deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box130 {
+  --cssB-v-130: 29470;
+  color: hsl(130, 90%, 40%);
+  background-color: hsl(310, 90%, 60%);
+  border: 1px solid hsl(220, 50%, 50%);
+  margin: 10px 0px 0px 10px;
+  padding: 10px 18px;
+  border-radius: 10px 8px;
+  box-shadow: 0px 4px 4px rgba(130, 5, 135, 0.5);
+  transform: rotate(130deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box131 {
+  --cssB-v-131: 37389;
+  color: hsl(167, 3%, 47%);
+  background-color: hsl(347, 3%, 53%);
+  border: 2px solid hsl(257, 50%, 50%);
+  margin: 11px 3px 5px 17px;
+  padding: 11px 20px;
+  border-radius: 11px 1px;
+  box-shadow: 1px 5px 5px rgba(131, 7, 138, 0.6);
+  transform: rotate(131deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box132 {
+  --cssB-v-132: 45308;
+  color: hsl(204, 16%, 54%);
+  background-color: hsl(24, 16%, 46%);
+  border: 3px solid hsl(294, 50%, 50%);
+  margin: 12px 6px 10px 6px;
+  padding: 12px 0px;
+  border-radius: 0px 3px;
+  box-shadow: 2px 6px 6px rgba(132, 9, 141, 0.7);
+  transform: rotate(132deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box133 {
+  --cssB-v-133: 53227;
+  color: hsl(241, 29%, 61%);
+  background-color: hsl(61, 29%, 39%);
+  border: 4px solid hsl(331, 50%, 50%);
+  margin: 13px 9px 15px 13px;
+  padding: 13px 2px;
+  border-radius: 1px 5px;
+  box-shadow: 3px 0px 7px rgba(133, 11, 144, 0.8);
+  transform: rotate(133deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box134 {
+  --cssB-v-134: 61146;
+  color: hsl(278, 42%, 68%);
+  background-color: hsl(98, 42%, 32%);
+  border: 5px solid hsl(8, 50%, 50%);
+  margin: 14px 12px 20px 2px;
+  padding: 14px 4px;
+  border-radius: 2px 7px;
+  box-shadow: 4px 1px 8px rgba(134, 13, 147, 0.9);
+  transform: rotate(134deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box135 {
+  --cssB-v-135: 69065;
+  color: hsl(315, 55%, 75%);
+  background-color: hsl(135, 55%, 25%);
+  border: 1px solid hsl(45, 50%, 50%);
+  margin: 15px 15px 0px 9px;
+  padding: 0px 6px;
+  border-radius: 3px 0px;
+  box-shadow: 0px 2px 0px rgba(135, 15, 150, 0.1);
+  transform: rotate(135deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box136 {
+  --cssB-v-136: 76984;
+  color: hsl(352, 68%, 32%);
+  background-color: hsl(172, 68%, 68%);
+  border: 2px solid hsl(82, 50%, 50%);
+  margin: 16px 18px 5px 16px;
+  padding: 1px 8px;
+  border-radius: 4px 2px;
+  box-shadow: 1px 3px 1px rgba(136, 17, 153, 0.2);
+  transform: rotate(136deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box137 {
+  --cssB-v-137: 84903;
+  color: hsl(29, 81%, 39%);
+  background-color: hsl(209, 81%, 61%);
+  border: 3px solid hsl(119, 50%, 50%);
+  margin: 17px 21px 10px 5px;
+  padding: 2px 10px;
+  border-radius: 5px 4px;
+  box-shadow: 2px 4px 2px rgba(137, 19, 156, 0.3);
+  transform: rotate(137deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box138 {
+  --cssB-v-138: 92822;
+  color: hsl(66, 94%, 46%);
+  background-color: hsl(246, 94%, 54%);
+  border: 4px solid hsl(156, 50%, 50%);
+  margin: 18px 24px 15px 12px;
+  padding: 3px 12px;
+  border-radius: 6px 6px;
+  box-shadow: 3px 5px 3px rgba(138, 21, 159, 0.4);
+  transform: rotate(138deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box139 {
+  --cssB-v-139: 100741;
+  color: hsl(103, 7%, 53%);
+  background-color: hsl(283, 7%, 47%);
+  border: 5px solid hsl(193, 50%, 50%);
+  margin: 19px 27px 20px 1px;
+  padding: 4px 14px;
+  border-radius: 7px 8px;
+  box-shadow: 4px 6px 4px rgba(139, 23, 162, 0.5);
+  transform: rotate(139deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box140 {
+  --cssB-v-140: 108660;
+  color: hsl(140, 20%, 60%);
+  background-color: hsl(320, 20%, 40%);
+  border: 1px solid hsl(230, 50%, 50%);
+  margin: 0px 0px 0px 8px;
+  padding: 5px 16px;
+  border-radius: 8px 1px;
+  box-shadow: 0px 0px 5px rgba(140, 25, 165, 0.6);
+  transform: rotate(140deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box141 {
+  --cssB-v-141: 116579;
+  color: hsl(177, 33%, 67%);
+  background-color: hsl(357, 33%, 33%);
+  border: 2px solid hsl(267, 50%, 50%);
+  margin: 1px 3px 5px 15px;
+  padding: 6px 18px;
+  border-radius: 9px 3px;
+  box-shadow: 1px 1px 6px rgba(141, 27, 168, 0.7);
+  transform: rotate(141deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box142 {
+  --cssB-v-142: 124498;
+  color: hsl(214, 46%, 74%);
+  background-color: hsl(34, 46%, 26%);
+  border: 3px solid hsl(304, 50%, 50%);
+  margin: 2px 6px 10px 4px;
+  padding: 7px 20px;
+  border-radius: 10px 5px;
+  box-shadow: 2px 2px 7px rgba(142, 29, 171, 0.8);
+  transform: rotate(142deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box143 {
+  --cssB-v-143: 132417;
+  color: hsl(251, 59%, 31%);
+  background-color: hsl(71, 59%, 69%);
+  border: 4px solid hsl(341, 50%, 50%);
+  margin: 3px 9px 15px 11px;
+  padding: 8px 0px;
+  border-radius: 11px 7px;
+  box-shadow: 3px 3px 8px rgba(143, 31, 174, 0.9);
+  transform: rotate(143deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box144 {
+  --cssB-v-144: 140336;
+  color: hsl(288, 72%, 38%);
+  background-color: hsl(108, 72%, 62%);
+  border: 5px solid hsl(18, 50%, 50%);
+  margin: 4px 12px 20px 0px;
+  padding: 9px 2px;
+  border-radius: 0px 0px;
+  box-shadow: 4px 4px 0px rgba(144, 33, 177, 0.1);
+  transform: rotate(144deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box145 {
+  --cssB-v-145: 148255;
+  color: hsl(325, 85%, 45%);
+  background-color: hsl(145, 85%, 55%);
+  border: 1px solid hsl(55, 50%, 50%);
+  margin: 5px 15px 0px 7px;
+  padding: 10px 4px;
+  border-radius: 1px 2px;
+  box-shadow: 0px 5px 1px rgba(145, 35, 180, 0.2);
+  transform: rotate(145deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box146 {
+  --cssB-v-146: 156174;
+  color: hsl(2, 98%, 52%);
+  background-color: hsl(182, 98%, 48%);
+  border: 2px solid hsl(92, 50%, 50%);
+  margin: 6px 18px 5px 14px;
+  padding: 11px 6px;
+  border-radius: 2px 4px;
+  box-shadow: 1px 6px 2px rgba(146, 37, 183, 0.3);
+  transform: rotate(146deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box147 {
+  --cssB-v-147: 164093;
+  color: hsl(39, 11%, 59%);
+  background-color: hsl(219, 11%, 41%);
+  border: 3px solid hsl(129, 50%, 50%);
+  margin: 7px 21px 10px 3px;
+  padding: 12px 8px;
+  border-radius: 3px 6px;
+  box-shadow: 2px 0px 3px rgba(147, 39, 186, 0.4);
+  transform: rotate(147deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box148 {
+  --cssB-v-148: 172012;
+  color: hsl(76, 24%, 66%);
+  background-color: hsl(256, 24%, 34%);
+  border: 4px solid hsl(166, 50%, 50%);
+  margin: 8px 24px 15px 10px;
+  padding: 13px 10px;
+  border-radius: 4px 8px;
+  box-shadow: 3px 1px 4px rgba(148, 41, 189, 0.5);
+  transform: rotate(148deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box149 {
+  --cssB-v-149: 179931;
+  color: hsl(113, 37%, 73%);
+  background-color: hsl(293, 37%, 27%);
+  border: 5px solid hsl(203, 50%, 50%);
+  margin: 9px 27px 20px 17px;
+  padding: 14px 12px;
+  border-radius: 5px 1px;
+  box-shadow: 4px 2px 5px rgba(149, 43, 192, 0.6);
+  transform: rotate(149deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box150 {
+  --cssB-v-150: 187850;
+  color: hsl(150, 50%, 30%);
+  background-color: hsl(330, 50%, 70%);
+  border: 1px solid hsl(240, 50%, 50%);
+  margin: 10px 0px 0px 6px;
+  padding: 0px 14px;
+  border-radius: 6px 3px;
+  box-shadow: 0px 3px 6px rgba(150, 45, 195, 0.7);
+  transform: rotate(150deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box151 {
+  --cssB-v-151: 195769;
+  color: hsl(187, 63%, 37%);
+  background-color: hsl(7, 63%, 63%);
+  border: 2px solid hsl(277, 50%, 50%);
+  margin: 11px 3px 5px 13px;
+  padding: 1px 16px;
+  border-radius: 7px 5px;
+  box-shadow: 1px 4px 7px rgba(151, 47, 198, 0.8);
+  transform: rotate(151deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box152 {
+  --cssB-v-152: 203688;
+  color: hsl(224, 76%, 44%);
+  background-color: hsl(44, 76%, 56%);
+  border: 3px solid hsl(314, 50%, 50%);
+  margin: 12px 6px 10px 2px;
+  padding: 2px 18px;
+  border-radius: 8px 7px;
+  box-shadow: 2px 5px 8px rgba(152, 49, 201, 0.9);
+  transform: rotate(152deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box153 {
+  --cssB-v-153: 211607;
+  color: hsl(261, 89%, 51%);
+  background-color: hsl(81, 89%, 49%);
+  border: 4px solid hsl(351, 50%, 50%);
+  margin: 13px 9px 15px 9px;
+  padding: 3px 20px;
+  border-radius: 9px 0px;
+  box-shadow: 3px 6px 0px rgba(153, 51, 204, 0.1);
+  transform: rotate(153deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box154 {
+  --cssB-v-154: 219526;
+  color: hsl(298, 2%, 58%);
+  background-color: hsl(118, 2%, 42%);
+  border: 5px solid hsl(28, 50%, 50%);
+  margin: 14px 12px 20px 16px;
+  padding: 4px 0px;
+  border-radius: 10px 2px;
+  box-shadow: 4px 0px 1px rgba(154, 53, 207, 0.2);
+  transform: rotate(154deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box155 {
+  --cssB-v-155: 227445;
+  color: hsl(335, 15%, 65%);
+  background-color: hsl(155, 15%, 35%);
+  border: 1px solid hsl(65, 50%, 50%);
+  margin: 15px 15px 0px 5px;
+  padding: 5px 2px;
+  border-radius: 11px 4px;
+  box-shadow: 0px 1px 2px rgba(155, 55, 210, 0.3);
+  transform: rotate(155deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box156 {
+  --cssB-v-156: 235364;
+  color: hsl(12, 28%, 72%);
+  background-color: hsl(192, 28%, 28%);
+  border: 2px solid hsl(102, 50%, 50%);
+  margin: 16px 18px 5px 12px;
+  padding: 6px 4px;
+  border-radius: 0px 6px;
+  box-shadow: 1px 2px 3px rgba(156, 57, 213, 0.4);
+  transform: rotate(156deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box157 {
+  --cssB-v-157: 243283;
+  color: hsl(49, 41%, 79%);
+  background-color: hsl(229, 41%, 21%);
+  border: 3px solid hsl(139, 50%, 50%);
+  margin: 17px 21px 10px 1px;
+  padding: 7px 6px;
+  border-radius: 1px 8px;
+  box-shadow: 2px 3px 4px rgba(157, 59, 216, 0.5);
+  transform: rotate(157deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box158 {
+  --cssB-v-158: 251202;
+  color: hsl(86, 54%, 36%);
+  background-color: hsl(266, 54%, 64%);
+  border: 4px solid hsl(176, 50%, 50%);
+  margin: 18px 24px 15px 8px;
+  padding: 8px 8px;
+  border-radius: 2px 1px;
+  box-shadow: 3px 4px 5px rgba(158, 61, 219, 0.6);
+  transform: rotate(158deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box159 {
+  --cssB-v-159: 259121;
+  color: hsl(123, 67%, 43%);
+  background-color: hsl(303, 67%, 57%);
+  border: 5px solid hsl(213, 50%, 50%);
+  margin: 19px 27px 20px 15px;
+  padding: 9px 10px;
+  border-radius: 3px 3px;
+  box-shadow: 4px 5px 6px rgba(159, 63, 222, 0.7);
+  transform: rotate(159deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box160 {
+  --cssB-v-160: 267040;
+  color: hsl(160, 80%, 50%);
+  background-color: hsl(340, 80%, 50%);
+  border: 1px solid hsl(250, 50%, 50%);
+  margin: 0px 0px 0px 4px;
+  padding: 10px 12px;
+  border-radius: 4px 5px;
+  box-shadow: 0px 6px 7px rgba(160, 65, 225, 0.8);
+  transform: rotate(160deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box161 {
+  --cssB-v-161: 274959;
+  color: hsl(197, 93%, 57%);
+  background-color: hsl(17, 93%, 43%);
+  border: 2px solid hsl(287, 50%, 50%);
+  margin: 1px 3px 5px 11px;
+  padding: 11px 14px;
+  border-radius: 5px 7px;
+  box-shadow: 1px 0px 8px rgba(161, 67, 228, 0.9);
+  transform: rotate(161deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box162 {
+  --cssB-v-162: 282878;
+  color: hsl(234, 6%, 64%);
+  background-color: hsl(54, 6%, 36%);
+  border: 3px solid hsl(324, 50%, 50%);
+  margin: 2px 6px 10px 0px;
+  padding: 12px 16px;
+  border-radius: 6px 0px;
+  box-shadow: 2px 1px 0px rgba(162, 69, 231, 0.1);
+  transform: rotate(162deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box163 {
+  --cssB-v-163: 290797;
+  color: hsl(271, 19%, 71%);
+  background-color: hsl(91, 19%, 29%);
+  border: 4px solid hsl(1, 50%, 50%);
+  margin: 3px 9px 15px 7px;
+  padding: 13px 18px;
+  border-radius: 7px 2px;
+  box-shadow: 3px 2px 1px rgba(163, 71, 234, 0.2);
+  transform: rotate(163deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box164 {
+  --cssB-v-164: 298716;
+  color: hsl(308, 32%, 78%);
+  background-color: hsl(128, 32%, 22%);
+  border: 5px solid hsl(38, 50%, 50%);
+  margin: 4px 12px 20px 14px;
+  padding: 14px 20px;
+  border-radius: 8px 4px;
+  box-shadow: 4px 3px 2px rgba(164, 73, 237, 0.3);
+  transform: rotate(164deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box165 {
+  --cssB-v-165: 306635;
+  color: hsl(345, 45%, 35%);
+  background-color: hsl(165, 45%, 65%);
+  border: 1px solid hsl(75, 50%, 50%);
+  margin: 5px 15px 0px 3px;
+  padding: 0px 0px;
+  border-radius: 9px 6px;
+  box-shadow: 0px 4px 3px rgba(165, 75, 240, 0.4);
+  transform: rotate(165deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box166 {
+  --cssB-v-166: 314554;
+  color: hsl(22, 58%, 42%);
+  background-color: hsl(202, 58%, 58%);
+  border: 2px solid hsl(112, 50%, 50%);
+  margin: 6px 18px 5px 10px;
+  padding: 1px 2px;
+  border-radius: 10px 8px;
+  box-shadow: 1px 5px 4px rgba(166, 77, 243, 0.5);
+  transform: rotate(166deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box167 {
+  --cssB-v-167: 322473;
+  color: hsl(59, 71%, 49%);
+  background-color: hsl(239, 71%, 51%);
+  border: 3px solid hsl(149, 50%, 50%);
+  margin: 7px 21px 10px 17px;
+  padding: 2px 4px;
+  border-radius: 11px 1px;
+  box-shadow: 2px 6px 5px rgba(167, 79, 246, 0.6);
+  transform: rotate(167deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box168 {
+  --cssB-v-168: 330392;
+  color: hsl(96, 84%, 56%);
+  background-color: hsl(276, 84%, 44%);
+  border: 4px solid hsl(186, 50%, 50%);
+  margin: 8px 24px 15px 6px;
+  padding: 3px 6px;
+  border-radius: 0px 3px;
+  box-shadow: 3px 0px 6px rgba(168, 81, 249, 0.7);
+  transform: rotate(168deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box169 {
+  --cssB-v-169: 338311;
+  color: hsl(133, 97%, 63%);
+  background-color: hsl(313, 97%, 37%);
+  border: 5px solid hsl(223, 50%, 50%);
+  margin: 9px 27px 20px 13px;
+  padding: 4px 8px;
+  border-radius: 1px 5px;
+  box-shadow: 4px 1px 7px rgba(169, 83, 252, 0.8);
+  transform: rotate(169deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box170 {
+  --cssB-v-170: 346230;
+  color: hsl(170, 10%, 70%);
+  background-color: hsl(350, 10%, 30%);
+  border: 1px solid hsl(260, 50%, 50%);
+  margin: 10px 0px 0px 2px;
+  padding: 5px 10px;
+  border-radius: 2px 7px;
+  box-shadow: 0px 2px 8px rgba(170, 85, 0, 0.9);
+  transform: rotate(170deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box171 {
+  --cssB-v-171: 354149;
+  color: hsl(207, 23%, 77%);
+  background-color: hsl(27, 23%, 23%);
+  border: 2px solid hsl(297, 50%, 50%);
+  margin: 11px 3px 5px 9px;
+  padding: 6px 12px;
+  border-radius: 3px 0px;
+  box-shadow: 1px 3px 0px rgba(171, 87, 3, 0.1);
+  transform: rotate(171deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box172 {
+  --cssB-v-172: 362068;
+  color: hsl(244, 36%, 34%);
+  background-color: hsl(64, 36%, 66%);
+  border: 3px solid hsl(334, 50%, 50%);
+  margin: 12px 6px 10px 16px;
+  padding: 7px 14px;
+  border-radius: 4px 2px;
+  box-shadow: 2px 4px 1px rgba(172, 89, 6, 0.2);
+  transform: rotate(172deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box173 {
+  --cssB-v-173: 369987;
+  color: hsl(281, 49%, 41%);
+  background-color: hsl(101, 49%, 59%);
+  border: 4px solid hsl(11, 50%, 50%);
+  margin: 13px 9px 15px 5px;
+  padding: 8px 16px;
+  border-radius: 5px 4px;
+  box-shadow: 3px 5px 2px rgba(173, 91, 9, 0.3);
+  transform: rotate(173deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box174 {
+  --cssB-v-174: 377906;
+  color: hsl(318, 62%, 48%);
+  background-color: hsl(138, 62%, 52%);
+  border: 5px solid hsl(48, 50%, 50%);
+  margin: 14px 12px 20px 12px;
+  padding: 9px 18px;
+  border-radius: 6px 6px;
+  box-shadow: 4px 6px 3px rgba(174, 93, 12, 0.4);
+  transform: rotate(174deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box175 {
+  --cssB-v-175: 385825;
+  color: hsl(355, 75%, 55%);
+  background-color: hsl(175, 75%, 45%);
+  border: 1px solid hsl(85, 50%, 50%);
+  margin: 15px 15px 0px 1px;
+  padding: 10px 20px;
+  border-radius: 7px 8px;
+  box-shadow: 0px 0px 4px rgba(175, 95, 15, 0.5);
+  transform: rotate(175deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box176 {
+  --cssB-v-176: 393744;
+  color: hsl(32, 88%, 62%);
+  background-color: hsl(212, 88%, 38%);
+  border: 2px solid hsl(122, 50%, 50%);
+  margin: 16px 18px 5px 8px;
+  padding: 11px 0px;
+  border-radius: 8px 1px;
+  box-shadow: 1px 1px 5px rgba(176, 97, 18, 0.6);
+  transform: rotate(176deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box177 {
+  --cssB-v-177: 401663;
+  color: hsl(69, 1%, 69%);
+  background-color: hsl(249, 1%, 31%);
+  border: 3px solid hsl(159, 50%, 50%);
+  margin: 17px 21px 10px 15px;
+  padding: 12px 2px;
+  border-radius: 9px 3px;
+  box-shadow: 2px 2px 6px rgba(177, 99, 21, 0.7);
+  transform: rotate(177deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box178 {
+  --cssB-v-178: 409582;
+  color: hsl(106, 14%, 76%);
+  background-color: hsl(286, 14%, 24%);
+  border: 4px solid hsl(196, 50%, 50%);
+  margin: 18px 24px 15px 4px;
+  padding: 13px 4px;
+  border-radius: 10px 5px;
+  box-shadow: 3px 3px 7px rgba(178, 101, 24, 0.8);
+  transform: rotate(178deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box179 {
+  --cssB-v-179: 417501;
+  color: hsl(143, 27%, 33%);
+  background-color: hsl(323, 27%, 67%);
+  border: 5px solid hsl(233, 50%, 50%);
+  margin: 19px 27px 20px 11px;
+  padding: 14px 6px;
+  border-radius: 11px 7px;
+  box-shadow: 4px 4px 8px rgba(179, 103, 27, 0.9);
+  transform: rotate(179deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box180 {
+  --cssB-v-180: 425420;
+  color: hsl(180, 40%, 40%);
+  background-color: hsl(0, 40%, 60%);
+  border: 1px solid hsl(270, 50%, 50%);
+  margin: 0px 0px 0px 0px;
+  padding: 0px 8px;
+  border-radius: 0px 0px;
+  box-shadow: 0px 5px 0px rgba(180, 105, 30, 0.1);
+  transform: rotate(180deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box181 {
+  --cssB-v-181: 433339;
+  color: hsl(217, 53%, 47%);
+  background-color: hsl(37, 53%, 53%);
+  border: 2px solid hsl(307, 50%, 50%);
+  margin: 1px 3px 5px 7px;
+  padding: 1px 10px;
+  border-radius: 1px 2px;
+  box-shadow: 1px 6px 1px rgba(181, 107, 33, 0.2);
+  transform: rotate(181deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box182 {
+  --cssB-v-182: 441258;
+  color: hsl(254, 66%, 54%);
+  background-color: hsl(74, 66%, 46%);
+  border: 3px solid hsl(344, 50%, 50%);
+  margin: 2px 6px 10px 14px;
+  padding: 2px 12px;
+  border-radius: 2px 4px;
+  box-shadow: 2px 0px 2px rgba(182, 109, 36, 0.3);
+  transform: rotate(182deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box183 {
+  --cssB-v-183: 449177;
+  color: hsl(291, 79%, 61%);
+  background-color: hsl(111, 79%, 39%);
+  border: 4px solid hsl(21, 50%, 50%);
+  margin: 3px 9px 15px 3px;
+  padding: 3px 14px;
+  border-radius: 3px 6px;
+  box-shadow: 3px 1px 3px rgba(183, 111, 39, 0.4);
+  transform: rotate(183deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box184 {
+  --cssB-v-184: 457096;
+  color: hsl(328, 92%, 68%);
+  background-color: hsl(148, 92%, 32%);
+  border: 5px solid hsl(58, 50%, 50%);
+  margin: 4px 12px 20px 10px;
+  padding: 4px 16px;
+  border-radius: 4px 8px;
+  box-shadow: 4px 2px 4px rgba(184, 113, 42, 0.5);
+  transform: rotate(184deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box185 {
+  --cssB-v-185: 465015;
+  color: hsl(5, 5%, 75%);
+  background-color: hsl(185, 5%, 25%);
+  border: 1px solid hsl(95, 50%, 50%);
+  margin: 5px 15px 0px 17px;
+  padding: 5px 18px;
+  border-radius: 5px 1px;
+  box-shadow: 0px 3px 5px rgba(185, 115, 45, 0.6);
+  transform: rotate(185deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box186 {
+  --cssB-v-186: 472934;
+  color: hsl(42, 18%, 32%);
+  background-color: hsl(222, 18%, 68%);
+  border: 2px solid hsl(132, 50%, 50%);
+  margin: 6px 18px 5px 6px;
+  padding: 6px 20px;
+  border-radius: 6px 3px;
+  box-shadow: 1px 4px 6px rgba(186, 117, 48, 0.7);
+  transform: rotate(186deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box187 {
+  --cssB-v-187: 480853;
+  color: hsl(79, 31%, 39%);
+  background-color: hsl(259, 31%, 61%);
+  border: 3px solid hsl(169, 50%, 50%);
+  margin: 7px 21px 10px 13px;
+  padding: 7px 0px;
+  border-radius: 7px 5px;
+  box-shadow: 2px 5px 7px rgba(187, 119, 51, 0.8);
+  transform: rotate(187deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box188 {
+  --cssB-v-188: 488772;
+  color: hsl(116, 44%, 46%);
+  background-color: hsl(296, 44%, 54%);
+  border: 4px solid hsl(206, 50%, 50%);
+  margin: 8px 24px 15px 2px;
+  padding: 8px 2px;
+  border-radius: 8px 7px;
+  box-shadow: 3px 6px 8px rgba(188, 121, 54, 0.9);
+  transform: rotate(188deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box189 {
+  --cssB-v-189: 496691;
+  color: hsl(153, 57%, 53%);
+  background-color: hsl(333, 57%, 47%);
+  border: 5px solid hsl(243, 50%, 50%);
+  margin: 9px 27px 20px 9px;
+  padding: 9px 4px;
+  border-radius: 9px 0px;
+  box-shadow: 4px 0px 0px rgba(189, 123, 57, 0.1);
+  transform: rotate(189deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box190 {
+  --cssB-v-190: 504610;
+  color: hsl(190, 70%, 60%);
+  background-color: hsl(10, 70%, 40%);
+  border: 1px solid hsl(280, 50%, 50%);
+  margin: 10px 0px 0px 16px;
+  padding: 10px 6px;
+  border-radius: 10px 2px;
+  box-shadow: 0px 1px 1px rgba(190, 125, 60, 0.2);
+  transform: rotate(190deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box191 {
+  --cssB-v-191: 512529;
+  color: hsl(227, 83%, 67%);
+  background-color: hsl(47, 83%, 33%);
+  border: 2px solid hsl(317, 50%, 50%);
+  margin: 11px 3px 5px 5px;
+  padding: 11px 8px;
+  border-radius: 11px 4px;
+  box-shadow: 1px 2px 2px rgba(191, 127, 63, 0.3);
+  transform: rotate(191deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box192 {
+  --cssB-v-192: 520448;
+  color: hsl(264, 96%, 74%);
+  background-color: hsl(84, 96%, 26%);
+  border: 3px solid hsl(354, 50%, 50%);
+  margin: 12px 6px 10px 12px;
+  padding: 12px 10px;
+  border-radius: 0px 6px;
+  box-shadow: 2px 3px 3px rgba(192, 129, 66, 0.4);
+  transform: rotate(192deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box193 {
+  --cssB-v-193: 528367;
+  color: hsl(301, 9%, 31%);
+  background-color: hsl(121, 9%, 69%);
+  border: 4px solid hsl(31, 50%, 50%);
+  margin: 13px 9px 15px 1px;
+  padding: 13px 12px;
+  border-radius: 1px 8px;
+  box-shadow: 3px 4px 4px rgba(193, 131, 69, 0.5);
+  transform: rotate(193deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box194 {
+  --cssB-v-194: 536286;
+  color: hsl(338, 22%, 38%);
+  background-color: hsl(158, 22%, 62%);
+  border: 5px solid hsl(68, 50%, 50%);
+  margin: 14px 12px 20px 8px;
+  padding: 14px 14px;
+  border-radius: 2px 1px;
+  box-shadow: 4px 5px 5px rgba(194, 133, 72, 0.6);
+  transform: rotate(194deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box195 {
+  --cssB-v-195: 544205;
+  color: hsl(15, 35%, 45%);
+  background-color: hsl(195, 35%, 55%);
+  border: 1px solid hsl(105, 50%, 50%);
+  margin: 15px 15px 0px 15px;
+  padding: 0px 16px;
+  border-radius: 3px 3px;
+  box-shadow: 0px 6px 6px rgba(195, 135, 75, 0.7);
+  transform: rotate(195deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box196 {
+  --cssB-v-196: 552124;
+  color: hsl(52, 48%, 52%);
+  background-color: hsl(232, 48%, 48%);
+  border: 2px solid hsl(142, 50%, 50%);
+  margin: 16px 18px 5px 4px;
+  padding: 1px 18px;
+  border-radius: 4px 5px;
+  box-shadow: 1px 0px 7px rgba(196, 137, 78, 0.8);
+  transform: rotate(196deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box197 {
+  --cssB-v-197: 560043;
+  color: hsl(89, 61%, 59%);
+  background-color: hsl(269, 61%, 41%);
+  border: 3px solid hsl(179, 50%, 50%);
+  margin: 17px 21px 10px 11px;
+  padding: 2px 20px;
+  border-radius: 5px 7px;
+  box-shadow: 2px 1px 8px rgba(197, 139, 81, 0.9);
+  transform: rotate(197deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box198 {
+  --cssB-v-198: 567962;
+  color: hsl(126, 74%, 66%);
+  background-color: hsl(306, 74%, 34%);
+  border: 4px solid hsl(216, 50%, 50%);
+  margin: 18px 24px 15px 0px;
+  padding: 3px 0px;
+  border-radius: 6px 0px;
+  box-shadow: 3px 2px 0px rgba(198, 141, 84, 0.1);
+  transform: rotate(198deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box199 {
+  --cssB-v-199: 575881;
+  color: hsl(163, 87%, 73%);
+  background-color: hsl(343, 87%, 27%);
+  border: 5px solid hsl(253, 50%, 50%);
+  margin: 19px 27px 20px 7px;
+  padding: 4px 2px;
+  border-radius: 7px 2px;
+  box-shadow: 4px 3px 1px rgba(199, 143, 87, 0.2);
+  transform: rotate(199deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box200 {
+  --cssB-v-200: 583800;
+  color: hsl(200, 0%, 30%);
+  background-color: hsl(20, 0%, 70%);
+  border: 1px solid hsl(290, 50%, 50%);
+  margin: 0px 0px 0px 14px;
+  padding: 5px 4px;
+  border-radius: 8px 4px;
+  box-shadow: 0px 4px 2px rgba(200, 145, 90, 0.3);
+  transform: rotate(200deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box201 {
+  --cssB-v-201: 591719;
+  color: hsl(237, 13%, 37%);
+  background-color: hsl(57, 13%, 63%);
+  border: 2px solid hsl(327, 50%, 50%);
+  margin: 1px 3px 5px 3px;
+  padding: 6px 6px;
+  border-radius: 9px 6px;
+  box-shadow: 1px 5px 3px rgba(201, 147, 93, 0.4);
+  transform: rotate(201deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box202 {
+  --cssB-v-202: 599638;
+  color: hsl(274, 26%, 44%);
+  background-color: hsl(94, 26%, 56%);
+  border: 3px solid hsl(4, 50%, 50%);
+  margin: 2px 6px 10px 10px;
+  padding: 7px 8px;
+  border-radius: 10px 8px;
+  box-shadow: 2px 6px 4px rgba(202, 149, 96, 0.5);
+  transform: rotate(202deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box203 {
+  --cssB-v-203: 607557;
+  color: hsl(311, 39%, 51%);
+  background-color: hsl(131, 39%, 49%);
+  border: 4px solid hsl(41, 50%, 50%);
+  margin: 3px 9px 15px 17px;
+  padding: 8px 10px;
+  border-radius: 11px 1px;
+  box-shadow: 3px 0px 5px rgba(203, 151, 99, 0.6);
+  transform: rotate(203deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box204 {
+  --cssB-v-204: 615476;
+  color: hsl(348, 52%, 58%);
+  background-color: hsl(168, 52%, 42%);
+  border: 5px solid hsl(78, 50%, 50%);
+  margin: 4px 12px 20px 6px;
+  padding: 9px 12px;
+  border-radius: 0px 3px;
+  box-shadow: 4px 1px 6px rgba(204, 153, 102, 0.7);
+  transform: rotate(204deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box205 {
+  --cssB-v-205: 623395;
+  color: hsl(25, 65%, 65%);
+  background-color: hsl(205, 65%, 35%);
+  border: 1px solid hsl(115, 50%, 50%);
+  margin: 5px 15px 0px 13px;
+  padding: 10px 14px;
+  border-radius: 1px 5px;
+  box-shadow: 0px 2px 7px rgba(205, 155, 105, 0.8);
+  transform: rotate(205deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box206 {
+  --cssB-v-206: 631314;
+  color: hsl(62, 78%, 72%);
+  background-color: hsl(242, 78%, 28%);
+  border: 2px solid hsl(152, 50%, 50%);
+  margin: 6px 18px 5px 2px;
+  padding: 11px 16px;
+  border-radius: 2px 7px;
+  box-shadow: 1px 3px 8px rgba(206, 157, 108, 0.9);
+  transform: rotate(206deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box207 {
+  --cssB-v-207: 639233;
+  color: hsl(99, 91%, 79%);
+  background-color: hsl(279, 91%, 21%);
+  border: 3px solid hsl(189, 50%, 50%);
+  margin: 7px 21px 10px 9px;
+  padding: 12px 18px;
+  border-radius: 3px 0px;
+  box-shadow: 2px 4px 0px rgba(207, 159, 111, 0.1);
+  transform: rotate(207deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box208 {
+  --cssB-v-208: 647152;
+  color: hsl(136, 4%, 36%);
+  background-color: hsl(316, 4%, 64%);
+  border: 4px solid hsl(226, 50%, 50%);
+  margin: 8px 24px 15px 16px;
+  padding: 13px 20px;
+  border-radius: 4px 2px;
+  box-shadow: 3px 5px 1px rgba(208, 161, 114, 0.2);
+  transform: rotate(208deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box209 {
+  --cssB-v-209: 655071;
+  color: hsl(173, 17%, 43%);
+  background-color: hsl(353, 17%, 57%);
+  border: 5px solid hsl(263, 50%, 50%);
+  margin: 9px 27px 20px 5px;
+  padding: 14px 0px;
+  border-radius: 5px 4px;
+  box-shadow: 4px 6px 2px rgba(209, 163, 117, 0.3);
+  transform: rotate(209deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box210 {
+  --cssB-v-210: 662990;
+  color: hsl(210, 30%, 50%);
+  background-color: hsl(30, 30%, 50%);
+  border: 1px solid hsl(300, 50%, 50%);
+  margin: 10px 0px 0px 12px;
+  padding: 0px 2px;
+  border-radius: 6px 6px;
+  box-shadow: 0px 0px 3px rgba(210, 165, 120, 0.4);
+  transform: rotate(210deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box211 {
+  --cssB-v-211: 670909;
+  color: hsl(247, 43%, 57%);
+  background-color: hsl(67, 43%, 43%);
+  border: 2px solid hsl(337, 50%, 50%);
+  margin: 11px 3px 5px 1px;
+  padding: 1px 4px;
+  border-radius: 7px 8px;
+  box-shadow: 1px 1px 4px rgba(211, 167, 123, 0.5);
+  transform: rotate(211deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box212 {
+  --cssB-v-212: 678828;
+  color: hsl(284, 56%, 64%);
+  background-color: hsl(104, 56%, 36%);
+  border: 3px solid hsl(14, 50%, 50%);
+  margin: 12px 6px 10px 8px;
+  padding: 2px 6px;
+  border-radius: 8px 1px;
+  box-shadow: 2px 2px 5px rgba(212, 169, 126, 0.6);
+  transform: rotate(212deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box213 {
+  --cssB-v-213: 686747;
+  color: hsl(321, 69%, 71%);
+  background-color: hsl(141, 69%, 29%);
+  border: 4px solid hsl(51, 50%, 50%);
+  margin: 13px 9px 15px 15px;
+  padding: 3px 8px;
+  border-radius: 9px 3px;
+  box-shadow: 3px 3px 6px rgba(213, 171, 129, 0.7);
+  transform: rotate(213deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box214 {
+  --cssB-v-214: 694666;
+  color: hsl(358, 82%, 78%);
+  background-color: hsl(178, 82%, 22%);
+  border: 5px solid hsl(88, 50%, 50%);
+  margin: 14px 12px 20px 4px;
+  padding: 4px 10px;
+  border-radius: 10px 5px;
+  box-shadow: 4px 4px 7px rgba(214, 173, 132, 0.8);
+  transform: rotate(214deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box215 {
+  --cssB-v-215: 702585;
+  color: hsl(35, 95%, 35%);
+  background-color: hsl(215, 95%, 65%);
+  border: 1px solid hsl(125, 50%, 50%);
+  margin: 15px 15px 0px 11px;
+  padding: 5px 12px;
+  border-radius: 11px 7px;
+  box-shadow: 0px 5px 8px rgba(215, 175, 135, 0.9);
+  transform: rotate(215deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box216 {
+  --cssB-v-216: 710504;
+  color: hsl(72, 8%, 42%);
+  background-color: hsl(252, 8%, 58%);
+  border: 2px solid hsl(162, 50%, 50%);
+  margin: 16px 18px 5px 0px;
+  padding: 6px 14px;
+  border-radius: 0px 0px;
+  box-shadow: 1px 6px 0px rgba(216, 177, 138, 0.1);
+  transform: rotate(216deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box217 {
+  --cssB-v-217: 718423;
+  color: hsl(109, 21%, 49%);
+  background-color: hsl(289, 21%, 51%);
+  border: 3px solid hsl(199, 50%, 50%);
+  margin: 17px 21px 10px 7px;
+  padding: 7px 16px;
+  border-radius: 1px 2px;
+  box-shadow: 2px 0px 1px rgba(217, 179, 141, 0.2);
+  transform: rotate(217deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box218 {
+  --cssB-v-218: 726342;
+  color: hsl(146, 34%, 56%);
+  background-color: hsl(326, 34%, 44%);
+  border: 4px solid hsl(236, 50%, 50%);
+  margin: 18px 24px 15px 14px;
+  padding: 8px 18px;
+  border-radius: 2px 4px;
+  box-shadow: 3px 1px 2px rgba(218, 181, 144, 0.3);
+  transform: rotate(218deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box219 {
+  --cssB-v-219: 734261;
+  color: hsl(183, 47%, 63%);
+  background-color: hsl(3, 47%, 37%);
+  border: 5px solid hsl(273, 50%, 50%);
+  margin: 19px 27px 20px 3px;
+  padding: 9px 20px;
+  border-radius: 3px 6px;
+  box-shadow: 4px 2px 3px rgba(219, 183, 147, 0.4);
+  transform: rotate(219deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box220 {
+  --cssB-v-220: 742180;
+  color: hsl(220, 60%, 70%);
+  background-color: hsl(40, 60%, 30%);
+  border: 1px solid hsl(310, 50%, 50%);
+  margin: 0px 0px 0px 10px;
+  padding: 10px 0px;
+  border-radius: 4px 8px;
+  box-shadow: 0px 3px 4px rgba(220, 185, 150, 0.5);
+  transform: rotate(220deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box221 {
+  --cssB-v-221: 750099;
+  color: hsl(257, 73%, 77%);
+  background-color: hsl(77, 73%, 23%);
+  border: 2px solid hsl(347, 50%, 50%);
+  margin: 1px 3px 5px 17px;
+  padding: 11px 2px;
+  border-radius: 5px 1px;
+  box-shadow: 1px 4px 5px rgba(221, 187, 153, 0.6);
+  transform: rotate(221deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box222 {
+  --cssB-v-222: 758018;
+  color: hsl(294, 86%, 34%);
+  background-color: hsl(114, 86%, 66%);
+  border: 3px solid hsl(24, 50%, 50%);
+  margin: 2px 6px 10px 6px;
+  padding: 12px 4px;
+  border-radius: 6px 3px;
+  box-shadow: 2px 5px 6px rgba(222, 189, 156, 0.7);
+  transform: rotate(222deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box223 {
+  --cssB-v-223: 765937;
+  color: hsl(331, 99%, 41%);
+  background-color: hsl(151, 99%, 59%);
+  border: 4px solid hsl(61, 50%, 50%);
+  margin: 3px 9px 15px 13px;
+  padding: 13px 6px;
+  border-radius: 7px 5px;
+  box-shadow: 3px 6px 7px rgba(223, 191, 159, 0.8);
+  transform: rotate(223deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box224 {
+  --cssB-v-224: 773856;
+  color: hsl(8, 12%, 48%);
+  background-color: hsl(188, 12%, 52%);
+  border: 5px solid hsl(98, 50%, 50%);
+  margin: 4px 12px 20px 2px;
+  padding: 14px 8px;
+  border-radius: 8px 7px;
+  box-shadow: 4px 0px 8px rgba(224, 193, 162, 0.9);
+  transform: rotate(224deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box225 {
+  --cssB-v-225: 781775;
+  color: hsl(45, 25%, 55%);
+  background-color: hsl(225, 25%, 45%);
+  border: 1px solid hsl(135, 50%, 50%);
+  margin: 5px 15px 0px 9px;
+  padding: 0px 10px;
+  border-radius: 9px 0px;
+  box-shadow: 0px 1px 0px rgba(225, 195, 165, 0.1);
+  transform: rotate(225deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box226 {
+  --cssB-v-226: 789694;
+  color: hsl(82, 38%, 62%);
+  background-color: hsl(262, 38%, 38%);
+  border: 2px solid hsl(172, 50%, 50%);
+  margin: 6px 18px 5px 16px;
+  padding: 1px 12px;
+  border-radius: 10px 2px;
+  box-shadow: 1px 2px 1px rgba(226, 197, 168, 0.2);
+  transform: rotate(226deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box227 {
+  --cssB-v-227: 797613;
+  color: hsl(119, 51%, 69%);
+  background-color: hsl(299, 51%, 31%);
+  border: 3px solid hsl(209, 50%, 50%);
+  margin: 7px 21px 10px 5px;
+  padding: 2px 14px;
+  border-radius: 11px 4px;
+  box-shadow: 2px 3px 2px rgba(227, 199, 171, 0.3);
+  transform: rotate(227deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box228 {
+  --cssB-v-228: 805532;
+  color: hsl(156, 64%, 76%);
+  background-color: hsl(336, 64%, 24%);
+  border: 4px solid hsl(246, 50%, 50%);
+  margin: 8px 24px 15px 12px;
+  padding: 3px 16px;
+  border-radius: 0px 6px;
+  box-shadow: 3px 4px 3px rgba(228, 201, 174, 0.4);
+  transform: rotate(228deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box229 {
+  --cssB-v-229: 813451;
+  color: hsl(193, 77%, 33%);
+  background-color: hsl(13, 77%, 67%);
+  border: 5px solid hsl(283, 50%, 50%);
+  margin: 9px 27px 20px 1px;
+  padding: 4px 18px;
+  border-radius: 1px 8px;
+  box-shadow: 4px 5px 4px rgba(229, 203, 177, 0.5);
+  transform: rotate(229deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box230 {
+  --cssB-v-230: 821370;
+  color: hsl(230, 90%, 40%);
+  background-color: hsl(50, 90%, 60%);
+  border: 1px solid hsl(320, 50%, 50%);
+  margin: 10px 0px 0px 8px;
+  padding: 5px 20px;
+  border-radius: 2px 1px;
+  box-shadow: 0px 6px 5px rgba(230, 205, 180, 0.6);
+  transform: rotate(230deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box231 {
+  --cssB-v-231: 829289;
+  color: hsl(267, 3%, 47%);
+  background-color: hsl(87, 3%, 53%);
+  border: 2px solid hsl(357, 50%, 50%);
+  margin: 11px 3px 5px 15px;
+  padding: 6px 0px;
+  border-radius: 3px 3px;
+  box-shadow: 1px 0px 6px rgba(231, 207, 183, 0.7);
+  transform: rotate(231deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box232 {
+  --cssB-v-232: 837208;
+  color: hsl(304, 16%, 54%);
+  background-color: hsl(124, 16%, 46%);
+  border: 3px solid hsl(34, 50%, 50%);
+  margin: 12px 6px 10px 4px;
+  padding: 7px 2px;
+  border-radius: 4px 5px;
+  box-shadow: 2px 1px 7px rgba(232, 209, 186, 0.8);
+  transform: rotate(232deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box233 {
+  --cssB-v-233: 845127;
+  color: hsl(341, 29%, 61%);
+  background-color: hsl(161, 29%, 39%);
+  border: 4px solid hsl(71, 50%, 50%);
+  margin: 13px 9px 15px 11px;
+  padding: 8px 4px;
+  border-radius: 5px 7px;
+  box-shadow: 3px 2px 8px rgba(233, 211, 189, 0.9);
+  transform: rotate(233deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box234 {
+  --cssB-v-234: 853046;
+  color: hsl(18, 42%, 68%);
+  background-color: hsl(198, 42%, 32%);
+  border: 5px solid hsl(108, 50%, 50%);
+  margin: 14px 12px 20px 0px;
+  padding: 9px 6px;
+  border-radius: 6px 0px;
+  box-shadow: 4px 3px 0px rgba(234, 213, 192, 0.1);
+  transform: rotate(234deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box235 {
+  --cssB-v-235: 860965;
+  color: hsl(55, 55%, 75%);
+  background-color: hsl(235, 55%, 25%);
+  border: 1px solid hsl(145, 50%, 50%);
+  margin: 15px 15px 0px 7px;
+  padding: 10px 8px;
+  border-radius: 7px 2px;
+  box-shadow: 0px 4px 1px rgba(235, 215, 195, 0.2);
+  transform: rotate(235deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box236 {
+  --cssB-v-236: 868884;
+  color: hsl(92, 68%, 32%);
+  background-color: hsl(272, 68%, 68%);
+  border: 2px solid hsl(182, 50%, 50%);
+  margin: 16px 18px 5px 14px;
+  padding: 11px 10px;
+  border-radius: 8px 4px;
+  box-shadow: 1px 5px 2px rgba(236, 217, 198, 0.3);
+  transform: rotate(236deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box237 {
+  --cssB-v-237: 876803;
+  color: hsl(129, 81%, 39%);
+  background-color: hsl(309, 81%, 61%);
+  border: 3px solid hsl(219, 50%, 50%);
+  margin: 17px 21px 10px 3px;
+  padding: 12px 12px;
+  border-radius: 9px 6px;
+  box-shadow: 2px 6px 3px rgba(237, 219, 201, 0.4);
+  transform: rotate(237deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box238 {
+  --cssB-v-238: 884722;
+  color: hsl(166, 94%, 46%);
+  background-color: hsl(346, 94%, 54%);
+  border: 4px solid hsl(256, 50%, 50%);
+  margin: 18px 24px 15px 10px;
+  padding: 13px 14px;
+  border-radius: 10px 8px;
+  box-shadow: 3px 0px 4px rgba(238, 221, 204, 0.5);
+  transform: rotate(238deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box239 {
+  --cssB-v-239: 892641;
+  color: hsl(203, 7%, 53%);
+  background-color: hsl(23, 7%, 47%);
+  border: 5px solid hsl(293, 50%, 50%);
+  margin: 19px 27px 20px 17px;
+  padding: 14px 16px;
+  border-radius: 11px 1px;
+  box-shadow: 4px 1px 5px rgba(239, 223, 207, 0.6);
+  transform: rotate(239deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box240 {
+  --cssB-v-240: 900560;
+  color: hsl(240, 20%, 60%);
+  background-color: hsl(60, 20%, 40%);
+  border: 1px solid hsl(330, 50%, 50%);
+  margin: 0px 0px 0px 6px;
+  padding: 0px 18px;
+  border-radius: 0px 3px;
+  box-shadow: 0px 2px 6px rgba(240, 225, 210, 0.7);
+  transform: rotate(240deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box241 {
+  --cssB-v-241: 908479;
+  color: hsl(277, 33%, 67%);
+  background-color: hsl(97, 33%, 33%);
+  border: 2px solid hsl(7, 50%, 50%);
+  margin: 1px 3px 5px 13px;
+  padding: 1px 20px;
+  border-radius: 1px 5px;
+  box-shadow: 1px 3px 7px rgba(241, 227, 213, 0.8);
+  transform: rotate(241deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box242 {
+  --cssB-v-242: 916398;
+  color: hsl(314, 46%, 74%);
+  background-color: hsl(134, 46%, 26%);
+  border: 3px solid hsl(44, 50%, 50%);
+  margin: 2px 6px 10px 2px;
+  padding: 2px 0px;
+  border-radius: 2px 7px;
+  box-shadow: 2px 4px 8px rgba(242, 229, 216, 0.9);
+  transform: rotate(242deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box243 {
+  --cssB-v-243: 924317;
+  color: hsl(351, 59%, 31%);
+  background-color: hsl(171, 59%, 69%);
+  border: 4px solid hsl(81, 50%, 50%);
+  margin: 3px 9px 15px 9px;
+  padding: 3px 2px;
+  border-radius: 3px 0px;
+  box-shadow: 3px 5px 0px rgba(243, 231, 219, 0.1);
+  transform: rotate(243deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box244 {
+  --cssB-v-244: 932236;
+  color: hsl(28, 72%, 38%);
+  background-color: hsl(208, 72%, 62%);
+  border: 5px solid hsl(118, 50%, 50%);
+  margin: 4px 12px 20px 16px;
+  padding: 4px 4px;
+  border-radius: 4px 2px;
+  box-shadow: 4px 6px 1px rgba(244, 233, 222, 0.2);
+  transform: rotate(244deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box245 {
+  --cssB-v-245: 940155;
+  color: hsl(65, 85%, 45%);
+  background-color: hsl(245, 85%, 55%);
+  border: 1px solid hsl(155, 50%, 50%);
+  margin: 5px 15px 0px 5px;
+  padding: 5px 6px;
+  border-radius: 5px 4px;
+  box-shadow: 0px 0px 2px rgba(245, 235, 225, 0.3);
+  transform: rotate(245deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box246 {
+  --cssB-v-246: 948074;
+  color: hsl(102, 98%, 52%);
+  background-color: hsl(282, 98%, 48%);
+  border: 2px solid hsl(192, 50%, 50%);
+  margin: 6px 18px 5px 12px;
+  padding: 6px 8px;
+  border-radius: 6px 6px;
+  box-shadow: 1px 1px 3px rgba(246, 237, 228, 0.4);
+  transform: rotate(246deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box247 {
+  --cssB-v-247: 955993;
+  color: hsl(139, 11%, 59%);
+  background-color: hsl(319, 11%, 41%);
+  border: 3px solid hsl(229, 50%, 50%);
+  margin: 7px 21px 10px 1px;
+  padding: 7px 10px;
+  border-radius: 7px 8px;
+  box-shadow: 2px 2px 4px rgba(247, 239, 231, 0.5);
+  transform: rotate(247deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box248 {
+  --cssB-v-248: 963912;
+  color: hsl(176, 24%, 66%);
+  background-color: hsl(356, 24%, 34%);
+  border: 4px solid hsl(266, 50%, 50%);
+  margin: 8px 24px 15px 8px;
+  padding: 8px 12px;
+  border-radius: 8px 1px;
+  box-shadow: 3px 3px 5px rgba(248, 241, 234, 0.6);
+  transform: rotate(248deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box249 {
+  --cssB-v-249: 971831;
+  color: hsl(213, 37%, 73%);
+  background-color: hsl(33, 37%, 27%);
+  border: 5px solid hsl(303, 50%, 50%);
+  margin: 9px 27px 20px 15px;
+  padding: 9px 14px;
+  border-radius: 9px 3px;
+  box-shadow: 4px 4px 6px rgba(249, 243, 237, 0.7);
+  transform: rotate(249deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box250 {
+  --cssB-v-250: 979750;
+  color: hsl(250, 50%, 30%);
+  background-color: hsl(70, 50%, 70%);
+  border: 1px solid hsl(340, 50%, 50%);
+  margin: 10px 0px 0px 4px;
+  padding: 10px 16px;
+  border-radius: 10px 5px;
+  box-shadow: 0px 5px 7px rgba(250, 245, 240, 0.8);
+  transform: rotate(250deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box251 {
+  --cssB-v-251: 987669;
+  color: hsl(287, 63%, 37%);
+  background-color: hsl(107, 63%, 63%);
+  border: 2px solid hsl(17, 50%, 50%);
+  margin: 11px 3px 5px 11px;
+  padding: 11px 18px;
+  border-radius: 11px 7px;
+  box-shadow: 1px 6px 8px rgba(251, 247, 243, 0.9);
+  transform: rotate(251deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box252 {
+  --cssB-v-252: 995588;
+  color: hsl(324, 76%, 44%);
+  background-color: hsl(144, 76%, 56%);
+  border: 3px solid hsl(54, 50%, 50%);
+  margin: 12px 6px 10px 0px;
+  padding: 12px 20px;
+  border-radius: 0px 0px;
+  box-shadow: 2px 0px 0px rgba(252, 249, 246, 0.1);
+  transform: rotate(252deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box253 {
+  --cssB-v-253: 3507;
+  color: hsl(1, 89%, 51%);
+  background-color: hsl(181, 89%, 49%);
+  border: 4px solid hsl(91, 50%, 50%);
+  margin: 13px 9px 15px 7px;
+  padding: 13px 0px;
+  border-radius: 1px 2px;
+  box-shadow: 3px 1px 1px rgba(253, 251, 249, 0.2);
+  transform: rotate(253deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box254 {
+  --cssB-v-254: 11426;
+  color: hsl(38, 2%, 58%);
+  background-color: hsl(218, 2%, 42%);
+  border: 5px solid hsl(128, 50%, 50%);
+  margin: 14px 12px 20px 14px;
+  padding: 14px 2px;
+  border-radius: 2px 4px;
+  box-shadow: 4px 2px 2px rgba(254, 253, 252, 0.3);
+  transform: rotate(254deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box255 {
+  --cssB-v-255: 19345;
+  color: hsl(75, 15%, 65%);
+  background-color: hsl(255, 15%, 35%);
+  border: 1px solid hsl(165, 50%, 50%);
+  margin: 15px 15px 0px 3px;
+  padding: 0px 4px;
+  border-radius: 3px 6px;
+  box-shadow: 0px 3px 3px rgba(0, 0, 0, 0.4);
+  transform: rotate(255deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box256 {
+  --cssB-v-256: 27264;
+  color: hsl(112, 28%, 72%);
+  background-color: hsl(292, 28%, 28%);
+  border: 2px solid hsl(202, 50%, 50%);
+  margin: 16px 18px 5px 10px;
+  padding: 1px 6px;
+  border-radius: 4px 8px;
+  box-shadow: 1px 4px 4px rgba(1, 2, 3, 0.5);
+  transform: rotate(256deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box257 {
+  --cssB-v-257: 35183;
+  color: hsl(149, 41%, 79%);
+  background-color: hsl(329, 41%, 21%);
+  border: 3px solid hsl(239, 50%, 50%);
+  margin: 17px 21px 10px 17px;
+  padding: 2px 8px;
+  border-radius: 5px 1px;
+  box-shadow: 2px 5px 5px rgba(2, 4, 6, 0.6);
+  transform: rotate(257deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box258 {
+  --cssB-v-258: 43102;
+  color: hsl(186, 54%, 36%);
+  background-color: hsl(6, 54%, 64%);
+  border: 4px solid hsl(276, 50%, 50%);
+  margin: 18px 24px 15px 6px;
+  padding: 3px 10px;
+  border-radius: 6px 3px;
+  box-shadow: 3px 6px 6px rgba(3, 6, 9, 0.7);
+  transform: rotate(258deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box259 {
+  --cssB-v-259: 51021;
+  color: hsl(223, 67%, 43%);
+  background-color: hsl(43, 67%, 57%);
+  border: 5px solid hsl(313, 50%, 50%);
+  margin: 19px 27px 20px 13px;
+  padding: 4px 12px;
+  border-radius: 7px 5px;
+  box-shadow: 4px 0px 7px rgba(4, 8, 12, 0.8);
+  transform: rotate(259deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box260 {
+  --cssB-v-260: 58940;
+  color: hsl(260, 80%, 50%);
+  background-color: hsl(80, 80%, 50%);
+  border: 1px solid hsl(350, 50%, 50%);
+  margin: 0px 0px 0px 2px;
+  padding: 5px 14px;
+  border-radius: 8px 7px;
+  box-shadow: 0px 1px 8px rgba(5, 10, 15, 0.9);
+  transform: rotate(260deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box261 {
+  --cssB-v-261: 66859;
+  color: hsl(297, 93%, 57%);
+  background-color: hsl(117, 93%, 43%);
+  border: 2px solid hsl(27, 50%, 50%);
+  margin: 1px 3px 5px 9px;
+  padding: 6px 16px;
+  border-radius: 9px 0px;
+  box-shadow: 1px 2px 0px rgba(6, 12, 18, 0.1);
+  transform: rotate(261deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box262 {
+  --cssB-v-262: 74778;
+  color: hsl(334, 6%, 64%);
+  background-color: hsl(154, 6%, 36%);
+  border: 3px solid hsl(64, 50%, 50%);
+  margin: 2px 6px 10px 16px;
+  padding: 7px 18px;
+  border-radius: 10px 2px;
+  box-shadow: 2px 3px 1px rgba(7, 14, 21, 0.2);
+  transform: rotate(262deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box263 {
+  --cssB-v-263: 82697;
+  color: hsl(11, 19%, 71%);
+  background-color: hsl(191, 19%, 29%);
+  border: 4px solid hsl(101, 50%, 50%);
+  margin: 3px 9px 15px 5px;
+  padding: 8px 20px;
+  border-radius: 11px 4px;
+  box-shadow: 3px 4px 2px rgba(8, 16, 24, 0.3);
+  transform: rotate(263deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box264 {
+  --cssB-v-264: 90616;
+  color: hsl(48, 32%, 78%);
+  background-color: hsl(228, 32%, 22%);
+  border: 5px solid hsl(138, 50%, 50%);
+  margin: 4px 12px 20px 12px;
+  padding: 9px 0px;
+  border-radius: 0px 6px;
+  box-shadow: 4px 5px 3px rgba(9, 18, 27, 0.4);
+  transform: rotate(264deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box265 {
+  --cssB-v-265: 98535;
+  color: hsl(85, 45%, 35%);
+  background-color: hsl(265, 45%, 65%);
+  border: 1px solid hsl(175, 50%, 50%);
+  margin: 5px 15px 0px 1px;
+  padding: 10px 2px;
+  border-radius: 1px 8px;
+  box-shadow: 0px 6px 4px rgba(10, 20, 30, 0.5);
+  transform: rotate(265deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box266 {
+  --cssB-v-266: 106454;
+  color: hsl(122, 58%, 42%);
+  background-color: hsl(302, 58%, 58%);
+  border: 2px solid hsl(212, 50%, 50%);
+  margin: 6px 18px 5px 8px;
+  padding: 11px 4px;
+  border-radius: 2px 1px;
+  box-shadow: 1px 0px 5px rgba(11, 22, 33, 0.6);
+  transform: rotate(266deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box267 {
+  --cssB-v-267: 114373;
+  color: hsl(159, 71%, 49%);
+  background-color: hsl(339, 71%, 51%);
+  border: 3px solid hsl(249, 50%, 50%);
+  margin: 7px 21px 10px 15px;
+  padding: 12px 6px;
+  border-radius: 3px 3px;
+  box-shadow: 2px 1px 6px rgba(12, 24, 36, 0.7);
+  transform: rotate(267deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box268 {
+  --cssB-v-268: 122292;
+  color: hsl(196, 84%, 56%);
+  background-color: hsl(16, 84%, 44%);
+  border: 4px solid hsl(286, 50%, 50%);
+  margin: 8px 24px 15px 4px;
+  padding: 13px 8px;
+  border-radius: 4px 5px;
+  box-shadow: 3px 2px 7px rgba(13, 26, 39, 0.8);
+  transform: rotate(268deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box269 {
+  --cssB-v-269: 130211;
+  color: hsl(233, 97%, 63%);
+  background-color: hsl(53, 97%, 37%);
+  border: 5px solid hsl(323, 50%, 50%);
+  margin: 9px 27px 20px 11px;
+  padding: 14px 10px;
+  border-radius: 5px 7px;
+  box-shadow: 4px 3px 8px rgba(14, 28, 42, 0.9);
+  transform: rotate(269deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box270 {
+  --cssB-v-270: 138130;
+  color: hsl(270, 10%, 70%);
+  background-color: hsl(90, 10%, 30%);
+  border: 1px solid hsl(0, 50%, 50%);
+  margin: 10px 0px 0px 0px;
+  padding: 0px 12px;
+  border-radius: 6px 0px;
+  box-shadow: 0px 4px 0px rgba(15, 30, 45, 0.1);
+  transform: rotate(270deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box271 {
+  --cssB-v-271: 146049;
+  color: hsl(307, 23%, 77%);
+  background-color: hsl(127, 23%, 23%);
+  border: 2px solid hsl(37, 50%, 50%);
+  margin: 11px 3px 5px 7px;
+  padding: 1px 14px;
+  border-radius: 7px 2px;
+  box-shadow: 1px 5px 1px rgba(16, 32, 48, 0.2);
+  transform: rotate(271deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box272 {
+  --cssB-v-272: 153968;
+  color: hsl(344, 36%, 34%);
+  background-color: hsl(164, 36%, 66%);
+  border: 3px solid hsl(74, 50%, 50%);
+  margin: 12px 6px 10px 14px;
+  padding: 2px 16px;
+  border-radius: 8px 4px;
+  box-shadow: 2px 6px 2px rgba(17, 34, 51, 0.3);
+  transform: rotate(272deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box273 {
+  --cssB-v-273: 161887;
+  color: hsl(21, 49%, 41%);
+  background-color: hsl(201, 49%, 59%);
+  border: 4px solid hsl(111, 50%, 50%);
+  margin: 13px 9px 15px 3px;
+  padding: 3px 18px;
+  border-radius: 9px 6px;
+  box-shadow: 3px 0px 3px rgba(18, 36, 54, 0.4);
+  transform: rotate(273deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box274 {
+  --cssB-v-274: 169806;
+  color: hsl(58, 62%, 48%);
+  background-color: hsl(238, 62%, 52%);
+  border: 5px solid hsl(148, 50%, 50%);
+  margin: 14px 12px 20px 10px;
+  padding: 4px 20px;
+  border-radius: 10px 8px;
+  box-shadow: 4px 1px 4px rgba(19, 38, 57, 0.5);
+  transform: rotate(274deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box275 {
+  --cssB-v-275: 177725;
+  color: hsl(95, 75%, 55%);
+  background-color: hsl(275, 75%, 45%);
+  border: 1px solid hsl(185, 50%, 50%);
+  margin: 15px 15px 0px 17px;
+  padding: 5px 0px;
+  border-radius: 11px 1px;
+  box-shadow: 0px 2px 5px rgba(20, 40, 60, 0.6);
+  transform: rotate(275deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box276 {
+  --cssB-v-276: 185644;
+  color: hsl(132, 88%, 62%);
+  background-color: hsl(312, 88%, 38%);
+  border: 2px solid hsl(222, 50%, 50%);
+  margin: 16px 18px 5px 6px;
+  padding: 6px 2px;
+  border-radius: 0px 3px;
+  box-shadow: 1px 3px 6px rgba(21, 42, 63, 0.7);
+  transform: rotate(276deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box277 {
+  --cssB-v-277: 193563;
+  color: hsl(169, 1%, 69%);
+  background-color: hsl(349, 1%, 31%);
+  border: 3px solid hsl(259, 50%, 50%);
+  margin: 17px 21px 10px 13px;
+  padding: 7px 4px;
+  border-radius: 1px 5px;
+  box-shadow: 2px 4px 7px rgba(22, 44, 66, 0.8);
+  transform: rotate(277deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box278 {
+  --cssB-v-278: 201482;
+  color: hsl(206, 14%, 76%);
+  background-color: hsl(26, 14%, 24%);
+  border: 4px solid hsl(296, 50%, 50%);
+  margin: 18px 24px 15px 2px;
+  padding: 8px 6px;
+  border-radius: 2px 7px;
+  box-shadow: 3px 5px 8px rgba(23, 46, 69, 0.9);
+  transform: rotate(278deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box279 {
+  --cssB-v-279: 209401;
+  color: hsl(243, 27%, 33%);
+  background-color: hsl(63, 27%, 67%);
+  border: 5px solid hsl(333, 50%, 50%);
+  margin: 19px 27px 20px 9px;
+  padding: 9px 8px;
+  border-radius: 3px 0px;
+  box-shadow: 4px 6px 0px rgba(24, 48, 72, 0.1);
+  transform: rotate(279deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box280 {
+  --cssB-v-280: 217320;
+  color: hsl(280, 40%, 40%);
+  background-color: hsl(100, 40%, 60%);
+  border: 1px solid hsl(10, 50%, 50%);
+  margin: 0px 0px 0px 16px;
+  padding: 10px 10px;
+  border-radius: 4px 2px;
+  box-shadow: 0px 0px 1px rgba(25, 50, 75, 0.2);
+  transform: rotate(280deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box281 {
+  --cssB-v-281: 225239;
+  color: hsl(317, 53%, 47%);
+  background-color: hsl(137, 53%, 53%);
+  border: 2px solid hsl(47, 50%, 50%);
+  margin: 1px 3px 5px 5px;
+  padding: 11px 12px;
+  border-radius: 5px 4px;
+  box-shadow: 1px 1px 2px rgba(26, 52, 78, 0.3);
+  transform: rotate(281deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box282 {
+  --cssB-v-282: 233158;
+  color: hsl(354, 66%, 54%);
+  background-color: hsl(174, 66%, 46%);
+  border: 3px solid hsl(84, 50%, 50%);
+  margin: 2px 6px 10px 12px;
+  padding: 12px 14px;
+  border-radius: 6px 6px;
+  box-shadow: 2px 2px 3px rgba(27, 54, 81, 0.4);
+  transform: rotate(282deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box283 {
+  --cssB-v-283: 241077;
+  color: hsl(31, 79%, 61%);
+  background-color: hsl(211, 79%, 39%);
+  border: 4px solid hsl(121, 50%, 50%);
+  margin: 3px 9px 15px 1px;
+  padding: 13px 16px;
+  border-radius: 7px 8px;
+  box-shadow: 3px 3px 4px rgba(28, 56, 84, 0.5);
+  transform: rotate(283deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box284 {
+  --cssB-v-284: 248996;
+  color: hsl(68, 92%, 68%);
+  background-color: hsl(248, 92%, 32%);
+  border: 5px solid hsl(158, 50%, 50%);
+  margin: 4px 12px 20px 8px;
+  padding: 14px 18px;
+  border-radius: 8px 1px;
+  box-shadow: 4px 4px 5px rgba(29, 58, 87, 0.6);
+  transform: rotate(284deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box285 {
+  --cssB-v-285: 256915;
+  color: hsl(105, 5%, 75%);
+  background-color: hsl(285, 5%, 25%);
+  border: 1px solid hsl(195, 50%, 50%);
+  margin: 5px 15px 0px 15px;
+  padding: 0px 20px;
+  border-radius: 9px 3px;
+  box-shadow: 0px 5px 6px rgba(30, 60, 90, 0.7);
+  transform: rotate(285deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box286 {
+  --cssB-v-286: 264834;
+  color: hsl(142, 18%, 32%);
+  background-color: hsl(322, 18%, 68%);
+  border: 2px solid hsl(232, 50%, 50%);
+  margin: 6px 18px 5px 4px;
+  padding: 1px 0px;
+  border-radius: 10px 5px;
+  box-shadow: 1px 6px 7px rgba(31, 62, 93, 0.8);
+  transform: rotate(286deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box287 {
+  --cssB-v-287: 272753;
+  color: hsl(179, 31%, 39%);
+  background-color: hsl(359, 31%, 61%);
+  border: 3px solid hsl(269, 50%, 50%);
+  margin: 7px 21px 10px 11px;
+  padding: 2px 2px;
+  border-radius: 11px 7px;
+  box-shadow: 2px 0px 8px rgba(32, 64, 96, 0.9);
+  transform: rotate(287deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box288 {
+  --cssB-v-288: 280672;
+  color: hsl(216, 44%, 46%);
+  background-color: hsl(36, 44%, 54%);
+  border: 4px solid hsl(306, 50%, 50%);
+  margin: 8px 24px 15px 0px;
+  padding: 3px 4px;
+  border-radius: 0px 0px;
+  box-shadow: 3px 1px 0px rgba(33, 66, 99, 0.1);
+  transform: rotate(288deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box289 {
+  --cssB-v-289: 288591;
+  color: hsl(253, 57%, 53%);
+  background-color: hsl(73, 57%, 47%);
+  border: 5px solid hsl(343, 50%, 50%);
+  margin: 9px 27px 20px 7px;
+  padding: 4px 6px;
+  border-radius: 1px 2px;
+  box-shadow: 4px 2px 1px rgba(34, 68, 102, 0.2);
+  transform: rotate(289deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box290 {
+  --cssB-v-290: 296510;
+  color: hsl(290, 70%, 60%);
+  background-color: hsl(110, 70%, 40%);
+  border: 1px solid hsl(20, 50%, 50%);
+  margin: 10px 0px 0px 14px;
+  padding: 5px 8px;
+  border-radius: 2px 4px;
+  box-shadow: 0px 3px 2px rgba(35, 70, 105, 0.3);
+  transform: rotate(290deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box291 {
+  --cssB-v-291: 304429;
+  color: hsl(327, 83%, 67%);
+  background-color: hsl(147, 83%, 33%);
+  border: 2px solid hsl(57, 50%, 50%);
+  margin: 11px 3px 5px 3px;
+  padding: 6px 10px;
+  border-radius: 3px 6px;
+  box-shadow: 1px 4px 3px rgba(36, 72, 108, 0.4);
+  transform: rotate(291deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box292 {
+  --cssB-v-292: 312348;
+  color: hsl(4, 96%, 74%);
+  background-color: hsl(184, 96%, 26%);
+  border: 3px solid hsl(94, 50%, 50%);
+  margin: 12px 6px 10px 10px;
+  padding: 7px 12px;
+  border-radius: 4px 8px;
+  box-shadow: 2px 5px 4px rgba(37, 74, 111, 0.5);
+  transform: rotate(292deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box293 {
+  --cssB-v-293: 320267;
+  color: hsl(41, 9%, 31%);
+  background-color: hsl(221, 9%, 69%);
+  border: 4px solid hsl(131, 50%, 50%);
+  margin: 13px 9px 15px 17px;
+  padding: 8px 14px;
+  border-radius: 5px 1px;
+  box-shadow: 3px 6px 5px rgba(38, 76, 114, 0.6);
+  transform: rotate(293deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box294 {
+  --cssB-v-294: 328186;
+  color: hsl(78, 22%, 38%);
+  background-color: hsl(258, 22%, 62%);
+  border: 5px solid hsl(168, 50%, 50%);
+  margin: 14px 12px 20px 6px;
+  padding: 9px 16px;
+  border-radius: 6px 3px;
+  box-shadow: 4px 0px 6px rgba(39, 78, 117, 0.7);
+  transform: rotate(294deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box295 {
+  --cssB-v-295: 336105;
+  color: hsl(115, 35%, 45%);
+  background-color: hsl(295, 35%, 55%);
+  border: 1px solid hsl(205, 50%, 50%);
+  margin: 15px 15px 0px 13px;
+  padding: 10px 18px;
+  border-radius: 7px 5px;
+  box-shadow: 0px 1px 7px rgba(40, 80, 120, 0.8);
+  transform: rotate(295deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box296 {
+  --cssB-v-296: 344024;
+  color: hsl(152, 48%, 52%);
+  background-color: hsl(332, 48%, 48%);
+  border: 2px solid hsl(242, 50%, 50%);
+  margin: 16px 18px 5px 2px;
+  padding: 11px 20px;
+  border-radius: 8px 7px;
+  box-shadow: 1px 2px 8px rgba(41, 82, 123, 0.9);
+  transform: rotate(296deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box297 {
+  --cssB-v-297: 351943;
+  color: hsl(189, 61%, 59%);
+  background-color: hsl(9, 61%, 41%);
+  border: 3px solid hsl(279, 50%, 50%);
+  margin: 17px 21px 10px 9px;
+  padding: 12px 0px;
+  border-radius: 9px 0px;
+  box-shadow: 2px 3px 0px rgba(42, 84, 126, 0.1);
+  transform: rotate(297deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box298 {
+  --cssB-v-298: 359862;
+  color: hsl(226, 74%, 66%);
+  background-color: hsl(46, 74%, 34%);
+  border: 4px solid hsl(316, 50%, 50%);
+  margin: 18px 24px 15px 16px;
+  padding: 13px 2px;
+  border-radius: 10px 2px;
+  box-shadow: 3px 4px 1px rgba(43, 86, 129, 0.2);
+  transform: rotate(298deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box299 {
+  --cssB-v-299: 367781;
+  color: hsl(263, 87%, 73%);
+  background-color: hsl(83, 87%, 27%);
+  border: 5px solid hsl(353, 50%, 50%);
+  margin: 19px 27px 20px 5px;
+  padding: 14px 4px;
+  border-radius: 11px 4px;
+  box-shadow: 4px 5px 2px rgba(44, 88, 132, 0.3);
+  transform: rotate(299deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box300 {
+  --cssB-v-300: 375700;
+  color: hsl(300, 0%, 30%);
+  background-color: hsl(120, 0%, 70%);
+  border: 1px solid hsl(30, 50%, 50%);
+  margin: 0px 0px 0px 12px;
+  padding: 0px 6px;
+  border-radius: 0px 6px;
+  box-shadow: 0px 6px 3px rgba(45, 90, 135, 0.4);
+  transform: rotate(300deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box301 {
+  --cssB-v-301: 383619;
+  color: hsl(337, 13%, 37%);
+  background-color: hsl(157, 13%, 63%);
+  border: 2px solid hsl(67, 50%, 50%);
+  margin: 1px 3px 5px 1px;
+  padding: 1px 8px;
+  border-radius: 1px 8px;
+  box-shadow: 1px 0px 4px rgba(46, 92, 138, 0.5);
+  transform: rotate(301deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box302 {
+  --cssB-v-302: 391538;
+  color: hsl(14, 26%, 44%);
+  background-color: hsl(194, 26%, 56%);
+  border: 3px solid hsl(104, 50%, 50%);
+  margin: 2px 6px 10px 8px;
+  padding: 2px 10px;
+  border-radius: 2px 1px;
+  box-shadow: 2px 1px 5px rgba(47, 94, 141, 0.6);
+  transform: rotate(302deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box303 {
+  --cssB-v-303: 399457;
+  color: hsl(51, 39%, 51%);
+  background-color: hsl(231, 39%, 49%);
+  border: 4px solid hsl(141, 50%, 50%);
+  margin: 3px 9px 15px 15px;
+  padding: 3px 12px;
+  border-radius: 3px 3px;
+  box-shadow: 3px 2px 6px rgba(48, 96, 144, 0.7);
+  transform: rotate(303deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box304 {
+  --cssB-v-304: 407376;
+  color: hsl(88, 52%, 58%);
+  background-color: hsl(268, 52%, 42%);
+  border: 5px solid hsl(178, 50%, 50%);
+  margin: 4px 12px 20px 4px;
+  padding: 4px 14px;
+  border-radius: 4px 5px;
+  box-shadow: 4px 3px 7px rgba(49, 98, 147, 0.8);
+  transform: rotate(304deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box305 {
+  --cssB-v-305: 415295;
+  color: hsl(125, 65%, 65%);
+  background-color: hsl(305, 65%, 35%);
+  border: 1px solid hsl(215, 50%, 50%);
+  margin: 5px 15px 0px 11px;
+  padding: 5px 16px;
+  border-radius: 5px 7px;
+  box-shadow: 0px 4px 8px rgba(50, 100, 150, 0.9);
+  transform: rotate(305deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box306 {
+  --cssB-v-306: 423214;
+  color: hsl(162, 78%, 72%);
+  background-color: hsl(342, 78%, 28%);
+  border: 2px solid hsl(252, 50%, 50%);
+  margin: 6px 18px 5px 0px;
+  padding: 6px 18px;
+  border-radius: 6px 0px;
+  box-shadow: 1px 5px 0px rgba(51, 102, 153, 0.1);
+  transform: rotate(306deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box307 {
+  --cssB-v-307: 431133;
+  color: hsl(199, 91%, 79%);
+  background-color: hsl(19, 91%, 21%);
+  border: 3px solid hsl(289, 50%, 50%);
+  margin: 7px 21px 10px 7px;
+  padding: 7px 20px;
+  border-radius: 7px 2px;
+  box-shadow: 2px 6px 1px rgba(52, 104, 156, 0.2);
+  transform: rotate(307deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box308 {
+  --cssB-v-308: 439052;
+  color: hsl(236, 4%, 36%);
+  background-color: hsl(56, 4%, 64%);
+  border: 4px solid hsl(326, 50%, 50%);
+  margin: 8px 24px 15px 14px;
+  padding: 8px 0px;
+  border-radius: 8px 4px;
+  box-shadow: 3px 0px 2px rgba(53, 106, 159, 0.3);
+  transform: rotate(308deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box309 {
+  --cssB-v-309: 446971;
+  color: hsl(273, 17%, 43%);
+  background-color: hsl(93, 17%, 57%);
+  border: 5px solid hsl(3, 50%, 50%);
+  margin: 9px 27px 20px 3px;
+  padding: 9px 2px;
+  border-radius: 9px 6px;
+  box-shadow: 4px 1px 3px rgba(54, 108, 162, 0.4);
+  transform: rotate(309deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box310 {
+  --cssB-v-310: 454890;
+  color: hsl(310, 30%, 50%);
+  background-color: hsl(130, 30%, 50%);
+  border: 1px solid hsl(40, 50%, 50%);
+  margin: 10px 0px 0px 10px;
+  padding: 10px 4px;
+  border-radius: 10px 8px;
+  box-shadow: 0px 2px 4px rgba(55, 110, 165, 0.5);
+  transform: rotate(310deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box311 {
+  --cssB-v-311: 462809;
+  color: hsl(347, 43%, 57%);
+  background-color: hsl(167, 43%, 43%);
+  border: 2px solid hsl(77, 50%, 50%);
+  margin: 11px 3px 5px 17px;
+  padding: 11px 6px;
+  border-radius: 11px 1px;
+  box-shadow: 1px 3px 5px rgba(56, 112, 168, 0.6);
+  transform: rotate(311deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box312 {
+  --cssB-v-312: 470728;
+  color: hsl(24, 56%, 64%);
+  background-color: hsl(204, 56%, 36%);
+  border: 3px solid hsl(114, 50%, 50%);
+  margin: 12px 6px 10px 6px;
+  padding: 12px 8px;
+  border-radius: 0px 3px;
+  box-shadow: 2px 4px 6px rgba(57, 114, 171, 0.7);
+  transform: rotate(312deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box313 {
+  --cssB-v-313: 478647;
+  color: hsl(61, 69%, 71%);
+  background-color: hsl(241, 69%, 29%);
+  border: 4px solid hsl(151, 50%, 50%);
+  margin: 13px 9px 15px 13px;
+  padding: 13px 10px;
+  border-radius: 1px 5px;
+  box-shadow: 3px 5px 7px rgba(58, 116, 174, 0.8);
+  transform: rotate(313deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box314 {
+  --cssB-v-314: 486566;
+  color: hsl(98, 82%, 78%);
+  background-color: hsl(278, 82%, 22%);
+  border: 5px solid hsl(188, 50%, 50%);
+  margin: 14px 12px 20px 2px;
+  padding: 14px 12px;
+  border-radius: 2px 7px;
+  box-shadow: 4px 6px 8px rgba(59, 118, 177, 0.9);
+  transform: rotate(314deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box315 {
+  --cssB-v-315: 494485;
+  color: hsl(135, 95%, 35%);
+  background-color: hsl(315, 95%, 65%);
+  border: 1px solid hsl(225, 50%, 50%);
+  margin: 15px 15px 0px 9px;
+  padding: 0px 14px;
+  border-radius: 3px 0px;
+  box-shadow: 0px 0px 0px rgba(60, 120, 180, 0.1);
+  transform: rotate(315deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box316 {
+  --cssB-v-316: 502404;
+  color: hsl(172, 8%, 42%);
+  background-color: hsl(352, 8%, 58%);
+  border: 2px solid hsl(262, 50%, 50%);
+  margin: 16px 18px 5px 16px;
+  padding: 1px 16px;
+  border-radius: 4px 2px;
+  box-shadow: 1px 1px 1px rgba(61, 122, 183, 0.2);
+  transform: rotate(316deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box317 {
+  --cssB-v-317: 510323;
+  color: hsl(209, 21%, 49%);
+  background-color: hsl(29, 21%, 51%);
+  border: 3px solid hsl(299, 50%, 50%);
+  margin: 17px 21px 10px 5px;
+  padding: 2px 18px;
+  border-radius: 5px 4px;
+  box-shadow: 2px 2px 2px rgba(62, 124, 186, 0.3);
+  transform: rotate(317deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box318 {
+  --cssB-v-318: 518242;
+  color: hsl(246, 34%, 56%);
+  background-color: hsl(66, 34%, 44%);
+  border: 4px solid hsl(336, 50%, 50%);
+  margin: 18px 24px 15px 12px;
+  padding: 3px 20px;
+  border-radius: 6px 6px;
+  box-shadow: 3px 3px 3px rgba(63, 126, 189, 0.4);
+  transform: rotate(318deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box319 {
+  --cssB-v-319: 526161;
+  color: hsl(283, 47%, 63%);
+  background-color: hsl(103, 47%, 37%);
+  border: 5px solid hsl(13, 50%, 50%);
+  margin: 19px 27px 20px 1px;
+  padding: 4px 0px;
+  border-radius: 7px 8px;
+  box-shadow: 4px 4px 4px rgba(64, 128, 192, 0.5);
+  transform: rotate(319deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box320 {
+  --cssB-v-320: 534080;
+  color: hsl(320, 60%, 70%);
+  background-color: hsl(140, 60%, 30%);
+  border: 1px solid hsl(50, 50%, 50%);
+  margin: 0px 0px 0px 8px;
+  padding: 5px 2px;
+  border-radius: 8px 1px;
+  box-shadow: 0px 5px 5px rgba(65, 130, 195, 0.6);
+  transform: rotate(320deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box321 {
+  --cssB-v-321: 541999;
+  color: hsl(357, 73%, 77%);
+  background-color: hsl(177, 73%, 23%);
+  border: 2px solid hsl(87, 50%, 50%);
+  margin: 1px 3px 5px 15px;
+  padding: 6px 4px;
+  border-radius: 9px 3px;
+  box-shadow: 1px 6px 6px rgba(66, 132, 198, 0.7);
+  transform: rotate(321deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box322 {
+  --cssB-v-322: 549918;
+  color: hsl(34, 86%, 34%);
+  background-color: hsl(214, 86%, 66%);
+  border: 3px solid hsl(124, 50%, 50%);
+  margin: 2px 6px 10px 4px;
+  padding: 7px 6px;
+  border-radius: 10px 5px;
+  box-shadow: 2px 0px 7px rgba(67, 134, 201, 0.8);
+  transform: rotate(322deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box323 {
+  --cssB-v-323: 557837;
+  color: hsl(71, 99%, 41%);
+  background-color: hsl(251, 99%, 59%);
+  border: 4px solid hsl(161, 50%, 50%);
+  margin: 3px 9px 15px 11px;
+  padding: 8px 8px;
+  border-radius: 11px 7px;
+  box-shadow: 3px 1px 8px rgba(68, 136, 204, 0.9);
+  transform: rotate(323deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box324 {
+  --cssB-v-324: 565756;
+  color: hsl(108, 12%, 48%);
+  background-color: hsl(288, 12%, 52%);
+  border: 5px solid hsl(198, 50%, 50%);
+  margin: 4px 12px 20px 0px;
+  padding: 9px 10px;
+  border-radius: 0px 0px;
+  box-shadow: 4px 2px 0px rgba(69, 138, 207, 0.1);
+  transform: rotate(324deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box325 {
+  --cssB-v-325: 573675;
+  color: hsl(145, 25%, 55%);
+  background-color: hsl(325, 25%, 45%);
+  border: 1px solid hsl(235, 50%, 50%);
+  margin: 5px 15px 0px 7px;
+  padding: 10px 12px;
+  border-radius: 1px 2px;
+  box-shadow: 0px 3px 1px rgba(70, 140, 210, 0.2);
+  transform: rotate(325deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box326 {
+  --cssB-v-326: 581594;
+  color: hsl(182, 38%, 62%);
+  background-color: hsl(2, 38%, 38%);
+  border: 2px solid hsl(272, 50%, 50%);
+  margin: 6px 18px 5px 14px;
+  padding: 11px 14px;
+  border-radius: 2px 4px;
+  box-shadow: 1px 4px 2px rgba(71, 142, 213, 0.3);
+  transform: rotate(326deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box327 {
+  --cssB-v-327: 589513;
+  color: hsl(219, 51%, 69%);
+  background-color: hsl(39, 51%, 31%);
+  border: 3px solid hsl(309, 50%, 50%);
+  margin: 7px 21px 10px 3px;
+  padding: 12px 16px;
+  border-radius: 3px 6px;
+  box-shadow: 2px 5px 3px rgba(72, 144, 216, 0.4);
+  transform: rotate(327deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box328 {
+  --cssB-v-328: 597432;
+  color: hsl(256, 64%, 76%);
+  background-color: hsl(76, 64%, 24%);
+  border: 4px solid hsl(346, 50%, 50%);
+  margin: 8px 24px 15px 10px;
+  padding: 13px 18px;
+  border-radius: 4px 8px;
+  box-shadow: 3px 6px 4px rgba(73, 146, 219, 0.5);
+  transform: rotate(328deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box329 {
+  --cssB-v-329: 605351;
+  color: hsl(293, 77%, 33%);
+  background-color: hsl(113, 77%, 67%);
+  border: 5px solid hsl(23, 50%, 50%);
+  margin: 9px 27px 20px 17px;
+  padding: 14px 20px;
+  border-radius: 5px 1px;
+  box-shadow: 4px 0px 5px rgba(74, 148, 222, 0.6);
+  transform: rotate(329deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box330 {
+  --cssB-v-330: 613270;
+  color: hsl(330, 90%, 40%);
+  background-color: hsl(150, 90%, 60%);
+  border: 1px solid hsl(60, 50%, 50%);
+  margin: 10px 0px 0px 6px;
+  padding: 0px 0px;
+  border-radius: 6px 3px;
+  box-shadow: 0px 1px 6px rgba(75, 150, 225, 0.7);
+  transform: rotate(330deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box331 {
+  --cssB-v-331: 621189;
+  color: hsl(7, 3%, 47%);
+  background-color: hsl(187, 3%, 53%);
+  border: 2px solid hsl(97, 50%, 50%);
+  margin: 11px 3px 5px 13px;
+  padding: 1px 2px;
+  border-radius: 7px 5px;
+  box-shadow: 1px 2px 7px rgba(76, 152, 228, 0.8);
+  transform: rotate(331deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box332 {
+  --cssB-v-332: 629108;
+  color: hsl(44, 16%, 54%);
+  background-color: hsl(224, 16%, 46%);
+  border: 3px solid hsl(134, 50%, 50%);
+  margin: 12px 6px 10px 2px;
+  padding: 2px 4px;
+  border-radius: 8px 7px;
+  box-shadow: 2px 3px 8px rgba(77, 154, 231, 0.9);
+  transform: rotate(332deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box333 {
+  --cssB-v-333: 637027;
+  color: hsl(81, 29%, 61%);
+  background-color: hsl(261, 29%, 39%);
+  border: 4px solid hsl(171, 50%, 50%);
+  margin: 13px 9px 15px 9px;
+  padding: 3px 6px;
+  border-radius: 9px 0px;
+  box-shadow: 3px 4px 0px rgba(78, 156, 234, 0.1);
+  transform: rotate(333deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box334 {
+  --cssB-v-334: 644946;
+  color: hsl(118, 42%, 68%);
+  background-color: hsl(298, 42%, 32%);
+  border: 5px solid hsl(208, 50%, 50%);
+  margin: 14px 12px 20px 16px;
+  padding: 4px 8px;
+  border-radius: 10px 2px;
+  box-shadow: 4px 5px 1px rgba(79, 158, 237, 0.2);
+  transform: rotate(334deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box335 {
+  --cssB-v-335: 652865;
+  color: hsl(155, 55%, 75%);
+  background-color: hsl(335, 55%, 25%);
+  border: 1px solid hsl(245, 50%, 50%);
+  margin: 15px 15px 0px 5px;
+  padding: 5px 10px;
+  border-radius: 11px 4px;
+  box-shadow: 0px 6px 2px rgba(80, 160, 240, 0.3);
+  transform: rotate(335deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box336 {
+  --cssB-v-336: 660784;
+  color: hsl(192, 68%, 32%);
+  background-color: hsl(12, 68%, 68%);
+  border: 2px solid hsl(282, 50%, 50%);
+  margin: 16px 18px 5px 12px;
+  padding: 6px 12px;
+  border-radius: 0px 6px;
+  box-shadow: 1px 0px 3px rgba(81, 162, 243, 0.4);
+  transform: rotate(336deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box337 {
+  --cssB-v-337: 668703;
+  color: hsl(229, 81%, 39%);
+  background-color: hsl(49, 81%, 61%);
+  border: 3px solid hsl(319, 50%, 50%);
+  margin: 17px 21px 10px 1px;
+  padding: 7px 14px;
+  border-radius: 1px 8px;
+  box-shadow: 2px 1px 4px rgba(82, 164, 246, 0.5);
+  transform: rotate(337deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box338 {
+  --cssB-v-338: 676622;
+  color: hsl(266, 94%, 46%);
+  background-color: hsl(86, 94%, 54%);
+  border: 4px solid hsl(356, 50%, 50%);
+  margin: 18px 24px 15px 8px;
+  padding: 8px 16px;
+  border-radius: 2px 1px;
+  box-shadow: 3px 2px 5px rgba(83, 166, 249, 0.6);
+  transform: rotate(338deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box339 {
+  --cssB-v-339: 684541;
+  color: hsl(303, 7%, 53%);
+  background-color: hsl(123, 7%, 47%);
+  border: 5px solid hsl(33, 50%, 50%);
+  margin: 19px 27px 20px 15px;
+  padding: 9px 18px;
+  border-radius: 3px 3px;
+  box-shadow: 4px 3px 6px rgba(84, 168, 252, 0.7);
+  transform: rotate(339deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box340 {
+  --cssB-v-340: 692460;
+  color: hsl(340, 20%, 60%);
+  background-color: hsl(160, 20%, 40%);
+  border: 1px solid hsl(70, 50%, 50%);
+  margin: 0px 0px 0px 4px;
+  padding: 10px 20px;
+  border-radius: 4px 5px;
+  box-shadow: 0px 4px 7px rgba(85, 170, 0, 0.8);
+  transform: rotate(340deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box341 {
+  --cssB-v-341: 700379;
+  color: hsl(17, 33%, 67%);
+  background-color: hsl(197, 33%, 33%);
+  border: 2px solid hsl(107, 50%, 50%);
+  margin: 1px 3px 5px 11px;
+  padding: 11px 0px;
+  border-radius: 5px 7px;
+  box-shadow: 1px 5px 8px rgba(86, 172, 3, 0.9);
+  transform: rotate(341deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box342 {
+  --cssB-v-342: 708298;
+  color: hsl(54, 46%, 74%);
+  background-color: hsl(234, 46%, 26%);
+  border: 3px solid hsl(144, 50%, 50%);
+  margin: 2px 6px 10px 0px;
+  padding: 12px 2px;
+  border-radius: 6px 0px;
+  box-shadow: 2px 6px 0px rgba(87, 174, 6, 0.1);
+  transform: rotate(342deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box343 {
+  --cssB-v-343: 716217;
+  color: hsl(91, 59%, 31%);
+  background-color: hsl(271, 59%, 69%);
+  border: 4px solid hsl(181, 50%, 50%);
+  margin: 3px 9px 15px 7px;
+  padding: 13px 4px;
+  border-radius: 7px 2px;
+  box-shadow: 3px 0px 1px rgba(88, 176, 9, 0.2);
+  transform: rotate(343deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box344 {
+  --cssB-v-344: 724136;
+  color: hsl(128, 72%, 38%);
+  background-color: hsl(308, 72%, 62%);
+  border: 5px solid hsl(218, 50%, 50%);
+  margin: 4px 12px 20px 14px;
+  padding: 14px 6px;
+  border-radius: 8px 4px;
+  box-shadow: 4px 1px 2px rgba(89, 178, 12, 0.3);
+  transform: rotate(344deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box345 {
+  --cssB-v-345: 732055;
+  color: hsl(165, 85%, 45%);
+  background-color: hsl(345, 85%, 55%);
+  border: 1px solid hsl(255, 50%, 50%);
+  margin: 5px 15px 0px 3px;
+  padding: 0px 8px;
+  border-radius: 9px 6px;
+  box-shadow: 0px 2px 3px rgba(90, 180, 15, 0.4);
+  transform: rotate(345deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box346 {
+  --cssB-v-346: 739974;
+  color: hsl(202, 98%, 52%);
+  background-color: hsl(22, 98%, 48%);
+  border: 2px solid hsl(292, 50%, 50%);
+  margin: 6px 18px 5px 10px;
+  padding: 1px 10px;
+  border-radius: 10px 8px;
+  box-shadow: 1px 3px 4px rgba(91, 182, 18, 0.5);
+  transform: rotate(346deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box347 {
+  --cssB-v-347: 747893;
+  color: hsl(239, 11%, 59%);
+  background-color: hsl(59, 11%, 41%);
+  border: 3px solid hsl(329, 50%, 50%);
+  margin: 7px 21px 10px 17px;
+  padding: 2px 12px;
+  border-radius: 11px 1px;
+  box-shadow: 2px 4px 5px rgba(92, 184, 21, 0.6);
+  transform: rotate(347deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box348 {
+  --cssB-v-348: 755812;
+  color: hsl(276, 24%, 66%);
+  background-color: hsl(96, 24%, 34%);
+  border: 4px solid hsl(6, 50%, 50%);
+  margin: 8px 24px 15px 6px;
+  padding: 3px 14px;
+  border-radius: 0px 3px;
+  box-shadow: 3px 5px 6px rgba(93, 186, 24, 0.7);
+  transform: rotate(348deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box349 {
+  --cssB-v-349: 763731;
+  color: hsl(313, 37%, 73%);
+  background-color: hsl(133, 37%, 27%);
+  border: 5px solid hsl(43, 50%, 50%);
+  margin: 9px 27px 20px 13px;
+  padding: 4px 16px;
+  border-radius: 1px 5px;
+  box-shadow: 4px 6px 7px rgba(94, 188, 27, 0.8);
+  transform: rotate(349deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box350 {
+  --cssB-v-350: 771650;
+  color: hsl(350, 50%, 30%);
+  background-color: hsl(170, 50%, 70%);
+  border: 1px solid hsl(80, 50%, 50%);
+  margin: 10px 0px 0px 2px;
+  padding: 5px 18px;
+  border-radius: 2px 7px;
+  box-shadow: 0px 0px 8px rgba(95, 190, 30, 0.9);
+  transform: rotate(350deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box351 {
+  --cssB-v-351: 779569;
+  color: hsl(27, 63%, 37%);
+  background-color: hsl(207, 63%, 63%);
+  border: 2px solid hsl(117, 50%, 50%);
+  margin: 11px 3px 5px 9px;
+  padding: 6px 20px;
+  border-radius: 3px 0px;
+  box-shadow: 1px 1px 0px rgba(96, 192, 33, 0.1);
+  transform: rotate(351deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box352 {
+  --cssB-v-352: 787488;
+  color: hsl(64, 76%, 44%);
+  background-color: hsl(244, 76%, 56%);
+  border: 3px solid hsl(154, 50%, 50%);
+  margin: 12px 6px 10px 16px;
+  padding: 7px 0px;
+  border-radius: 4px 2px;
+  box-shadow: 2px 2px 1px rgba(97, 194, 36, 0.2);
+  transform: rotate(352deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box353 {
+  --cssB-v-353: 795407;
+  color: hsl(101, 89%, 51%);
+  background-color: hsl(281, 89%, 49%);
+  border: 4px solid hsl(191, 50%, 50%);
+  margin: 13px 9px 15px 5px;
+  padding: 8px 2px;
+  border-radius: 5px 4px;
+  box-shadow: 3px 3px 2px rgba(98, 196, 39, 0.3);
+  transform: rotate(353deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box354 {
+  --cssB-v-354: 803326;
+  color: hsl(138, 2%, 58%);
+  background-color: hsl(318, 2%, 42%);
+  border: 5px solid hsl(228, 50%, 50%);
+  margin: 14px 12px 20px 12px;
+  padding: 9px 4px;
+  border-radius: 6px 6px;
+  box-shadow: 4px 4px 3px rgba(99, 198, 42, 0.4);
+  transform: rotate(354deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box355 {
+  --cssB-v-355: 811245;
+  color: hsl(175, 15%, 65%);
+  background-color: hsl(355, 15%, 35%);
+  border: 1px solid hsl(265, 50%, 50%);
+  margin: 15px 15px 0px 1px;
+  padding: 10px 6px;
+  border-radius: 7px 8px;
+  box-shadow: 0px 5px 4px rgba(100, 200, 45, 0.5);
+  transform: rotate(355deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box356 {
+  --cssB-v-356: 819164;
+  color: hsl(212, 28%, 72%);
+  background-color: hsl(32, 28%, 28%);
+  border: 2px solid hsl(302, 50%, 50%);
+  margin: 16px 18px 5px 8px;
+  padding: 11px 8px;
+  border-radius: 8px 1px;
+  box-shadow: 1px 6px 5px rgba(101, 202, 48, 0.6);
+  transform: rotate(356deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box357 {
+  --cssB-v-357: 827083;
+  color: hsl(249, 41%, 79%);
+  background-color: hsl(69, 41%, 21%);
+  border: 3px solid hsl(339, 50%, 50%);
+  margin: 17px 21px 10px 15px;
+  padding: 12px 10px;
+  border-radius: 9px 3px;
+  box-shadow: 2px 0px 6px rgba(102, 204, 51, 0.7);
+  transform: rotate(357deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box358 {
+  --cssB-v-358: 835002;
+  color: hsl(286, 54%, 36%);
+  background-color: hsl(106, 54%, 64%);
+  border: 4px solid hsl(16, 50%, 50%);
+  margin: 18px 24px 15px 4px;
+  padding: 13px 12px;
+  border-radius: 10px 5px;
+  box-shadow: 3px 1px 7px rgba(103, 206, 54, 0.8);
+  transform: rotate(358deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box359 {
+  --cssB-v-359: 842921;
+  color: hsl(323, 67%, 43%);
+  background-color: hsl(143, 67%, 57%);
+  border: 5px solid hsl(53, 50%, 50%);
+  margin: 19px 27px 20px 11px;
+  padding: 14px 14px;
+  border-radius: 11px 7px;
+  box-shadow: 4px 2px 8px rgba(104, 208, 57, 0.9);
+  transform: rotate(359deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box360 {
+  --cssB-v-360: 850840;
+  color: hsl(0, 80%, 50%);
+  background-color: hsl(180, 80%, 50%);
+  border: 1px solid hsl(90, 50%, 50%);
+  margin: 0px 0px 0px 0px;
+  padding: 0px 16px;
+  border-radius: 0px 0px;
+  box-shadow: 0px 3px 0px rgba(105, 210, 60, 0.1);
+  transform: rotate(0deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box361 {
+  --cssB-v-361: 858759;
+  color: hsl(37, 93%, 57%);
+  background-color: hsl(217, 93%, 43%);
+  border: 2px solid hsl(127, 50%, 50%);
+  margin: 1px 3px 5px 7px;
+  padding: 1px 18px;
+  border-radius: 1px 2px;
+  box-shadow: 1px 4px 1px rgba(106, 212, 63, 0.2);
+  transform: rotate(1deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box362 {
+  --cssB-v-362: 866678;
+  color: hsl(74, 6%, 64%);
+  background-color: hsl(254, 6%, 36%);
+  border: 3px solid hsl(164, 50%, 50%);
+  margin: 2px 6px 10px 14px;
+  padding: 2px 20px;
+  border-radius: 2px 4px;
+  box-shadow: 2px 5px 2px rgba(107, 214, 66, 0.3);
+  transform: rotate(2deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box363 {
+  --cssB-v-363: 874597;
+  color: hsl(111, 19%, 71%);
+  background-color: hsl(291, 19%, 29%);
+  border: 4px solid hsl(201, 50%, 50%);
+  margin: 3px 9px 15px 3px;
+  padding: 3px 0px;
+  border-radius: 3px 6px;
+  box-shadow: 3px 6px 3px rgba(108, 216, 69, 0.4);
+  transform: rotate(3deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box364 {
+  --cssB-v-364: 882516;
+  color: hsl(148, 32%, 78%);
+  background-color: hsl(328, 32%, 22%);
+  border: 5px solid hsl(238, 50%, 50%);
+  margin: 4px 12px 20px 10px;
+  padding: 4px 2px;
+  border-radius: 4px 8px;
+  box-shadow: 4px 0px 4px rgba(109, 218, 72, 0.5);
+  transform: rotate(4deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box365 {
+  --cssB-v-365: 890435;
+  color: hsl(185, 45%, 35%);
+  background-color: hsl(5, 45%, 65%);
+  border: 1px solid hsl(275, 50%, 50%);
+  margin: 5px 15px 0px 17px;
+  padding: 5px 4px;
+  border-radius: 5px 1px;
+  box-shadow: 0px 1px 5px rgba(110, 220, 75, 0.6);
+  transform: rotate(5deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box366 {
+  --cssB-v-366: 898354;
+  color: hsl(222, 58%, 42%);
+  background-color: hsl(42, 58%, 58%);
+  border: 2px solid hsl(312, 50%, 50%);
+  margin: 6px 18px 5px 6px;
+  padding: 6px 6px;
+  border-radius: 6px 3px;
+  box-shadow: 1px 2px 6px rgba(111, 222, 78, 0.7);
+  transform: rotate(6deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box367 {
+  --cssB-v-367: 906273;
+  color: hsl(259, 71%, 49%);
+  background-color: hsl(79, 71%, 51%);
+  border: 3px solid hsl(349, 50%, 50%);
+  margin: 7px 21px 10px 13px;
+  padding: 7px 8px;
+  border-radius: 7px 5px;
+  box-shadow: 2px 3px 7px rgba(112, 224, 81, 0.8);
+  transform: rotate(7deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box368 {
+  --cssB-v-368: 914192;
+  color: hsl(296, 84%, 56%);
+  background-color: hsl(116, 84%, 44%);
+  border: 4px solid hsl(26, 50%, 50%);
+  margin: 8px 24px 15px 2px;
+  padding: 8px 10px;
+  border-radius: 8px 7px;
+  box-shadow: 3px 4px 8px rgba(113, 226, 84, 0.9);
+  transform: rotate(8deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box369 {
+  --cssB-v-369: 922111;
+  color: hsl(333, 97%, 63%);
+  background-color: hsl(153, 97%, 37%);
+  border: 5px solid hsl(63, 50%, 50%);
+  margin: 9px 27px 20px 9px;
+  padding: 9px 12px;
+  border-radius: 9px 0px;
+  box-shadow: 4px 5px 0px rgba(114, 228, 87, 0.1);
+  transform: rotate(9deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box370 {
+  --cssB-v-370: 930030;
+  color: hsl(10, 10%, 70%);
+  background-color: hsl(190, 10%, 30%);
+  border: 1px solid hsl(100, 50%, 50%);
+  margin: 10px 0px 0px 16px;
+  padding: 10px 14px;
+  border-radius: 10px 2px;
+  box-shadow: 0px 6px 1px rgba(115, 230, 90, 0.2);
+  transform: rotate(10deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box371 {
+  --cssB-v-371: 937949;
+  color: hsl(47, 23%, 77%);
+  background-color: hsl(227, 23%, 23%);
+  border: 2px solid hsl(137, 50%, 50%);
+  margin: 11px 3px 5px 5px;
+  padding: 11px 16px;
+  border-radius: 11px 4px;
+  box-shadow: 1px 0px 2px rgba(116, 232, 93, 0.3);
+  transform: rotate(11deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box372 {
+  --cssB-v-372: 945868;
+  color: hsl(84, 36%, 34%);
+  background-color: hsl(264, 36%, 66%);
+  border: 3px solid hsl(174, 50%, 50%);
+  margin: 12px 6px 10px 12px;
+  padding: 12px 18px;
+  border-radius: 0px 6px;
+  box-shadow: 2px 1px 3px rgba(117, 234, 96, 0.4);
+  transform: rotate(12deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box373 {
+  --cssB-v-373: 953787;
+  color: hsl(121, 49%, 41%);
+  background-color: hsl(301, 49%, 59%);
+  border: 4px solid hsl(211, 50%, 50%);
+  margin: 13px 9px 15px 1px;
+  padding: 13px 20px;
+  border-radius: 1px 8px;
+  box-shadow: 3px 2px 4px rgba(118, 236, 99, 0.5);
+  transform: rotate(13deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box374 {
+  --cssB-v-374: 961706;
+  color: hsl(158, 62%, 48%);
+  background-color: hsl(338, 62%, 52%);
+  border: 5px solid hsl(248, 50%, 50%);
+  margin: 14px 12px 20px 8px;
+  padding: 14px 0px;
+  border-radius: 2px 1px;
+  box-shadow: 4px 3px 5px rgba(119, 238, 102, 0.6);
+  transform: rotate(14deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box375 {
+  --cssB-v-375: 969625;
+  color: hsl(195, 75%, 55%);
+  background-color: hsl(15, 75%, 45%);
+  border: 1px solid hsl(285, 50%, 50%);
+  margin: 15px 15px 0px 15px;
+  padding: 0px 2px;
+  border-radius: 3px 3px;
+  box-shadow: 0px 4px 6px rgba(120, 240, 105, 0.7);
+  transform: rotate(15deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box376 {
+  --cssB-v-376: 977544;
+  color: hsl(232, 88%, 62%);
+  background-color: hsl(52, 88%, 38%);
+  border: 2px solid hsl(322, 50%, 50%);
+  margin: 16px 18px 5px 4px;
+  padding: 1px 4px;
+  border-radius: 4px 5px;
+  box-shadow: 1px 5px 7px rgba(121, 242, 108, 0.8);
+  transform: rotate(16deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box377 {
+  --cssB-v-377: 985463;
+  color: hsl(269, 1%, 69%);
+  background-color: hsl(89, 1%, 31%);
+  border: 3px solid hsl(359, 50%, 50%);
+  margin: 17px 21px 10px 11px;
+  padding: 2px 6px;
+  border-radius: 5px 7px;
+  box-shadow: 2px 6px 8px rgba(122, 244, 111, 0.9);
+  transform: rotate(17deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box378 {
+  --cssB-v-378: 993382;
+  color: hsl(306, 14%, 76%);
+  background-color: hsl(126, 14%, 24%);
+  border: 4px solid hsl(36, 50%, 50%);
+  margin: 18px 24px 15px 0px;
+  padding: 3px 8px;
+  border-radius: 6px 0px;
+  box-shadow: 3px 0px 0px rgba(123, 246, 114, 0.1);
+  transform: rotate(18deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box379 {
+  --cssB-v-379: 1301;
+  color: hsl(343, 27%, 33%);
+  background-color: hsl(163, 27%, 67%);
+  border: 5px solid hsl(73, 50%, 50%);
+  margin: 19px 27px 20px 7px;
+  padding: 4px 10px;
+  border-radius: 7px 2px;
+  box-shadow: 4px 1px 1px rgba(124, 248, 117, 0.2);
+  transform: rotate(19deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box380 {
+  --cssB-v-380: 9220;
+  color: hsl(20, 40%, 40%);
+  background-color: hsl(200, 40%, 60%);
+  border: 1px solid hsl(110, 50%, 50%);
+  margin: 0px 0px 0px 14px;
+  padding: 5px 12px;
+  border-radius: 8px 4px;
+  box-shadow: 0px 2px 2px rgba(125, 250, 120, 0.3);
+  transform: rotate(20deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box381 {
+  --cssB-v-381: 17139;
+  color: hsl(57, 53%, 47%);
+  background-color: hsl(237, 53%, 53%);
+  border: 2px solid hsl(147, 50%, 50%);
+  margin: 1px 3px 5px 3px;
+  padding: 6px 14px;
+  border-radius: 9px 6px;
+  box-shadow: 1px 3px 3px rgba(126, 252, 123, 0.4);
+  transform: rotate(21deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box382 {
+  --cssB-v-382: 25058;
+  color: hsl(94, 66%, 54%);
+  background-color: hsl(274, 66%, 46%);
+  border: 3px solid hsl(184, 50%, 50%);
+  margin: 2px 6px 10px 10px;
+  padding: 7px 16px;
+  border-radius: 10px 8px;
+  box-shadow: 2px 4px 4px rgba(127, 254, 126, 0.5);
+  transform: rotate(22deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box383 {
+  --cssB-v-383: 32977;
+  color: hsl(131, 79%, 61%);
+  background-color: hsl(311, 79%, 39%);
+  border: 4px solid hsl(221, 50%, 50%);
+  margin: 3px 9px 15px 17px;
+  padding: 8px 18px;
+  border-radius: 11px 1px;
+  box-shadow: 3px 5px 5px rgba(128, 1, 129, 0.6);
+  transform: rotate(23deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box384 {
+  --cssB-v-384: 40896;
+  color: hsl(168, 92%, 68%);
+  background-color: hsl(348, 92%, 32%);
+  border: 5px solid hsl(258, 50%, 50%);
+  margin: 4px 12px 20px 6px;
+  padding: 9px 20px;
+  border-radius: 0px 3px;
+  box-shadow: 4px 6px 6px rgba(129, 3, 132, 0.7);
+  transform: rotate(24deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box385 {
+  --cssB-v-385: 48815;
+  color: hsl(205, 5%, 75%);
+  background-color: hsl(25, 5%, 25%);
+  border: 1px solid hsl(295, 50%, 50%);
+  margin: 5px 15px 0px 13px;
+  padding: 10px 0px;
+  border-radius: 1px 5px;
+  box-shadow: 0px 0px 7px rgba(130, 5, 135, 0.8);
+  transform: rotate(25deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box386 {
+  --cssB-v-386: 56734;
+  color: hsl(242, 18%, 32%);
+  background-color: hsl(62, 18%, 68%);
+  border: 2px solid hsl(332, 50%, 50%);
+  margin: 6px 18px 5px 2px;
+  padding: 11px 2px;
+  border-radius: 2px 7px;
+  box-shadow: 1px 1px 8px rgba(131, 7, 138, 0.9);
+  transform: rotate(26deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box387 {
+  --cssB-v-387: 64653;
+  color: hsl(279, 31%, 39%);
+  background-color: hsl(99, 31%, 61%);
+  border: 3px solid hsl(9, 50%, 50%);
+  margin: 7px 21px 10px 9px;
+  padding: 12px 4px;
+  border-radius: 3px 0px;
+  box-shadow: 2px 2px 0px rgba(132, 9, 141, 0.1);
+  transform: rotate(27deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box388 {
+  --cssB-v-388: 72572;
+  color: hsl(316, 44%, 46%);
+  background-color: hsl(136, 44%, 54%);
+  border: 4px solid hsl(46, 50%, 50%);
+  margin: 8px 24px 15px 16px;
+  padding: 13px 6px;
+  border-radius: 4px 2px;
+  box-shadow: 3px 3px 1px rgba(133, 11, 144, 0.2);
+  transform: rotate(28deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box389 {
+  --cssB-v-389: 80491;
+  color: hsl(353, 57%, 53%);
+  background-color: hsl(173, 57%, 47%);
+  border: 5px solid hsl(83, 50%, 50%);
+  margin: 9px 27px 20px 5px;
+  padding: 14px 8px;
+  border-radius: 5px 4px;
+  box-shadow: 4px 4px 2px rgba(134, 13, 147, 0.3);
+  transform: rotate(29deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box390 {
+  --cssB-v-390: 88410;
+  color: hsl(30, 70%, 60%);
+  background-color: hsl(210, 70%, 40%);
+  border: 1px solid hsl(120, 50%, 50%);
+  margin: 10px 0px 0px 12px;
+  padding: 0px 10px;
+  border-radius: 6px 6px;
+  box-shadow: 0px 5px 3px rgba(135, 15, 150, 0.4);
+  transform: rotate(30deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box391 {
+  --cssB-v-391: 96329;
+  color: hsl(67, 83%, 67%);
+  background-color: hsl(247, 83%, 33%);
+  border: 2px solid hsl(157, 50%, 50%);
+  margin: 11px 3px 5px 1px;
+  padding: 1px 12px;
+  border-radius: 7px 8px;
+  box-shadow: 1px 6px 4px rgba(136, 17, 153, 0.5);
+  transform: rotate(31deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box392 {
+  --cssB-v-392: 104248;
+  color: hsl(104, 96%, 74%);
+  background-color: hsl(284, 96%, 26%);
+  border: 3px solid hsl(194, 50%, 50%);
+  margin: 12px 6px 10px 8px;
+  padding: 2px 14px;
+  border-radius: 8px 1px;
+  box-shadow: 2px 0px 5px rgba(137, 19, 156, 0.6);
+  transform: rotate(32deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box393 {
+  --cssB-v-393: 112167;
+  color: hsl(141, 9%, 31%);
+  background-color: hsl(321, 9%, 69%);
+  border: 4px solid hsl(231, 50%, 50%);
+  margin: 13px 9px 15px 15px;
+  padding: 3px 16px;
+  border-radius: 9px 3px;
+  box-shadow: 3px 1px 6px rgba(138, 21, 159, 0.7);
+  transform: rotate(33deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box394 {
+  --cssB-v-394: 120086;
+  color: hsl(178, 22%, 38%);
+  background-color: hsl(358, 22%, 62%);
+  border: 5px solid hsl(268, 50%, 50%);
+  margin: 14px 12px 20px 4px;
+  padding: 4px 18px;
+  border-radius: 10px 5px;
+  box-shadow: 4px 2px 7px rgba(139, 23, 162, 0.8);
+  transform: rotate(34deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box395 {
+  --cssB-v-395: 128005;
+  color: hsl(215, 35%, 45%);
+  background-color: hsl(35, 35%, 55%);
+  border: 1px solid hsl(305, 50%, 50%);
+  margin: 15px 15px 0px 11px;
+  padding: 5px 20px;
+  border-radius: 11px 7px;
+  box-shadow: 0px 3px 8px rgba(140, 25, 165, 0.9);
+  transform: rotate(35deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box396 {
+  --cssB-v-396: 135924;
+  color: hsl(252, 48%, 52%);
+  background-color: hsl(72, 48%, 48%);
+  border: 2px solid hsl(342, 50%, 50%);
+  margin: 16px 18px 5px 0px;
+  padding: 6px 0px;
+  border-radius: 0px 0px;
+  box-shadow: 1px 4px 0px rgba(141, 27, 168, 0.1);
+  transform: rotate(36deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box397 {
+  --cssB-v-397: 143843;
+  color: hsl(289, 61%, 59%);
+  background-color: hsl(109, 61%, 41%);
+  border: 3px solid hsl(19, 50%, 50%);
+  margin: 17px 21px 10px 7px;
+  padding: 7px 2px;
+  border-radius: 1px 2px;
+  box-shadow: 2px 5px 1px rgba(142, 29, 171, 0.2);
+  transform: rotate(37deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box398 {
+  --cssB-v-398: 151762;
+  color: hsl(326, 74%, 66%);
+  background-color: hsl(146, 74%, 34%);
+  border: 4px solid hsl(56, 50%, 50%);
+  margin: 18px 24px 15px 14px;
+  padding: 8px 4px;
+  border-radius: 2px 4px;
+  box-shadow: 3px 6px 2px rgba(143, 31, 174, 0.3);
+  transform: rotate(38deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box399 {
+  --cssB-v-399: 159681;
+  color: hsl(3, 87%, 73%);
+  background-color: hsl(183, 87%, 27%);
+  border: 5px solid hsl(93, 50%, 50%);
+  margin: 19px 27px 20px 3px;
+  padding: 9px 6px;
+  border-radius: 3px 6px;
+  box-shadow: 4px 0px 3px rgba(144, 33, 177, 0.4);
+  transform: rotate(39deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box400 {
+  --cssB-v-400: 167600;
+  color: hsl(40, 0%, 30%);
+  background-color: hsl(220, 0%, 70%);
+  border: 1px solid hsl(130, 50%, 50%);
+  margin: 0px 0px 0px 10px;
+  padding: 10px 8px;
+  border-radius: 4px 8px;
+  box-shadow: 0px 1px 4px rgba(145, 35, 180, 0.5);
+  transform: rotate(40deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box401 {
+  --cssB-v-401: 175519;
+  color: hsl(77, 13%, 37%);
+  background-color: hsl(257, 13%, 63%);
+  border: 2px solid hsl(167, 50%, 50%);
+  margin: 1px 3px 5px 17px;
+  padding: 11px 10px;
+  border-radius: 5px 1px;
+  box-shadow: 1px 2px 5px rgba(146, 37, 183, 0.6);
+  transform: rotate(41deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box402 {
+  --cssB-v-402: 183438;
+  color: hsl(114, 26%, 44%);
+  background-color: hsl(294, 26%, 56%);
+  border: 3px solid hsl(204, 50%, 50%);
+  margin: 2px 6px 10px 6px;
+  padding: 12px 12px;
+  border-radius: 6px 3px;
+  box-shadow: 2px 3px 6px rgba(147, 39, 186, 0.7);
+  transform: rotate(42deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box403 {
+  --cssB-v-403: 191357;
+  color: hsl(151, 39%, 51%);
+  background-color: hsl(331, 39%, 49%);
+  border: 4px solid hsl(241, 50%, 50%);
+  margin: 3px 9px 15px 13px;
+  padding: 13px 14px;
+  border-radius: 7px 5px;
+  box-shadow: 3px 4px 7px rgba(148, 41, 189, 0.8);
+  transform: rotate(43deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box404 {
+  --cssB-v-404: 199276;
+  color: hsl(188, 52%, 58%);
+  background-color: hsl(8, 52%, 42%);
+  border: 5px solid hsl(278, 50%, 50%);
+  margin: 4px 12px 20px 2px;
+  padding: 14px 16px;
+  border-radius: 8px 7px;
+  box-shadow: 4px 5px 8px rgba(149, 43, 192, 0.9);
+  transform: rotate(44deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box405 {
+  --cssB-v-405: 207195;
+  color: hsl(225, 65%, 65%);
+  background-color: hsl(45, 65%, 35%);
+  border: 1px solid hsl(315, 50%, 50%);
+  margin: 5px 15px 0px 9px;
+  padding: 0px 18px;
+  border-radius: 9px 0px;
+  box-shadow: 0px 6px 0px rgba(150, 45, 195, 0.1);
+  transform: rotate(45deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box406 {
+  --cssB-v-406: 215114;
+  color: hsl(262, 78%, 72%);
+  background-color: hsl(82, 78%, 28%);
+  border: 2px solid hsl(352, 50%, 50%);
+  margin: 6px 18px 5px 16px;
+  padding: 1px 20px;
+  border-radius: 10px 2px;
+  box-shadow: 1px 0px 1px rgba(151, 47, 198, 0.2);
+  transform: rotate(46deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box407 {
+  --cssB-v-407: 223033;
+  color: hsl(299, 91%, 79%);
+  background-color: hsl(119, 91%, 21%);
+  border: 3px solid hsl(29, 50%, 50%);
+  margin: 7px 21px 10px 5px;
+  padding: 2px 0px;
+  border-radius: 11px 4px;
+  box-shadow: 2px 1px 2px rgba(152, 49, 201, 0.3);
+  transform: rotate(47deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box408 {
+  --cssB-v-408: 230952;
+  color: hsl(336, 4%, 36%);
+  background-color: hsl(156, 4%, 64%);
+  border: 4px solid hsl(66, 50%, 50%);
+  margin: 8px 24px 15px 12px;
+  padding: 3px 2px;
+  border-radius: 0px 6px;
+  box-shadow: 3px 2px 3px rgba(153, 51, 204, 0.4);
+  transform: rotate(48deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box409 {
+  --cssB-v-409: 238871;
+  color: hsl(13, 17%, 43%);
+  background-color: hsl(193, 17%, 57%);
+  border: 5px solid hsl(103, 50%, 50%);
+  margin: 9px 27px 20px 1px;
+  padding: 4px 4px;
+  border-radius: 1px 8px;
+  box-shadow: 4px 3px 4px rgba(154, 53, 207, 0.5);
+  transform: rotate(49deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box410 {
+  --cssB-v-410: 246790;
+  color: hsl(50, 30%, 50%);
+  background-color: hsl(230, 30%, 50%);
+  border: 1px solid hsl(140, 50%, 50%);
+  margin: 10px 0px 0px 8px;
+  padding: 5px 6px;
+  border-radius: 2px 1px;
+  box-shadow: 0px 4px 5px rgba(155, 55, 210, 0.6);
+  transform: rotate(50deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box411 {
+  --cssB-v-411: 254709;
+  color: hsl(87, 43%, 57%);
+  background-color: hsl(267, 43%, 43%);
+  border: 2px solid hsl(177, 50%, 50%);
+  margin: 11px 3px 5px 15px;
+  padding: 6px 8px;
+  border-radius: 3px 3px;
+  box-shadow: 1px 5px 6px rgba(156, 57, 213, 0.7);
+  transform: rotate(51deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box412 {
+  --cssB-v-412: 262628;
+  color: hsl(124, 56%, 64%);
+  background-color: hsl(304, 56%, 36%);
+  border: 3px solid hsl(214, 50%, 50%);
+  margin: 12px 6px 10px 4px;
+  padding: 7px 10px;
+  border-radius: 4px 5px;
+  box-shadow: 2px 6px 7px rgba(157, 59, 216, 0.8);
+  transform: rotate(52deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box413 {
+  --cssB-v-413: 270547;
+  color: hsl(161, 69%, 71%);
+  background-color: hsl(341, 69%, 29%);
+  border: 4px solid hsl(251, 50%, 50%);
+  margin: 13px 9px 15px 11px;
+  padding: 8px 12px;
+  border-radius: 5px 7px;
+  box-shadow: 3px 0px 8px rgba(158, 61, 219, 0.9);
+  transform: rotate(53deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box414 {
+  --cssB-v-414: 278466;
+  color: hsl(198, 82%, 78%);
+  background-color: hsl(18, 82%, 22%);
+  border: 5px solid hsl(288, 50%, 50%);
+  margin: 14px 12px 20px 0px;
+  padding: 9px 14px;
+  border-radius: 6px 0px;
+  box-shadow: 4px 1px 0px rgba(159, 63, 222, 0.1);
+  transform: rotate(54deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box415 {
+  --cssB-v-415: 286385;
+  color: hsl(235, 95%, 35%);
+  background-color: hsl(55, 95%, 65%);
+  border: 1px solid hsl(325, 50%, 50%);
+  margin: 15px 15px 0px 7px;
+  padding: 10px 16px;
+  border-radius: 7px 2px;
+  box-shadow: 0px 2px 1px rgba(160, 65, 225, 0.2);
+  transform: rotate(55deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box416 {
+  --cssB-v-416: 294304;
+  color: hsl(272, 8%, 42%);
+  background-color: hsl(92, 8%, 58%);
+  border: 2px solid hsl(2, 50%, 50%);
+  margin: 16px 18px 5px 14px;
+  padding: 11px 18px;
+  border-radius: 8px 4px;
+  box-shadow: 1px 3px 2px rgba(161, 67, 228, 0.3);
+  transform: rotate(56deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box417 {
+  --cssB-v-417: 302223;
+  color: hsl(309, 21%, 49%);
+  background-color: hsl(129, 21%, 51%);
+  border: 3px solid hsl(39, 50%, 50%);
+  margin: 17px 21px 10px 3px;
+  padding: 12px 20px;
+  border-radius: 9px 6px;
+  box-shadow: 2px 4px 3px rgba(162, 69, 231, 0.4);
+  transform: rotate(57deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box418 {
+  --cssB-v-418: 310142;
+  color: hsl(346, 34%, 56%);
+  background-color: hsl(166, 34%, 44%);
+  border: 4px solid hsl(76, 50%, 50%);
+  margin: 18px 24px 15px 10px;
+  padding: 13px 0px;
+  border-radius: 10px 8px;
+  box-shadow: 3px 5px 4px rgba(163, 71, 234, 0.5);
+  transform: rotate(58deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box419 {
+  --cssB-v-419: 318061;
+  color: hsl(23, 47%, 63%);
+  background-color: hsl(203, 47%, 37%);
+  border: 5px solid hsl(113, 50%, 50%);
+  margin: 19px 27px 20px 17px;
+  padding: 14px 2px;
+  border-radius: 11px 1px;
+  box-shadow: 4px 6px 5px rgba(164, 73, 237, 0.6);
+  transform: rotate(59deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box420 {
+  --cssB-v-420: 325980;
+  color: hsl(60, 60%, 70%);
+  background-color: hsl(240, 60%, 30%);
+  border: 1px solid hsl(150, 50%, 50%);
+  margin: 0px 0px 0px 6px;
+  padding: 0px 4px;
+  border-radius: 0px 3px;
+  box-shadow: 0px 0px 6px rgba(165, 75, 240, 0.7);
+  transform: rotate(60deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box421 {
+  --cssB-v-421: 333899;
+  color: hsl(97, 73%, 77%);
+  background-color: hsl(277, 73%, 23%);
+  border: 2px solid hsl(187, 50%, 50%);
+  margin: 1px 3px 5px 13px;
+  padding: 1px 6px;
+  border-radius: 1px 5px;
+  box-shadow: 1px 1px 7px rgba(166, 77, 243, 0.8);
+  transform: rotate(61deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box422 {
+  --cssB-v-422: 341818;
+  color: hsl(134, 86%, 34%);
+  background-color: hsl(314, 86%, 66%);
+  border: 3px solid hsl(224, 50%, 50%);
+  margin: 2px 6px 10px 2px;
+  padding: 2px 8px;
+  border-radius: 2px 7px;
+  box-shadow: 2px 2px 8px rgba(167, 79, 246, 0.9);
+  transform: rotate(62deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box423 {
+  --cssB-v-423: 349737;
+  color: hsl(171, 99%, 41%);
+  background-color: hsl(351, 99%, 59%);
+  border: 4px solid hsl(261, 50%, 50%);
+  margin: 3px 9px 15px 9px;
+  padding: 3px 10px;
+  border-radius: 3px 0px;
+  box-shadow: 3px 3px 0px rgba(168, 81, 249, 0.1);
+  transform: rotate(63deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box424 {
+  --cssB-v-424: 357656;
+  color: hsl(208, 12%, 48%);
+  background-color: hsl(28, 12%, 52%);
+  border: 5px solid hsl(298, 50%, 50%);
+  margin: 4px 12px 20px 16px;
+  padding: 4px 12px;
+  border-radius: 4px 2px;
+  box-shadow: 4px 4px 1px rgba(169, 83, 252, 0.2);
+  transform: rotate(64deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box425 {
+  --cssB-v-425: 365575;
+  color: hsl(245, 25%, 55%);
+  background-color: hsl(65, 25%, 45%);
+  border: 1px solid hsl(335, 50%, 50%);
+  margin: 5px 15px 0px 5px;
+  padding: 5px 14px;
+  border-radius: 5px 4px;
+  box-shadow: 0px 5px 2px rgba(170, 85, 0, 0.3);
+  transform: rotate(65deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box426 {
+  --cssB-v-426: 373494;
+  color: hsl(282, 38%, 62%);
+  background-color: hsl(102, 38%, 38%);
+  border: 2px solid hsl(12, 50%, 50%);
+  margin: 6px 18px 5px 12px;
+  padding: 6px 16px;
+  border-radius: 6px 6px;
+  box-shadow: 1px 6px 3px rgba(171, 87, 3, 0.4);
+  transform: rotate(66deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box427 {
+  --cssB-v-427: 381413;
+  color: hsl(319, 51%, 69%);
+  background-color: hsl(139, 51%, 31%);
+  border: 3px solid hsl(49, 50%, 50%);
+  margin: 7px 21px 10px 1px;
+  padding: 7px 18px;
+  border-radius: 7px 8px;
+  box-shadow: 2px 0px 4px rgba(172, 89, 6, 0.5);
+  transform: rotate(67deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box428 {
+  --cssB-v-428: 389332;
+  color: hsl(356, 64%, 76%);
+  background-color: hsl(176, 64%, 24%);
+  border: 4px solid hsl(86, 50%, 50%);
+  margin: 8px 24px 15px 8px;
+  padding: 8px 20px;
+  border-radius: 8px 1px;
+  box-shadow: 3px 1px 5px rgba(173, 91, 9, 0.6);
+  transform: rotate(68deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box429 {
+  --cssB-v-429: 397251;
+  color: hsl(33, 77%, 33%);
+  background-color: hsl(213, 77%, 67%);
+  border: 5px solid hsl(123, 50%, 50%);
+  margin: 9px 27px 20px 15px;
+  padding: 9px 0px;
+  border-radius: 9px 3px;
+  box-shadow: 4px 2px 6px rgba(174, 93, 12, 0.7);
+  transform: rotate(69deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box430 {
+  --cssB-v-430: 405170;
+  color: hsl(70, 90%, 40%);
+  background-color: hsl(250, 90%, 60%);
+  border: 1px solid hsl(160, 50%, 50%);
+  margin: 10px 0px 0px 4px;
+  padding: 10px 2px;
+  border-radius: 10px 5px;
+  box-shadow: 0px 3px 7px rgba(175, 95, 15, 0.8);
+  transform: rotate(70deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box431 {
+  --cssB-v-431: 413089;
+  color: hsl(107, 3%, 47%);
+  background-color: hsl(287, 3%, 53%);
+  border: 2px solid hsl(197, 50%, 50%);
+  margin: 11px 3px 5px 11px;
+  padding: 11px 4px;
+  border-radius: 11px 7px;
+  box-shadow: 1px 4px 8px rgba(176, 97, 18, 0.9);
+  transform: rotate(71deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box432 {
+  --cssB-v-432: 421008;
+  color: hsl(144, 16%, 54%);
+  background-color: hsl(324, 16%, 46%);
+  border: 3px solid hsl(234, 50%, 50%);
+  margin: 12px 6px 10px 0px;
+  padding: 12px 6px;
+  border-radius: 0px 0px;
+  box-shadow: 2px 5px 0px rgba(177, 99, 21, 0.1);
+  transform: rotate(72deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box433 {
+  --cssB-v-433: 428927;
+  color: hsl(181, 29%, 61%);
+  background-color: hsl(1, 29%, 39%);
+  border: 4px solid hsl(271, 50%, 50%);
+  margin: 13px 9px 15px 7px;
+  padding: 13px 8px;
+  border-radius: 1px 2px;
+  box-shadow: 3px 6px 1px rgba(178, 101, 24, 0.2);
+  transform: rotate(73deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box434 {
+  --cssB-v-434: 436846;
+  color: hsl(218, 42%, 68%);
+  background-color: hsl(38, 42%, 32%);
+  border: 5px solid hsl(308, 50%, 50%);
+  margin: 14px 12px 20px 14px;
+  padding: 14px 10px;
+  border-radius: 2px 4px;
+  box-shadow: 4px 0px 2px rgba(179, 103, 27, 0.3);
+  transform: rotate(74deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box435 {
+  --cssB-v-435: 444765;
+  color: hsl(255, 55%, 75%);
+  background-color: hsl(75, 55%, 25%);
+  border: 1px solid hsl(345, 50%, 50%);
+  margin: 15px 15px 0px 3px;
+  padding: 0px 12px;
+  border-radius: 3px 6px;
+  box-shadow: 0px 1px 3px rgba(180, 105, 30, 0.4);
+  transform: rotate(75deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box436 {
+  --cssB-v-436: 452684;
+  color: hsl(292, 68%, 32%);
+  background-color: hsl(112, 68%, 68%);
+  border: 2px solid hsl(22, 50%, 50%);
+  margin: 16px 18px 5px 10px;
+  padding: 1px 14px;
+  border-radius: 4px 8px;
+  box-shadow: 1px 2px 4px rgba(181, 107, 33, 0.5);
+  transform: rotate(76deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box437 {
+  --cssB-v-437: 460603;
+  color: hsl(329, 81%, 39%);
+  background-color: hsl(149, 81%, 61%);
+  border: 3px solid hsl(59, 50%, 50%);
+  margin: 17px 21px 10px 17px;
+  padding: 2px 16px;
+  border-radius: 5px 1px;
+  box-shadow: 2px 3px 5px rgba(182, 109, 36, 0.6);
+  transform: rotate(77deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box438 {
+  --cssB-v-438: 468522;
+  color: hsl(6, 94%, 46%);
+  background-color: hsl(186, 94%, 54%);
+  border: 4px solid hsl(96, 50%, 50%);
+  margin: 18px 24px 15px 6px;
+  padding: 3px 18px;
+  border-radius: 6px 3px;
+  box-shadow: 3px 4px 6px rgba(183, 111, 39, 0.7);
+  transform: rotate(78deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box439 {
+  --cssB-v-439: 476441;
+  color: hsl(43, 7%, 53%);
+  background-color: hsl(223, 7%, 47%);
+  border: 5px solid hsl(133, 50%, 50%);
+  margin: 19px 27px 20px 13px;
+  padding: 4px 20px;
+  border-radius: 7px 5px;
+  box-shadow: 4px 5px 7px rgba(184, 113, 42, 0.8);
+  transform: rotate(79deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box440 {
+  --cssB-v-440: 484360;
+  color: hsl(80, 20%, 60%);
+  background-color: hsl(260, 20%, 40%);
+  border: 1px solid hsl(170, 50%, 50%);
+  margin: 0px 0px 0px 2px;
+  padding: 5px 0px;
+  border-radius: 8px 7px;
+  box-shadow: 0px 6px 8px rgba(185, 115, 45, 0.9);
+  transform: rotate(80deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box441 {
+  --cssB-v-441: 492279;
+  color: hsl(117, 33%, 67%);
+  background-color: hsl(297, 33%, 33%);
+  border: 2px solid hsl(207, 50%, 50%);
+  margin: 1px 3px 5px 9px;
+  padding: 6px 2px;
+  border-radius: 9px 0px;
+  box-shadow: 1px 0px 0px rgba(186, 117, 48, 0.1);
+  transform: rotate(81deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box442 {
+  --cssB-v-442: 500198;
+  color: hsl(154, 46%, 74%);
+  background-color: hsl(334, 46%, 26%);
+  border: 3px solid hsl(244, 50%, 50%);
+  margin: 2px 6px 10px 16px;
+  padding: 7px 4px;
+  border-radius: 10px 2px;
+  box-shadow: 2px 1px 1px rgba(187, 119, 51, 0.2);
+  transform: rotate(82deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box443 {
+  --cssB-v-443: 508117;
+  color: hsl(191, 59%, 31%);
+  background-color: hsl(11, 59%, 69%);
+  border: 4px solid hsl(281, 50%, 50%);
+  margin: 3px 9px 15px 5px;
+  padding: 8px 6px;
+  border-radius: 11px 4px;
+  box-shadow: 3px 2px 2px rgba(188, 121, 54, 0.3);
+  transform: rotate(83deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box444 {
+  --cssB-v-444: 516036;
+  color: hsl(228, 72%, 38%);
+  background-color: hsl(48, 72%, 62%);
+  border: 5px solid hsl(318, 50%, 50%);
+  margin: 4px 12px 20px 12px;
+  padding: 9px 8px;
+  border-radius: 0px 6px;
+  box-shadow: 4px 3px 3px rgba(189, 123, 57, 0.4);
+  transform: rotate(84deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box445 {
+  --cssB-v-445: 523955;
+  color: hsl(265, 85%, 45%);
+  background-color: hsl(85, 85%, 55%);
+  border: 1px solid hsl(355, 50%, 50%);
+  margin: 5px 15px 0px 1px;
+  padding: 10px 10px;
+  border-radius: 1px 8px;
+  box-shadow: 0px 4px 4px rgba(190, 125, 60, 0.5);
+  transform: rotate(85deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box446 {
+  --cssB-v-446: 531874;
+  color: hsl(302, 98%, 52%);
+  background-color: hsl(122, 98%, 48%);
+  border: 2px solid hsl(32, 50%, 50%);
+  margin: 6px 18px 5px 8px;
+  padding: 11px 12px;
+  border-radius: 2px 1px;
+  box-shadow: 1px 5px 5px rgba(191, 127, 63, 0.6);
+  transform: rotate(86deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box447 {
+  --cssB-v-447: 539793;
+  color: hsl(339, 11%, 59%);
+  background-color: hsl(159, 11%, 41%);
+  border: 3px solid hsl(69, 50%, 50%);
+  margin: 7px 21px 10px 15px;
+  padding: 12px 14px;
+  border-radius: 3px 3px;
+  box-shadow: 2px 6px 6px rgba(192, 129, 66, 0.7);
+  transform: rotate(87deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box448 {
+  --cssB-v-448: 547712;
+  color: hsl(16, 24%, 66%);
+  background-color: hsl(196, 24%, 34%);
+  border: 4px solid hsl(106, 50%, 50%);
+  margin: 8px 24px 15px 4px;
+  padding: 13px 16px;
+  border-radius: 4px 5px;
+  box-shadow: 3px 0px 7px rgba(193, 131, 69, 0.8);
+  transform: rotate(88deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box449 {
+  --cssB-v-449: 555631;
+  color: hsl(53, 37%, 73%);
+  background-color: hsl(233, 37%, 27%);
+  border: 5px solid hsl(143, 50%, 50%);
+  margin: 9px 27px 20px 11px;
+  padding: 14px 18px;
+  border-radius: 5px 7px;
+  box-shadow: 4px 1px 8px rgba(194, 133, 72, 0.9);
+  transform: rotate(89deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box450 {
+  --cssB-v-450: 563550;
+  color: hsl(90, 50%, 30%);
+  background-color: hsl(270, 50%, 70%);
+  border: 1px solid hsl(180, 50%, 50%);
+  margin: 10px 0px 0px 0px;
+  padding: 0px 20px;
+  border-radius: 6px 0px;
+  box-shadow: 0px 2px 0px rgba(195, 135, 75, 0.1);
+  transform: rotate(90deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box451 {
+  --cssB-v-451: 571469;
+  color: hsl(127, 63%, 37%);
+  background-color: hsl(307, 63%, 63%);
+  border: 2px solid hsl(217, 50%, 50%);
+  margin: 11px 3px 5px 7px;
+  padding: 1px 0px;
+  border-radius: 7px 2px;
+  box-shadow: 1px 3px 1px rgba(196, 137, 78, 0.2);
+  transform: rotate(91deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box452 {
+  --cssB-v-452: 579388;
+  color: hsl(164, 76%, 44%);
+  background-color: hsl(344, 76%, 56%);
+  border: 3px solid hsl(254, 50%, 50%);
+  margin: 12px 6px 10px 14px;
+  padding: 2px 2px;
+  border-radius: 8px 4px;
+  box-shadow: 2px 4px 2px rgba(197, 139, 81, 0.3);
+  transform: rotate(92deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box453 {
+  --cssB-v-453: 587307;
+  color: hsl(201, 89%, 51%);
+  background-color: hsl(21, 89%, 49%);
+  border: 4px solid hsl(291, 50%, 50%);
+  margin: 13px 9px 15px 3px;
+  padding: 3px 4px;
+  border-radius: 9px 6px;
+  box-shadow: 3px 5px 3px rgba(198, 141, 84, 0.4);
+  transform: rotate(93deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box454 {
+  --cssB-v-454: 595226;
+  color: hsl(238, 2%, 58%);
+  background-color: hsl(58, 2%, 42%);
+  border: 5px solid hsl(328, 50%, 50%);
+  margin: 14px 12px 20px 10px;
+  padding: 4px 6px;
+  border-radius: 10px 8px;
+  box-shadow: 4px 6px 4px rgba(199, 143, 87, 0.5);
+  transform: rotate(94deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box455 {
+  --cssB-v-455: 603145;
+  color: hsl(275, 15%, 65%);
+  background-color: hsl(95, 15%, 35%);
+  border: 1px solid hsl(5, 50%, 50%);
+  margin: 15px 15px 0px 17px;
+  padding: 5px 8px;
+  border-radius: 11px 1px;
+  box-shadow: 0px 0px 5px rgba(200, 145, 90, 0.6);
+  transform: rotate(95deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box456 {
+  --cssB-v-456: 611064;
+  color: hsl(312, 28%, 72%);
+  background-color: hsl(132, 28%, 28%);
+  border: 2px solid hsl(42, 50%, 50%);
+  margin: 16px 18px 5px 6px;
+  padding: 6px 10px;
+  border-radius: 0px 3px;
+  box-shadow: 1px 1px 6px rgba(201, 147, 93, 0.7);
+  transform: rotate(96deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box457 {
+  --cssB-v-457: 618983;
+  color: hsl(349, 41%, 79%);
+  background-color: hsl(169, 41%, 21%);
+  border: 3px solid hsl(79, 50%, 50%);
+  margin: 17px 21px 10px 13px;
+  padding: 7px 12px;
+  border-radius: 1px 5px;
+  box-shadow: 2px 2px 7px rgba(202, 149, 96, 0.8);
+  transform: rotate(97deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box458 {
+  --cssB-v-458: 626902;
+  color: hsl(26, 54%, 36%);
+  background-color: hsl(206, 54%, 64%);
+  border: 4px solid hsl(116, 50%, 50%);
+  margin: 18px 24px 15px 2px;
+  padding: 8px 14px;
+  border-radius: 2px 7px;
+  box-shadow: 3px 3px 8px rgba(203, 151, 99, 0.9);
+  transform: rotate(98deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box459 {
+  --cssB-v-459: 634821;
+  color: hsl(63, 67%, 43%);
+  background-color: hsl(243, 67%, 57%);
+  border: 5px solid hsl(153, 50%, 50%);
+  margin: 19px 27px 20px 9px;
+  padding: 9px 16px;
+  border-radius: 3px 0px;
+  box-shadow: 4px 4px 0px rgba(204, 153, 102, 0.1);
+  transform: rotate(99deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box460 {
+  --cssB-v-460: 642740;
+  color: hsl(100, 80%, 50%);
+  background-color: hsl(280, 80%, 50%);
+  border: 1px solid hsl(190, 50%, 50%);
+  margin: 0px 0px 0px 16px;
+  padding: 10px 18px;
+  border-radius: 4px 2px;
+  box-shadow: 0px 5px 1px rgba(205, 155, 105, 0.2);
+  transform: rotate(100deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box461 {
+  --cssB-v-461: 650659;
+  color: hsl(137, 93%, 57%);
+  background-color: hsl(317, 93%, 43%);
+  border: 2px solid hsl(227, 50%, 50%);
+  margin: 1px 3px 5px 5px;
+  padding: 11px 20px;
+  border-radius: 5px 4px;
+  box-shadow: 1px 6px 2px rgba(206, 157, 108, 0.3);
+  transform: rotate(101deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box462 {
+  --cssB-v-462: 658578;
+  color: hsl(174, 6%, 64%);
+  background-color: hsl(354, 6%, 36%);
+  border: 3px solid hsl(264, 50%, 50%);
+  margin: 2px 6px 10px 12px;
+  padding: 12px 0px;
+  border-radius: 6px 6px;
+  box-shadow: 2px 0px 3px rgba(207, 159, 111, 0.4);
+  transform: rotate(102deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box463 {
+  --cssB-v-463: 666497;
+  color: hsl(211, 19%, 71%);
+  background-color: hsl(31, 19%, 29%);
+  border: 4px solid hsl(301, 50%, 50%);
+  margin: 3px 9px 15px 1px;
+  padding: 13px 2px;
+  border-radius: 7px 8px;
+  box-shadow: 3px 1px 4px rgba(208, 161, 114, 0.5);
+  transform: rotate(103deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box464 {
+  --cssB-v-464: 674416;
+  color: hsl(248, 32%, 78%);
+  background-color: hsl(68, 32%, 22%);
+  border: 5px solid hsl(338, 50%, 50%);
+  margin: 4px 12px 20px 8px;
+  padding: 14px 4px;
+  border-radius: 8px 1px;
+  box-shadow: 4px 2px 5px rgba(209, 163, 117, 0.6);
+  transform: rotate(104deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box465 {
+  --cssB-v-465: 682335;
+  color: hsl(285, 45%, 35%);
+  background-color: hsl(105, 45%, 65%);
+  border: 1px solid hsl(15, 50%, 50%);
+  margin: 5px 15px 0px 15px;
+  padding: 0px 6px;
+  border-radius: 9px 3px;
+  box-shadow: 0px 3px 6px rgba(210, 165, 120, 0.7);
+  transform: rotate(105deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box466 {
+  --cssB-v-466: 690254;
+  color: hsl(322, 58%, 42%);
+  background-color: hsl(142, 58%, 58%);
+  border: 2px solid hsl(52, 50%, 50%);
+  margin: 6px 18px 5px 4px;
+  padding: 1px 8px;
+  border-radius: 10px 5px;
+  box-shadow: 1px 4px 7px rgba(211, 167, 123, 0.8);
+  transform: rotate(106deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box467 {
+  --cssB-v-467: 698173;
+  color: hsl(359, 71%, 49%);
+  background-color: hsl(179, 71%, 51%);
+  border: 3px solid hsl(89, 50%, 50%);
+  margin: 7px 21px 10px 11px;
+  padding: 2px 10px;
+  border-radius: 11px 7px;
+  box-shadow: 2px 5px 8px rgba(212, 169, 126, 0.9);
+  transform: rotate(107deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box468 {
+  --cssB-v-468: 706092;
+  color: hsl(36, 84%, 56%);
+  background-color: hsl(216, 84%, 44%);
+  border: 4px solid hsl(126, 50%, 50%);
+  margin: 8px 24px 15px 0px;
+  padding: 3px 12px;
+  border-radius: 0px 0px;
+  box-shadow: 3px 6px 0px rgba(213, 171, 129, 0.1);
+  transform: rotate(108deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box469 {
+  --cssB-v-469: 714011;
+  color: hsl(73, 97%, 63%);
+  background-color: hsl(253, 97%, 37%);
+  border: 5px solid hsl(163, 50%, 50%);
+  margin: 9px 27px 20px 7px;
+  padding: 4px 14px;
+  border-radius: 1px 2px;
+  box-shadow: 4px 0px 1px rgba(214, 173, 132, 0.2);
+  transform: rotate(109deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box470 {
+  --cssB-v-470: 721930;
+  color: hsl(110, 10%, 70%);
+  background-color: hsl(290, 10%, 30%);
+  border: 1px solid hsl(200, 50%, 50%);
+  margin: 10px 0px 0px 14px;
+  padding: 5px 16px;
+  border-radius: 2px 4px;
+  box-shadow: 0px 1px 2px rgba(215, 175, 135, 0.3);
+  transform: rotate(110deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box471 {
+  --cssB-v-471: 729849;
+  color: hsl(147, 23%, 77%);
+  background-color: hsl(327, 23%, 23%);
+  border: 2px solid hsl(237, 50%, 50%);
+  margin: 11px 3px 5px 3px;
+  padding: 6px 18px;
+  border-radius: 3px 6px;
+  box-shadow: 1px 2px 3px rgba(216, 177, 138, 0.4);
+  transform: rotate(111deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box472 {
+  --cssB-v-472: 737768;
+  color: hsl(184, 36%, 34%);
+  background-color: hsl(4, 36%, 66%);
+  border: 3px solid hsl(274, 50%, 50%);
+  margin: 12px 6px 10px 10px;
+  padding: 7px 20px;
+  border-radius: 4px 8px;
+  box-shadow: 2px 3px 4px rgba(217, 179, 141, 0.5);
+  transform: rotate(112deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box473 {
+  --cssB-v-473: 745687;
+  color: hsl(221, 49%, 41%);
+  background-color: hsl(41, 49%, 59%);
+  border: 4px solid hsl(311, 50%, 50%);
+  margin: 13px 9px 15px 17px;
+  padding: 8px 0px;
+  border-radius: 5px 1px;
+  box-shadow: 3px 4px 5px rgba(218, 181, 144, 0.6);
+  transform: rotate(113deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box474 {
+  --cssB-v-474: 753606;
+  color: hsl(258, 62%, 48%);
+  background-color: hsl(78, 62%, 52%);
+  border: 5px solid hsl(348, 50%, 50%);
+  margin: 14px 12px 20px 6px;
+  padding: 9px 2px;
+  border-radius: 6px 3px;
+  box-shadow: 4px 5px 6px rgba(219, 183, 147, 0.7);
+  transform: rotate(114deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box475 {
+  --cssB-v-475: 761525;
+  color: hsl(295, 75%, 55%);
+  background-color: hsl(115, 75%, 45%);
+  border: 1px solid hsl(25, 50%, 50%);
+  margin: 15px 15px 0px 13px;
+  padding: 10px 4px;
+  border-radius: 7px 5px;
+  box-shadow: 0px 6px 7px rgba(220, 185, 150, 0.8);
+  transform: rotate(115deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box476 {
+  --cssB-v-476: 769444;
+  color: hsl(332, 88%, 62%);
+  background-color: hsl(152, 88%, 38%);
+  border: 2px solid hsl(62, 50%, 50%);
+  margin: 16px 18px 5px 2px;
+  padding: 11px 6px;
+  border-radius: 8px 7px;
+  box-shadow: 1px 0px 8px rgba(221, 187, 153, 0.9);
+  transform: rotate(116deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box477 {
+  --cssB-v-477: 777363;
+  color: hsl(9, 1%, 69%);
+  background-color: hsl(189, 1%, 31%);
+  border: 3px solid hsl(99, 50%, 50%);
+  margin: 17px 21px 10px 9px;
+  padding: 12px 8px;
+  border-radius: 9px 0px;
+  box-shadow: 2px 1px 0px rgba(222, 189, 156, 0.1);
+  transform: rotate(117deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box478 {
+  --cssB-v-478: 785282;
+  color: hsl(46, 14%, 76%);
+  background-color: hsl(226, 14%, 24%);
+  border: 4px solid hsl(136, 50%, 50%);
+  margin: 18px 24px 15px 16px;
+  padding: 13px 10px;
+  border-radius: 10px 2px;
+  box-shadow: 3px 2px 1px rgba(223, 191, 159, 0.2);
+  transform: rotate(118deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box479 {
+  --cssB-v-479: 793201;
+  color: hsl(83, 27%, 33%);
+  background-color: hsl(263, 27%, 67%);
+  border: 5px solid hsl(173, 50%, 50%);
+  margin: 19px 27px 20px 5px;
+  padding: 14px 12px;
+  border-radius: 11px 4px;
+  box-shadow: 4px 3px 2px rgba(224, 193, 162, 0.3);
+  transform: rotate(119deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box480 {
+  --cssB-v-480: 801120;
+  color: hsl(120, 40%, 40%);
+  background-color: hsl(300, 40%, 60%);
+  border: 1px solid hsl(210, 50%, 50%);
+  margin: 0px 0px 0px 12px;
+  padding: 0px 14px;
+  border-radius: 0px 6px;
+  box-shadow: 0px 4px 3px rgba(225, 195, 165, 0.4);
+  transform: rotate(120deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box481 {
+  --cssB-v-481: 809039;
+  color: hsl(157, 53%, 47%);
+  background-color: hsl(337, 53%, 53%);
+  border: 2px solid hsl(247, 50%, 50%);
+  margin: 1px 3px 5px 1px;
+  padding: 1px 16px;
+  border-radius: 1px 8px;
+  box-shadow: 1px 5px 4px rgba(226, 197, 168, 0.5);
+  transform: rotate(121deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box482 {
+  --cssB-v-482: 816958;
+  color: hsl(194, 66%, 54%);
+  background-color: hsl(14, 66%, 46%);
+  border: 3px solid hsl(284, 50%, 50%);
+  margin: 2px 6px 10px 8px;
+  padding: 2px 18px;
+  border-radius: 2px 1px;
+  box-shadow: 2px 6px 5px rgba(227, 199, 171, 0.6);
+  transform: rotate(122deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box483 {
+  --cssB-v-483: 824877;
+  color: hsl(231, 79%, 61%);
+  background-color: hsl(51, 79%, 39%);
+  border: 4px solid hsl(321, 50%, 50%);
+  margin: 3px 9px 15px 15px;
+  padding: 3px 20px;
+  border-radius: 3px 3px;
+  box-shadow: 3px 0px 6px rgba(228, 201, 174, 0.7);
+  transform: rotate(123deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box484 {
+  --cssB-v-484: 832796;
+  color: hsl(268, 92%, 68%);
+  background-color: hsl(88, 92%, 32%);
+  border: 5px solid hsl(358, 50%, 50%);
+  margin: 4px 12px 20px 4px;
+  padding: 4px 0px;
+  border-radius: 4px 5px;
+  box-shadow: 4px 1px 7px rgba(229, 203, 177, 0.8);
+  transform: rotate(124deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box485 {
+  --cssB-v-485: 840715;
+  color: hsl(305, 5%, 75%);
+  background-color: hsl(125, 5%, 25%);
+  border: 1px solid hsl(35, 50%, 50%);
+  margin: 5px 15px 0px 11px;
+  padding: 5px 2px;
+  border-radius: 5px 7px;
+  box-shadow: 0px 2px 8px rgba(230, 205, 180, 0.9);
+  transform: rotate(125deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box486 {
+  --cssB-v-486: 848634;
+  color: hsl(342, 18%, 32%);
+  background-color: hsl(162, 18%, 68%);
+  border: 2px solid hsl(72, 50%, 50%);
+  margin: 6px 18px 5px 0px;
+  padding: 6px 4px;
+  border-radius: 6px 0px;
+  box-shadow: 1px 3px 0px rgba(231, 207, 183, 0.1);
+  transform: rotate(126deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box487 {
+  --cssB-v-487: 856553;
+  color: hsl(19, 31%, 39%);
+  background-color: hsl(199, 31%, 61%);
+  border: 3px solid hsl(109, 50%, 50%);
+  margin: 7px 21px 10px 7px;
+  padding: 7px 6px;
+  border-radius: 7px 2px;
+  box-shadow: 2px 4px 1px rgba(232, 209, 186, 0.2);
+  transform: rotate(127deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box488 {
+  --cssB-v-488: 864472;
+  color: hsl(56, 44%, 46%);
+  background-color: hsl(236, 44%, 54%);
+  border: 4px solid hsl(146, 50%, 50%);
+  margin: 8px 24px 15px 14px;
+  padding: 8px 8px;
+  border-radius: 8px 4px;
+  box-shadow: 3px 5px 2px rgba(233, 211, 189, 0.3);
+  transform: rotate(128deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box489 {
+  --cssB-v-489: 872391;
+  color: hsl(93, 57%, 53%);
+  background-color: hsl(273, 57%, 47%);
+  border: 5px solid hsl(183, 50%, 50%);
+  margin: 9px 27px 20px 3px;
+  padding: 9px 10px;
+  border-radius: 9px 6px;
+  box-shadow: 4px 6px 3px rgba(234, 213, 192, 0.4);
+  transform: rotate(129deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box490 {
+  --cssB-v-490: 880310;
+  color: hsl(130, 70%, 60%);
+  background-color: hsl(310, 70%, 40%);
+  border: 1px solid hsl(220, 50%, 50%);
+  margin: 10px 0px 0px 10px;
+  padding: 10px 12px;
+  border-radius: 10px 8px;
+  box-shadow: 0px 0px 4px rgba(235, 215, 195, 0.5);
+  transform: rotate(130deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box491 {
+  --cssB-v-491: 888229;
+  color: hsl(167, 83%, 67%);
+  background-color: hsl(347, 83%, 33%);
+  border: 2px solid hsl(257, 50%, 50%);
+  margin: 11px 3px 5px 17px;
+  padding: 11px 14px;
+  border-radius: 11px 1px;
+  box-shadow: 1px 1px 5px rgba(236, 217, 198, 0.6);
+  transform: rotate(131deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box492 {
+  --cssB-v-492: 896148;
+  color: hsl(204, 96%, 74%);
+  background-color: hsl(24, 96%, 26%);
+  border: 3px solid hsl(294, 50%, 50%);
+  margin: 12px 6px 10px 6px;
+  padding: 12px 16px;
+  border-radius: 0px 3px;
+  box-shadow: 2px 2px 6px rgba(237, 219, 201, 0.7);
+  transform: rotate(132deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box493 {
+  --cssB-v-493: 904067;
+  color: hsl(241, 9%, 31%);
+  background-color: hsl(61, 9%, 69%);
+  border: 4px solid hsl(331, 50%, 50%);
+  margin: 13px 9px 15px 13px;
+  padding: 13px 18px;
+  border-radius: 1px 5px;
+  box-shadow: 3px 3px 7px rgba(238, 221, 204, 0.8);
+  transform: rotate(133deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box494 {
+  --cssB-v-494: 911986;
+  color: hsl(278, 22%, 38%);
+  background-color: hsl(98, 22%, 62%);
+  border: 5px solid hsl(8, 50%, 50%);
+  margin: 14px 12px 20px 2px;
+  padding: 14px 20px;
+  border-radius: 2px 7px;
+  box-shadow: 4px 4px 8px rgba(239, 223, 207, 0.9);
+  transform: rotate(134deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box495 {
+  --cssB-v-495: 919905;
+  color: hsl(315, 35%, 45%);
+  background-color: hsl(135, 35%, 55%);
+  border: 1px solid hsl(45, 50%, 50%);
+  margin: 15px 15px 0px 9px;
+  padding: 0px 0px;
+  border-radius: 3px 0px;
+  box-shadow: 0px 5px 0px rgba(240, 225, 210, 0.1);
+  transform: rotate(135deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box496 {
+  --cssB-v-496: 927824;
+  color: hsl(352, 48%, 52%);
+  background-color: hsl(172, 48%, 48%);
+  border: 2px solid hsl(82, 50%, 50%);
+  margin: 16px 18px 5px 16px;
+  padding: 1px 2px;
+  border-radius: 4px 2px;
+  box-shadow: 1px 6px 1px rgba(241, 227, 213, 0.2);
+  transform: rotate(136deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box497 {
+  --cssB-v-497: 935743;
+  color: hsl(29, 61%, 59%);
+  background-color: hsl(209, 61%, 41%);
+  border: 3px solid hsl(119, 50%, 50%);
+  margin: 17px 21px 10px 5px;
+  padding: 2px 4px;
+  border-radius: 5px 4px;
+  box-shadow: 2px 0px 2px rgba(242, 229, 216, 0.3);
+  transform: rotate(137deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box498 {
+  --cssB-v-498: 943662;
+  color: hsl(66, 74%, 66%);
+  background-color: hsl(246, 74%, 34%);
+  border: 4px solid hsl(156, 50%, 50%);
+  margin: 18px 24px 15px 12px;
+  padding: 3px 6px;
+  border-radius: 6px 6px;
+  box-shadow: 3px 1px 3px rgba(243, 231, 219, 0.4);
+  transform: rotate(138deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box499 {
+  --cssB-v-499: 951581;
+  color: hsl(103, 87%, 73%);
+  background-color: hsl(283, 87%, 27%);
+  border: 5px solid hsl(193, 50%, 50%);
+  margin: 19px 27px 20px 1px;
+  padding: 4px 8px;
+  border-radius: 7px 8px;
+  box-shadow: 4px 2px 4px rgba(244, 233, 222, 0.5);
+  transform: rotate(139deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box500 {
+  --cssB-v-500: 959500;
+  color: hsl(140, 0%, 30%);
+  background-color: hsl(320, 0%, 70%);
+  border: 1px solid hsl(230, 50%, 50%);
+  margin: 0px 0px 0px 8px;
+  padding: 5px 10px;
+  border-radius: 8px 1px;
+  box-shadow: 0px 3px 5px rgba(245, 235, 225, 0.6);
+  transform: rotate(140deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box501 {
+  --cssB-v-501: 967419;
+  color: hsl(177, 13%, 37%);
+  background-color: hsl(357, 13%, 63%);
+  border: 2px solid hsl(267, 50%, 50%);
+  margin: 1px 3px 5px 15px;
+  padding: 6px 12px;
+  border-radius: 9px 3px;
+  box-shadow: 1px 4px 6px rgba(246, 237, 228, 0.7);
+  transform: rotate(141deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box502 {
+  --cssB-v-502: 975338;
+  color: hsl(214, 26%, 44%);
+  background-color: hsl(34, 26%, 56%);
+  border: 3px solid hsl(304, 50%, 50%);
+  margin: 2px 6px 10px 4px;
+  padding: 7px 14px;
+  border-radius: 10px 5px;
+  box-shadow: 2px 5px 7px rgba(247, 239, 231, 0.8);
+  transform: rotate(142deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box503 {
+  --cssB-v-503: 983257;
+  color: hsl(251, 39%, 51%);
+  background-color: hsl(71, 39%, 49%);
+  border: 4px solid hsl(341, 50%, 50%);
+  margin: 3px 9px 15px 11px;
+  padding: 8px 16px;
+  border-radius: 11px 7px;
+  box-shadow: 3px 6px 8px rgba(248, 241, 234, 0.9);
+  transform: rotate(143deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box504 {
+  --cssB-v-504: 991176;
+  color: hsl(288, 52%, 58%);
+  background-color: hsl(108, 52%, 42%);
+  border: 5px solid hsl(18, 50%, 50%);
+  margin: 4px 12px 20px 0px;
+  padding: 9px 18px;
+  border-radius: 0px 0px;
+  box-shadow: 4px 0px 0px rgba(249, 243, 237, 0.1);
+  transform: rotate(144deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box505 {
+  --cssB-v-505: 999095;
+  color: hsl(325, 65%, 65%);
+  background-color: hsl(145, 65%, 35%);
+  border: 1px solid hsl(55, 50%, 50%);
+  margin: 5px 15px 0px 7px;
+  padding: 10px 20px;
+  border-radius: 1px 2px;
+  box-shadow: 0px 1px 1px rgba(250, 245, 240, 0.2);
+  transform: rotate(145deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box506 {
+  --cssB-v-506: 7014;
+  color: hsl(2, 78%, 72%);
+  background-color: hsl(182, 78%, 28%);
+  border: 2px solid hsl(92, 50%, 50%);
+  margin: 6px 18px 5px 14px;
+  padding: 11px 0px;
+  border-radius: 2px 4px;
+  box-shadow: 1px 2px 2px rgba(251, 247, 243, 0.3);
+  transform: rotate(146deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box507 {
+  --cssB-v-507: 14933;
+  color: hsl(39, 91%, 79%);
+  background-color: hsl(219, 91%, 21%);
+  border: 3px solid hsl(129, 50%, 50%);
+  margin: 7px 21px 10px 3px;
+  padding: 12px 2px;
+  border-radius: 3px 6px;
+  box-shadow: 2px 3px 3px rgba(252, 249, 246, 0.4);
+  transform: rotate(147deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box508 {
+  --cssB-v-508: 22852;
+  color: hsl(76, 4%, 36%);
+  background-color: hsl(256, 4%, 64%);
+  border: 4px solid hsl(166, 50%, 50%);
+  margin: 8px 24px 15px 10px;
+  padding: 13px 4px;
+  border-radius: 4px 8px;
+  box-shadow: 3px 4px 4px rgba(253, 251, 249, 0.5);
+  transform: rotate(148deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box509 {
+  --cssB-v-509: 30771;
+  color: hsl(113, 17%, 43%);
+  background-color: hsl(293, 17%, 57%);
+  border: 5px solid hsl(203, 50%, 50%);
+  margin: 9px 27px 20px 17px;
+  padding: 14px 6px;
+  border-radius: 5px 1px;
+  box-shadow: 4px 5px 5px rgba(254, 253, 252, 0.6);
+  transform: rotate(149deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box510 {
+  --cssB-v-510: 38690;
+  color: hsl(150, 30%, 50%);
+  background-color: hsl(330, 30%, 50%);
+  border: 1px solid hsl(240, 50%, 50%);
+  margin: 10px 0px 0px 6px;
+  padding: 0px 8px;
+  border-radius: 6px 3px;
+  box-shadow: 0px 6px 6px rgba(0, 0, 0, 0.7);
+  transform: rotate(150deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box511 {
+  --cssB-v-511: 46609;
+  color: hsl(187, 43%, 57%);
+  background-color: hsl(7, 43%, 43%);
+  border: 2px solid hsl(277, 50%, 50%);
+  margin: 11px 3px 5px 13px;
+  padding: 1px 10px;
+  border-radius: 7px 5px;
+  box-shadow: 1px 0px 7px rgba(1, 2, 3, 0.8);
+  transform: rotate(151deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box512 {
+  --cssB-v-512: 54528;
+  color: hsl(224, 56%, 64%);
+  background-color: hsl(44, 56%, 36%);
+  border: 3px solid hsl(314, 50%, 50%);
+  margin: 12px 6px 10px 2px;
+  padding: 2px 12px;
+  border-radius: 8px 7px;
+  box-shadow: 2px 1px 8px rgba(2, 4, 6, 0.9);
+  transform: rotate(152deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box513 {
+  --cssB-v-513: 62447;
+  color: hsl(261, 69%, 71%);
+  background-color: hsl(81, 69%, 29%);
+  border: 4px solid hsl(351, 50%, 50%);
+  margin: 13px 9px 15px 9px;
+  padding: 3px 14px;
+  border-radius: 9px 0px;
+  box-shadow: 3px 2px 0px rgba(3, 6, 9, 0.1);
+  transform: rotate(153deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box514 {
+  --cssB-v-514: 70366;
+  color: hsl(298, 82%, 78%);
+  background-color: hsl(118, 82%, 22%);
+  border: 5px solid hsl(28, 50%, 50%);
+  margin: 14px 12px 20px 16px;
+  padding: 4px 16px;
+  border-radius: 10px 2px;
+  box-shadow: 4px 3px 1px rgba(4, 8, 12, 0.2);
+  transform: rotate(154deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box515 {
+  --cssB-v-515: 78285;
+  color: hsl(335, 95%, 35%);
+  background-color: hsl(155, 95%, 65%);
+  border: 1px solid hsl(65, 50%, 50%);
+  margin: 15px 15px 0px 5px;
+  padding: 5px 18px;
+  border-radius: 11px 4px;
+  box-shadow: 0px 4px 2px rgba(5, 10, 15, 0.3);
+  transform: rotate(155deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box516 {
+  --cssB-v-516: 86204;
+  color: hsl(12, 8%, 42%);
+  background-color: hsl(192, 8%, 58%);
+  border: 2px solid hsl(102, 50%, 50%);
+  margin: 16px 18px 5px 12px;
+  padding: 6px 20px;
+  border-radius: 0px 6px;
+  box-shadow: 1px 5px 3px rgba(6, 12, 18, 0.4);
+  transform: rotate(156deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box517 {
+  --cssB-v-517: 94123;
+  color: hsl(49, 21%, 49%);
+  background-color: hsl(229, 21%, 51%);
+  border: 3px solid hsl(139, 50%, 50%);
+  margin: 17px 21px 10px 1px;
+  padding: 7px 0px;
+  border-radius: 1px 8px;
+  box-shadow: 2px 6px 4px rgba(7, 14, 21, 0.5);
+  transform: rotate(157deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box518 {
+  --cssB-v-518: 102042;
+  color: hsl(86, 34%, 56%);
+  background-color: hsl(266, 34%, 44%);
+  border: 4px solid hsl(176, 50%, 50%);
+  margin: 18px 24px 15px 8px;
+  padding: 8px 2px;
+  border-radius: 2px 1px;
+  box-shadow: 3px 0px 5px rgba(8, 16, 24, 0.6);
+  transform: rotate(158deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box519 {
+  --cssB-v-519: 109961;
+  color: hsl(123, 47%, 63%);
+  background-color: hsl(303, 47%, 37%);
+  border: 5px solid hsl(213, 50%, 50%);
+  margin: 19px 27px 20px 15px;
+  padding: 9px 4px;
+  border-radius: 3px 3px;
+  box-shadow: 4px 1px 6px rgba(9, 18, 27, 0.7);
+  transform: rotate(159deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box520 {
+  --cssB-v-520: 117880;
+  color: hsl(160, 60%, 70%);
+  background-color: hsl(340, 60%, 30%);
+  border: 1px solid hsl(250, 50%, 50%);
+  margin: 0px 0px 0px 4px;
+  padding: 10px 6px;
+  border-radius: 4px 5px;
+  box-shadow: 0px 2px 7px rgba(10, 20, 30, 0.8);
+  transform: rotate(160deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box521 {
+  --cssB-v-521: 125799;
+  color: hsl(197, 73%, 77%);
+  background-color: hsl(17, 73%, 23%);
+  border: 2px solid hsl(287, 50%, 50%);
+  margin: 1px 3px 5px 11px;
+  padding: 11px 8px;
+  border-radius: 5px 7px;
+  box-shadow: 1px 3px 8px rgba(11, 22, 33, 0.9);
+  transform: rotate(161deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box522 {
+  --cssB-v-522: 133718;
+  color: hsl(234, 86%, 34%);
+  background-color: hsl(54, 86%, 66%);
+  border: 3px solid hsl(324, 50%, 50%);
+  margin: 2px 6px 10px 0px;
+  padding: 12px 10px;
+  border-radius: 6px 0px;
+  box-shadow: 2px 4px 0px rgba(12, 24, 36, 0.1);
+  transform: rotate(162deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box523 {
+  --cssB-v-523: 141637;
+  color: hsl(271, 99%, 41%);
+  background-color: hsl(91, 99%, 59%);
+  border: 4px solid hsl(1, 50%, 50%);
+  margin: 3px 9px 15px 7px;
+  padding: 13px 12px;
+  border-radius: 7px 2px;
+  box-shadow: 3px 5px 1px rgba(13, 26, 39, 0.2);
+  transform: rotate(163deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box524 {
+  --cssB-v-524: 149556;
+  color: hsl(308, 12%, 48%);
+  background-color: hsl(128, 12%, 52%);
+  border: 5px solid hsl(38, 50%, 50%);
+  margin: 4px 12px 20px 14px;
+  padding: 14px 14px;
+  border-radius: 8px 4px;
+  box-shadow: 4px 6px 2px rgba(14, 28, 42, 0.3);
+  transform: rotate(164deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box525 {
+  --cssB-v-525: 157475;
+  color: hsl(345, 25%, 55%);
+  background-color: hsl(165, 25%, 45%);
+  border: 1px solid hsl(75, 50%, 50%);
+  margin: 5px 15px 0px 3px;
+  padding: 0px 16px;
+  border-radius: 9px 6px;
+  box-shadow: 0px 0px 3px rgba(15, 30, 45, 0.4);
+  transform: rotate(165deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box526 {
+  --cssB-v-526: 165394;
+  color: hsl(22, 38%, 62%);
+  background-color: hsl(202, 38%, 38%);
+  border: 2px solid hsl(112, 50%, 50%);
+  margin: 6px 18px 5px 10px;
+  padding: 1px 18px;
+  border-radius: 10px 8px;
+  box-shadow: 1px 1px 4px rgba(16, 32, 48, 0.5);
+  transform: rotate(166deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box527 {
+  --cssB-v-527: 173313;
+  color: hsl(59, 51%, 69%);
+  background-color: hsl(239, 51%, 31%);
+  border: 3px solid hsl(149, 50%, 50%);
+  margin: 7px 21px 10px 17px;
+  padding: 2px 20px;
+  border-radius: 11px 1px;
+  box-shadow: 2px 2px 5px rgba(17, 34, 51, 0.6);
+  transform: rotate(167deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box528 {
+  --cssB-v-528: 181232;
+  color: hsl(96, 64%, 76%);
+  background-color: hsl(276, 64%, 24%);
+  border: 4px solid hsl(186, 50%, 50%);
+  margin: 8px 24px 15px 6px;
+  padding: 3px 0px;
+  border-radius: 0px 3px;
+  box-shadow: 3px 3px 6px rgba(18, 36, 54, 0.7);
+  transform: rotate(168deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box529 {
+  --cssB-v-529: 189151;
+  color: hsl(133, 77%, 33%);
+  background-color: hsl(313, 77%, 67%);
+  border: 5px solid hsl(223, 50%, 50%);
+  margin: 9px 27px 20px 13px;
+  padding: 4px 2px;
+  border-radius: 1px 5px;
+  box-shadow: 4px 4px 7px rgba(19, 38, 57, 0.8);
+  transform: rotate(169deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box530 {
+  --cssB-v-530: 197070;
+  color: hsl(170, 90%, 40%);
+  background-color: hsl(350, 90%, 60%);
+  border: 1px solid hsl(260, 50%, 50%);
+  margin: 10px 0px 0px 2px;
+  padding: 5px 4px;
+  border-radius: 2px 7px;
+  box-shadow: 0px 5px 8px rgba(20, 40, 60, 0.9);
+  transform: rotate(170deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box531 {
+  --cssB-v-531: 204989;
+  color: hsl(207, 3%, 47%);
+  background-color: hsl(27, 3%, 53%);
+  border: 2px solid hsl(297, 50%, 50%);
+  margin: 11px 3px 5px 9px;
+  padding: 6px 6px;
+  border-radius: 3px 0px;
+  box-shadow: 1px 6px 0px rgba(21, 42, 63, 0.1);
+  transform: rotate(171deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box532 {
+  --cssB-v-532: 212908;
+  color: hsl(244, 16%, 54%);
+  background-color: hsl(64, 16%, 46%);
+  border: 3px solid hsl(334, 50%, 50%);
+  margin: 12px 6px 10px 16px;
+  padding: 7px 8px;
+  border-radius: 4px 2px;
+  box-shadow: 2px 0px 1px rgba(22, 44, 66, 0.2);
+  transform: rotate(172deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box533 {
+  --cssB-v-533: 220827;
+  color: hsl(281, 29%, 61%);
+  background-color: hsl(101, 29%, 39%);
+  border: 4px solid hsl(11, 50%, 50%);
+  margin: 13px 9px 15px 5px;
+  padding: 8px 10px;
+  border-radius: 5px 4px;
+  box-shadow: 3px 1px 2px rgba(23, 46, 69, 0.3);
+  transform: rotate(173deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box534 {
+  --cssB-v-534: 228746;
+  color: hsl(318, 42%, 68%);
+  background-color: hsl(138, 42%, 32%);
+  border: 5px solid hsl(48, 50%, 50%);
+  margin: 14px 12px 20px 12px;
+  padding: 9px 12px;
+  border-radius: 6px 6px;
+  box-shadow: 4px 2px 3px rgba(24, 48, 72, 0.4);
+  transform: rotate(174deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box535 {
+  --cssB-v-535: 236665;
+  color: hsl(355, 55%, 75%);
+  background-color: hsl(175, 55%, 25%);
+  border: 1px solid hsl(85, 50%, 50%);
+  margin: 15px 15px 0px 1px;
+  padding: 10px 14px;
+  border-radius: 7px 8px;
+  box-shadow: 0px 3px 4px rgba(25, 50, 75, 0.5);
+  transform: rotate(175deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box536 {
+  --cssB-v-536: 244584;
+  color: hsl(32, 68%, 32%);
+  background-color: hsl(212, 68%, 68%);
+  border: 2px solid hsl(122, 50%, 50%);
+  margin: 16px 18px 5px 8px;
+  padding: 11px 16px;
+  border-radius: 8px 1px;
+  box-shadow: 1px 4px 5px rgba(26, 52, 78, 0.6);
+  transform: rotate(176deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box537 {
+  --cssB-v-537: 252503;
+  color: hsl(69, 81%, 39%);
+  background-color: hsl(249, 81%, 61%);
+  border: 3px solid hsl(159, 50%, 50%);
+  margin: 17px 21px 10px 15px;
+  padding: 12px 18px;
+  border-radius: 9px 3px;
+  box-shadow: 2px 5px 6px rgba(27, 54, 81, 0.7);
+  transform: rotate(177deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box538 {
+  --cssB-v-538: 260422;
+  color: hsl(106, 94%, 46%);
+  background-color: hsl(286, 94%, 54%);
+  border: 4px solid hsl(196, 50%, 50%);
+  margin: 18px 24px 15px 4px;
+  padding: 13px 20px;
+  border-radius: 10px 5px;
+  box-shadow: 3px 6px 7px rgba(28, 56, 84, 0.8);
+  transform: rotate(178deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box539 {
+  --cssB-v-539: 268341;
+  color: hsl(143, 7%, 53%);
+  background-color: hsl(323, 7%, 47%);
+  border: 5px solid hsl(233, 50%, 50%);
+  margin: 19px 27px 20px 11px;
+  padding: 14px 0px;
+  border-radius: 11px 7px;
+  box-shadow: 4px 0px 8px rgba(29, 58, 87, 0.9);
+  transform: rotate(179deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box540 {
+  --cssB-v-540: 276260;
+  color: hsl(180, 20%, 60%);
+  background-color: hsl(0, 20%, 40%);
+  border: 1px solid hsl(270, 50%, 50%);
+  margin: 0px 0px 0px 0px;
+  padding: 0px 2px;
+  border-radius: 0px 0px;
+  box-shadow: 0px 1px 0px rgba(30, 60, 90, 0.1);
+  transform: rotate(180deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box541 {
+  --cssB-v-541: 284179;
+  color: hsl(217, 33%, 67%);
+  background-color: hsl(37, 33%, 33%);
+  border: 2px solid hsl(307, 50%, 50%);
+  margin: 1px 3px 5px 7px;
+  padding: 1px 4px;
+  border-radius: 1px 2px;
+  box-shadow: 1px 2px 1px rgba(31, 62, 93, 0.2);
+  transform: rotate(181deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box542 {
+  --cssB-v-542: 292098;
+  color: hsl(254, 46%, 74%);
+  background-color: hsl(74, 46%, 26%);
+  border: 3px solid hsl(344, 50%, 50%);
+  margin: 2px 6px 10px 14px;
+  padding: 2px 6px;
+  border-radius: 2px 4px;
+  box-shadow: 2px 3px 2px rgba(32, 64, 96, 0.3);
+  transform: rotate(182deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box543 {
+  --cssB-v-543: 300017;
+  color: hsl(291, 59%, 31%);
+  background-color: hsl(111, 59%, 69%);
+  border: 4px solid hsl(21, 50%, 50%);
+  margin: 3px 9px 15px 3px;
+  padding: 3px 8px;
+  border-radius: 3px 6px;
+  box-shadow: 3px 4px 3px rgba(33, 66, 99, 0.4);
+  transform: rotate(183deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box544 {
+  --cssB-v-544: 307936;
+  color: hsl(328, 72%, 38%);
+  background-color: hsl(148, 72%, 62%);
+  border: 5px solid hsl(58, 50%, 50%);
+  margin: 4px 12px 20px 10px;
+  padding: 4px 10px;
+  border-radius: 4px 8px;
+  box-shadow: 4px 5px 4px rgba(34, 68, 102, 0.5);
+  transform: rotate(184deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box545 {
+  --cssB-v-545: 315855;
+  color: hsl(5, 85%, 45%);
+  background-color: hsl(185, 85%, 55%);
+  border: 1px solid hsl(95, 50%, 50%);
+  margin: 5px 15px 0px 17px;
+  padding: 5px 12px;
+  border-radius: 5px 1px;
+  box-shadow: 0px 6px 5px rgba(35, 70, 105, 0.6);
+  transform: rotate(185deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box546 {
+  --cssB-v-546: 323774;
+  color: hsl(42, 98%, 52%);
+  background-color: hsl(222, 98%, 48%);
+  border: 2px solid hsl(132, 50%, 50%);
+  margin: 6px 18px 5px 6px;
+  padding: 6px 14px;
+  border-radius: 6px 3px;
+  box-shadow: 1px 0px 6px rgba(36, 72, 108, 0.7);
+  transform: rotate(186deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box547 {
+  --cssB-v-547: 331693;
+  color: hsl(79, 11%, 59%);
+  background-color: hsl(259, 11%, 41%);
+  border: 3px solid hsl(169, 50%, 50%);
+  margin: 7px 21px 10px 13px;
+  padding: 7px 16px;
+  border-radius: 7px 5px;
+  box-shadow: 2px 1px 7px rgba(37, 74, 111, 0.8);
+  transform: rotate(187deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box548 {
+  --cssB-v-548: 339612;
+  color: hsl(116, 24%, 66%);
+  background-color: hsl(296, 24%, 34%);
+  border: 4px solid hsl(206, 50%, 50%);
+  margin: 8px 24px 15px 2px;
+  padding: 8px 18px;
+  border-radius: 8px 7px;
+  box-shadow: 3px 2px 8px rgba(38, 76, 114, 0.9);
+  transform: rotate(188deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box549 {
+  --cssB-v-549: 347531;
+  color: hsl(153, 37%, 73%);
+  background-color: hsl(333, 37%, 27%);
+  border: 5px solid hsl(243, 50%, 50%);
+  margin: 9px 27px 20px 9px;
+  padding: 9px 20px;
+  border-radius: 9px 0px;
+  box-shadow: 4px 3px 0px rgba(39, 78, 117, 0.1);
+  transform: rotate(189deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box550 {
+  --cssB-v-550: 355450;
+  color: hsl(190, 50%, 30%);
+  background-color: hsl(10, 50%, 70%);
+  border: 1px solid hsl(280, 50%, 50%);
+  margin: 10px 0px 0px 16px;
+  padding: 10px 0px;
+  border-radius: 10px 2px;
+  box-shadow: 0px 4px 1px rgba(40, 80, 120, 0.2);
+  transform: rotate(190deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box551 {
+  --cssB-v-551: 363369;
+  color: hsl(227, 63%, 37%);
+  background-color: hsl(47, 63%, 63%);
+  border: 2px solid hsl(317, 50%, 50%);
+  margin: 11px 3px 5px 5px;
+  padding: 11px 2px;
+  border-radius: 11px 4px;
+  box-shadow: 1px 5px 2px rgba(41, 82, 123, 0.3);
+  transform: rotate(191deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box552 {
+  --cssB-v-552: 371288;
+  color: hsl(264, 76%, 44%);
+  background-color: hsl(84, 76%, 56%);
+  border: 3px solid hsl(354, 50%, 50%);
+  margin: 12px 6px 10px 12px;
+  padding: 12px 4px;
+  border-radius: 0px 6px;
+  box-shadow: 2px 6px 3px rgba(42, 84, 126, 0.4);
+  transform: rotate(192deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box553 {
+  --cssB-v-553: 379207;
+  color: hsl(301, 89%, 51%);
+  background-color: hsl(121, 89%, 49%);
+  border: 4px solid hsl(31, 50%, 50%);
+  margin: 13px 9px 15px 1px;
+  padding: 13px 6px;
+  border-radius: 1px 8px;
+  box-shadow: 3px 0px 4px rgba(43, 86, 129, 0.5);
+  transform: rotate(193deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box554 {
+  --cssB-v-554: 387126;
+  color: hsl(338, 2%, 58%);
+  background-color: hsl(158, 2%, 42%);
+  border: 5px solid hsl(68, 50%, 50%);
+  margin: 14px 12px 20px 8px;
+  padding: 14px 8px;
+  border-radius: 2px 1px;
+  box-shadow: 4px 1px 5px rgba(44, 88, 132, 0.6);
+  transform: rotate(194deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box555 {
+  --cssB-v-555: 395045;
+  color: hsl(15, 15%, 65%);
+  background-color: hsl(195, 15%, 35%);
+  border: 1px solid hsl(105, 50%, 50%);
+  margin: 15px 15px 0px 15px;
+  padding: 0px 10px;
+  border-radius: 3px 3px;
+  box-shadow: 0px 2px 6px rgba(45, 90, 135, 0.7);
+  transform: rotate(195deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box556 {
+  --cssB-v-556: 402964;
+  color: hsl(52, 28%, 72%);
+  background-color: hsl(232, 28%, 28%);
+  border: 2px solid hsl(142, 50%, 50%);
+  margin: 16px 18px 5px 4px;
+  padding: 1px 12px;
+  border-radius: 4px 5px;
+  box-shadow: 1px 3px 7px rgba(46, 92, 138, 0.8);
+  transform: rotate(196deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box557 {
+  --cssB-v-557: 410883;
+  color: hsl(89, 41%, 79%);
+  background-color: hsl(269, 41%, 21%);
+  border: 3px solid hsl(179, 50%, 50%);
+  margin: 17px 21px 10px 11px;
+  padding: 2px 14px;
+  border-radius: 5px 7px;
+  box-shadow: 2px 4px 8px rgba(47, 94, 141, 0.9);
+  transform: rotate(197deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box558 {
+  --cssB-v-558: 418802;
+  color: hsl(126, 54%, 36%);
+  background-color: hsl(306, 54%, 64%);
+  border: 4px solid hsl(216, 50%, 50%);
+  margin: 18px 24px 15px 0px;
+  padding: 3px 16px;
+  border-radius: 6px 0px;
+  box-shadow: 3px 5px 0px rgba(48, 96, 144, 0.1);
+  transform: rotate(198deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box559 {
+  --cssB-v-559: 426721;
+  color: hsl(163, 67%, 43%);
+  background-color: hsl(343, 67%, 57%);
+  border: 5px solid hsl(253, 50%, 50%);
+  margin: 19px 27px 20px 7px;
+  padding: 4px 18px;
+  border-radius: 7px 2px;
+  box-shadow: 4px 6px 1px rgba(49, 98, 147, 0.2);
+  transform: rotate(199deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box560 {
+  --cssB-v-560: 434640;
+  color: hsl(200, 80%, 50%);
+  background-color: hsl(20, 80%, 50%);
+  border: 1px solid hsl(290, 50%, 50%);
+  margin: 0px 0px 0px 14px;
+  padding: 5px 20px;
+  border-radius: 8px 4px;
+  box-shadow: 0px 0px 2px rgba(50, 100, 150, 0.3);
+  transform: rotate(200deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box561 {
+  --cssB-v-561: 442559;
+  color: hsl(237, 93%, 57%);
+  background-color: hsl(57, 93%, 43%);
+  border: 2px solid hsl(327, 50%, 50%);
+  margin: 1px 3px 5px 3px;
+  padding: 6px 0px;
+  border-radius: 9px 6px;
+  box-shadow: 1px 1px 3px rgba(51, 102, 153, 0.4);
+  transform: rotate(201deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box562 {
+  --cssB-v-562: 450478;
+  color: hsl(274, 6%, 64%);
+  background-color: hsl(94, 6%, 36%);
+  border: 3px solid hsl(4, 50%, 50%);
+  margin: 2px 6px 10px 10px;
+  padding: 7px 2px;
+  border-radius: 10px 8px;
+  box-shadow: 2px 2px 4px rgba(52, 104, 156, 0.5);
+  transform: rotate(202deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box563 {
+  --cssB-v-563: 458397;
+  color: hsl(311, 19%, 71%);
+  background-color: hsl(131, 19%, 29%);
+  border: 4px solid hsl(41, 50%, 50%);
+  margin: 3px 9px 15px 17px;
+  padding: 8px 4px;
+  border-radius: 11px 1px;
+  box-shadow: 3px 3px 5px rgba(53, 106, 159, 0.6);
+  transform: rotate(203deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box564 {
+  --cssB-v-564: 466316;
+  color: hsl(348, 32%, 78%);
+  background-color: hsl(168, 32%, 22%);
+  border: 5px solid hsl(78, 50%, 50%);
+  margin: 4px 12px 20px 6px;
+  padding: 9px 6px;
+  border-radius: 0px 3px;
+  box-shadow: 4px 4px 6px rgba(54, 108, 162, 0.7);
+  transform: rotate(204deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box565 {
+  --cssB-v-565: 474235;
+  color: hsl(25, 45%, 35%);
+  background-color: hsl(205, 45%, 65%);
+  border: 1px solid hsl(115, 50%, 50%);
+  margin: 5px 15px 0px 13px;
+  padding: 10px 8px;
+  border-radius: 1px 5px;
+  box-shadow: 0px 5px 7px rgba(55, 110, 165, 0.8);
+  transform: rotate(205deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box566 {
+  --cssB-v-566: 482154;
+  color: hsl(62, 58%, 42%);
+  background-color: hsl(242, 58%, 58%);
+  border: 2px solid hsl(152, 50%, 50%);
+  margin: 6px 18px 5px 2px;
+  padding: 11px 10px;
+  border-radius: 2px 7px;
+  box-shadow: 1px 6px 8px rgba(56, 112, 168, 0.9);
+  transform: rotate(206deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box567 {
+  --cssB-v-567: 490073;
+  color: hsl(99, 71%, 49%);
+  background-color: hsl(279, 71%, 51%);
+  border: 3px solid hsl(189, 50%, 50%);
+  margin: 7px 21px 10px 9px;
+  padding: 12px 12px;
+  border-radius: 3px 0px;
+  box-shadow: 2px 0px 0px rgba(57, 114, 171, 0.1);
+  transform: rotate(207deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box568 {
+  --cssB-v-568: 497992;
+  color: hsl(136, 84%, 56%);
+  background-color: hsl(316, 84%, 44%);
+  border: 4px solid hsl(226, 50%, 50%);
+  margin: 8px 24px 15px 16px;
+  padding: 13px 14px;
+  border-radius: 4px 2px;
+  box-shadow: 3px 1px 1px rgba(58, 116, 174, 0.2);
+  transform: rotate(208deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box569 {
+  --cssB-v-569: 505911;
+  color: hsl(173, 97%, 63%);
+  background-color: hsl(353, 97%, 37%);
+  border: 5px solid hsl(263, 50%, 50%);
+  margin: 9px 27px 20px 5px;
+  padding: 14px 16px;
+  border-radius: 5px 4px;
+  box-shadow: 4px 2px 2px rgba(59, 118, 177, 0.3);
+  transform: rotate(209deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box570 {
+  --cssB-v-570: 513830;
+  color: hsl(210, 10%, 70%);
+  background-color: hsl(30, 10%, 30%);
+  border: 1px solid hsl(300, 50%, 50%);
+  margin: 10px 0px 0px 12px;
+  padding: 0px 18px;
+  border-radius: 6px 6px;
+  box-shadow: 0px 3px 3px rgba(60, 120, 180, 0.4);
+  transform: rotate(210deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box571 {
+  --cssB-v-571: 521749;
+  color: hsl(247, 23%, 77%);
+  background-color: hsl(67, 23%, 23%);
+  border: 2px solid hsl(337, 50%, 50%);
+  margin: 11px 3px 5px 1px;
+  padding: 1px 20px;
+  border-radius: 7px 8px;
+  box-shadow: 1px 4px 4px rgba(61, 122, 183, 0.5);
+  transform: rotate(211deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box572 {
+  --cssB-v-572: 529668;
+  color: hsl(284, 36%, 34%);
+  background-color: hsl(104, 36%, 66%);
+  border: 3px solid hsl(14, 50%, 50%);
+  margin: 12px 6px 10px 8px;
+  padding: 2px 0px;
+  border-radius: 8px 1px;
+  box-shadow: 2px 5px 5px rgba(62, 124, 186, 0.6);
+  transform: rotate(212deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box573 {
+  --cssB-v-573: 537587;
+  color: hsl(321, 49%, 41%);
+  background-color: hsl(141, 49%, 59%);
+  border: 4px solid hsl(51, 50%, 50%);
+  margin: 13px 9px 15px 15px;
+  padding: 3px 2px;
+  border-radius: 9px 3px;
+  box-shadow: 3px 6px 6px rgba(63, 126, 189, 0.7);
+  transform: rotate(213deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box574 {
+  --cssB-v-574: 545506;
+  color: hsl(358, 62%, 48%);
+  background-color: hsl(178, 62%, 52%);
+  border: 5px solid hsl(88, 50%, 50%);
+  margin: 14px 12px 20px 4px;
+  padding: 4px 4px;
+  border-radius: 10px 5px;
+  box-shadow: 4px 0px 7px rgba(64, 128, 192, 0.8);
+  transform: rotate(214deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box575 {
+  --cssB-v-575: 553425;
+  color: hsl(35, 75%, 55%);
+  background-color: hsl(215, 75%, 45%);
+  border: 1px solid hsl(125, 50%, 50%);
+  margin: 15px 15px 0px 11px;
+  padding: 5px 6px;
+  border-radius: 11px 7px;
+  box-shadow: 0px 1px 8px rgba(65, 130, 195, 0.9);
+  transform: rotate(215deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box576 {
+  --cssB-v-576: 561344;
+  color: hsl(72, 88%, 62%);
+  background-color: hsl(252, 88%, 38%);
+  border: 2px solid hsl(162, 50%, 50%);
+  margin: 16px 18px 5px 0px;
+  padding: 6px 8px;
+  border-radius: 0px 0px;
+  box-shadow: 1px 2px 0px rgba(66, 132, 198, 0.1);
+  transform: rotate(216deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box577 {
+  --cssB-v-577: 569263;
+  color: hsl(109, 1%, 69%);
+  background-color: hsl(289, 1%, 31%);
+  border: 3px solid hsl(199, 50%, 50%);
+  margin: 17px 21px 10px 7px;
+  padding: 7px 10px;
+  border-radius: 1px 2px;
+  box-shadow: 2px 3px 1px rgba(67, 134, 201, 0.2);
+  transform: rotate(217deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box578 {
+  --cssB-v-578: 577182;
+  color: hsl(146, 14%, 76%);
+  background-color: hsl(326, 14%, 24%);
+  border: 4px solid hsl(236, 50%, 50%);
+  margin: 18px 24px 15px 14px;
+  padding: 8px 12px;
+  border-radius: 2px 4px;
+  box-shadow: 3px 4px 2px rgba(68, 136, 204, 0.3);
+  transform: rotate(218deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box579 {
+  --cssB-v-579: 585101;
+  color: hsl(183, 27%, 33%);
+  background-color: hsl(3, 27%, 67%);
+  border: 5px solid hsl(273, 50%, 50%);
+  margin: 19px 27px 20px 3px;
+  padding: 9px 14px;
+  border-radius: 3px 6px;
+  box-shadow: 4px 5px 3px rgba(69, 138, 207, 0.4);
+  transform: rotate(219deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box580 {
+  --cssB-v-580: 593020;
+  color: hsl(220, 40%, 40%);
+  background-color: hsl(40, 40%, 60%);
+  border: 1px solid hsl(310, 50%, 50%);
+  margin: 0px 0px 0px 10px;
+  padding: 10px 16px;
+  border-radius: 4px 8px;
+  box-shadow: 0px 6px 4px rgba(70, 140, 210, 0.5);
+  transform: rotate(220deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box581 {
+  --cssB-v-581: 600939;
+  color: hsl(257, 53%, 47%);
+  background-color: hsl(77, 53%, 53%);
+  border: 2px solid hsl(347, 50%, 50%);
+  margin: 1px 3px 5px 17px;
+  padding: 11px 18px;
+  border-radius: 5px 1px;
+  box-shadow: 1px 0px 5px rgba(71, 142, 213, 0.6);
+  transform: rotate(221deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box582 {
+  --cssB-v-582: 608858;
+  color: hsl(294, 66%, 54%);
+  background-color: hsl(114, 66%, 46%);
+  border: 3px solid hsl(24, 50%, 50%);
+  margin: 2px 6px 10px 6px;
+  padding: 12px 20px;
+  border-radius: 6px 3px;
+  box-shadow: 2px 1px 6px rgba(72, 144, 216, 0.7);
+  transform: rotate(222deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box583 {
+  --cssB-v-583: 616777;
+  color: hsl(331, 79%, 61%);
+  background-color: hsl(151, 79%, 39%);
+  border: 4px solid hsl(61, 50%, 50%);
+  margin: 3px 9px 15px 13px;
+  padding: 13px 0px;
+  border-radius: 7px 5px;
+  box-shadow: 3px 2px 7px rgba(73, 146, 219, 0.8);
+  transform: rotate(223deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box584 {
+  --cssB-v-584: 624696;
+  color: hsl(8, 92%, 68%);
+  background-color: hsl(188, 92%, 32%);
+  border: 5px solid hsl(98, 50%, 50%);
+  margin: 4px 12px 20px 2px;
+  padding: 14px 2px;
+  border-radius: 8px 7px;
+  box-shadow: 4px 3px 8px rgba(74, 148, 222, 0.9);
+  transform: rotate(224deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box585 {
+  --cssB-v-585: 632615;
+  color: hsl(45, 5%, 75%);
+  background-color: hsl(225, 5%, 25%);
+  border: 1px solid hsl(135, 50%, 50%);
+  margin: 5px 15px 0px 9px;
+  padding: 0px 4px;
+  border-radius: 9px 0px;
+  box-shadow: 0px 4px 0px rgba(75, 150, 225, 0.1);
+  transform: rotate(225deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box586 {
+  --cssB-v-586: 640534;
+  color: hsl(82, 18%, 32%);
+  background-color: hsl(262, 18%, 68%);
+  border: 2px solid hsl(172, 50%, 50%);
+  margin: 6px 18px 5px 16px;
+  padding: 1px 6px;
+  border-radius: 10px 2px;
+  box-shadow: 1px 5px 1px rgba(76, 152, 228, 0.2);
+  transform: rotate(226deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box587 {
+  --cssB-v-587: 648453;
+  color: hsl(119, 31%, 39%);
+  background-color: hsl(299, 31%, 61%);
+  border: 3px solid hsl(209, 50%, 50%);
+  margin: 7px 21px 10px 5px;
+  padding: 2px 8px;
+  border-radius: 11px 4px;
+  box-shadow: 2px 6px 2px rgba(77, 154, 231, 0.3);
+  transform: rotate(227deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box588 {
+  --cssB-v-588: 656372;
+  color: hsl(156, 44%, 46%);
+  background-color: hsl(336, 44%, 54%);
+  border: 4px solid hsl(246, 50%, 50%);
+  margin: 8px 24px 15px 12px;
+  padding: 3px 10px;
+  border-radius: 0px 6px;
+  box-shadow: 3px 0px 3px rgba(78, 156, 234, 0.4);
+  transform: rotate(228deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box589 {
+  --cssB-v-589: 664291;
+  color: hsl(193, 57%, 53%);
+  background-color: hsl(13, 57%, 47%);
+  border: 5px solid hsl(283, 50%, 50%);
+  margin: 9px 27px 20px 1px;
+  padding: 4px 12px;
+  border-radius: 1px 8px;
+  box-shadow: 4px 1px 4px rgba(79, 158, 237, 0.5);
+  transform: rotate(229deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box590 {
+  --cssB-v-590: 672210;
+  color: hsl(230, 70%, 60%);
+  background-color: hsl(50, 70%, 40%);
+  border: 1px solid hsl(320, 50%, 50%);
+  margin: 10px 0px 0px 8px;
+  padding: 5px 14px;
+  border-radius: 2px 1px;
+  box-shadow: 0px 2px 5px rgba(80, 160, 240, 0.6);
+  transform: rotate(230deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box591 {
+  --cssB-v-591: 680129;
+  color: hsl(267, 83%, 67%);
+  background-color: hsl(87, 83%, 33%);
+  border: 2px solid hsl(357, 50%, 50%);
+  margin: 11px 3px 5px 15px;
+  padding: 6px 16px;
+  border-radius: 3px 3px;
+  box-shadow: 1px 3px 6px rgba(81, 162, 243, 0.7);
+  transform: rotate(231deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box592 {
+  --cssB-v-592: 688048;
+  color: hsl(304, 96%, 74%);
+  background-color: hsl(124, 96%, 26%);
+  border: 3px solid hsl(34, 50%, 50%);
+  margin: 12px 6px 10px 4px;
+  padding: 7px 18px;
+  border-radius: 4px 5px;
+  box-shadow: 2px 4px 7px rgba(82, 164, 246, 0.8);
+  transform: rotate(232deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box593 {
+  --cssB-v-593: 695967;
+  color: hsl(341, 9%, 31%);
+  background-color: hsl(161, 9%, 69%);
+  border: 4px solid hsl(71, 50%, 50%);
+  margin: 13px 9px 15px 11px;
+  padding: 8px 20px;
+  border-radius: 5px 7px;
+  box-shadow: 3px 5px 8px rgba(83, 166, 249, 0.9);
+  transform: rotate(233deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box594 {
+  --cssB-v-594: 703886;
+  color: hsl(18, 22%, 38%);
+  background-color: hsl(198, 22%, 62%);
+  border: 5px solid hsl(108, 50%, 50%);
+  margin: 14px 12px 20px 0px;
+  padding: 9px 0px;
+  border-radius: 6px 0px;
+  box-shadow: 4px 6px 0px rgba(84, 168, 252, 0.1);
+  transform: rotate(234deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box595 {
+  --cssB-v-595: 711805;
+  color: hsl(55, 35%, 45%);
+  background-color: hsl(235, 35%, 55%);
+  border: 1px solid hsl(145, 50%, 50%);
+  margin: 15px 15px 0px 7px;
+  padding: 10px 2px;
+  border-radius: 7px 2px;
+  box-shadow: 0px 0px 1px rgba(85, 170, 0, 0.2);
+  transform: rotate(235deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box596 {
+  --cssB-v-596: 719724;
+  color: hsl(92, 48%, 52%);
+  background-color: hsl(272, 48%, 48%);
+  border: 2px solid hsl(182, 50%, 50%);
+  margin: 16px 18px 5px 14px;
+  padding: 11px 4px;
+  border-radius: 8px 4px;
+  box-shadow: 1px 1px 2px rgba(86, 172, 3, 0.3);
+  transform: rotate(236deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box597 {
+  --cssB-v-597: 727643;
+  color: hsl(129, 61%, 59%);
+  background-color: hsl(309, 61%, 41%);
+  border: 3px solid hsl(219, 50%, 50%);
+  margin: 17px 21px 10px 3px;
+  padding: 12px 6px;
+  border-radius: 9px 6px;
+  box-shadow: 2px 2px 3px rgba(87, 174, 6, 0.4);
+  transform: rotate(237deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box598 {
+  --cssB-v-598: 735562;
+  color: hsl(166, 74%, 66%);
+  background-color: hsl(346, 74%, 34%);
+  border: 4px solid hsl(256, 50%, 50%);
+  margin: 18px 24px 15px 10px;
+  padding: 13px 8px;
+  border-radius: 10px 8px;
+  box-shadow: 3px 3px 4px rgba(88, 176, 9, 0.5);
+  transform: rotate(238deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box599 {
+  --cssB-v-599: 743481;
+  color: hsl(203, 87%, 73%);
+  background-color: hsl(23, 87%, 27%);
+  border: 5px solid hsl(293, 50%, 50%);
+  margin: 19px 27px 20px 17px;
+  padding: 14px 10px;
+  border-radius: 11px 1px;
+  box-shadow: 4px 4px 5px rgba(89, 178, 12, 0.6);
+  transform: rotate(239deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box600 {
+  --cssB-v-600: 751400;
+  color: hsl(240, 0%, 30%);
+  background-color: hsl(60, 0%, 70%);
+  border: 1px solid hsl(330, 50%, 50%);
+  margin: 0px 0px 0px 6px;
+  padding: 0px 12px;
+  border-radius: 0px 3px;
+  box-shadow: 0px 5px 6px rgba(90, 180, 15, 0.7);
+  transform: rotate(240deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box601 {
+  --cssB-v-601: 759319;
+  color: hsl(277, 13%, 37%);
+  background-color: hsl(97, 13%, 63%);
+  border: 2px solid hsl(7, 50%, 50%);
+  margin: 1px 3px 5px 13px;
+  padding: 1px 14px;
+  border-radius: 1px 5px;
+  box-shadow: 1px 6px 7px rgba(91, 182, 18, 0.8);
+  transform: rotate(241deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box602 {
+  --cssB-v-602: 767238;
+  color: hsl(314, 26%, 44%);
+  background-color: hsl(134, 26%, 56%);
+  border: 3px solid hsl(44, 50%, 50%);
+  margin: 2px 6px 10px 2px;
+  padding: 2px 16px;
+  border-radius: 2px 7px;
+  box-shadow: 2px 0px 8px rgba(92, 184, 21, 0.9);
+  transform: rotate(242deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box603 {
+  --cssB-v-603: 775157;
+  color: hsl(351, 39%, 51%);
+  background-color: hsl(171, 39%, 49%);
+  border: 4px solid hsl(81, 50%, 50%);
+  margin: 3px 9px 15px 9px;
+  padding: 3px 18px;
+  border-radius: 3px 0px;
+  box-shadow: 3px 1px 0px rgba(93, 186, 24, 0.1);
+  transform: rotate(243deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box604 {
+  --cssB-v-604: 783076;
+  color: hsl(28, 52%, 58%);
+  background-color: hsl(208, 52%, 42%);
+  border: 5px solid hsl(118, 50%, 50%);
+  margin: 4px 12px 20px 16px;
+  padding: 4px 20px;
+  border-radius: 4px 2px;
+  box-shadow: 4px 2px 1px rgba(94, 188, 27, 0.2);
+  transform: rotate(244deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box605 {
+  --cssB-v-605: 790995;
+  color: hsl(65, 65%, 65%);
+  background-color: hsl(245, 65%, 35%);
+  border: 1px solid hsl(155, 50%, 50%);
+  margin: 5px 15px 0px 5px;
+  padding: 5px 0px;
+  border-radius: 5px 4px;
+  box-shadow: 0px 3px 2px rgba(95, 190, 30, 0.3);
+  transform: rotate(245deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box606 {
+  --cssB-v-606: 798914;
+  color: hsl(102, 78%, 72%);
+  background-color: hsl(282, 78%, 28%);
+  border: 2px solid hsl(192, 50%, 50%);
+  margin: 6px 18px 5px 12px;
+  padding: 6px 2px;
+  border-radius: 6px 6px;
+  box-shadow: 1px 4px 3px rgba(96, 192, 33, 0.4);
+  transform: rotate(246deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box607 {
+  --cssB-v-607: 806833;
+  color: hsl(139, 91%, 79%);
+  background-color: hsl(319, 91%, 21%);
+  border: 3px solid hsl(229, 50%, 50%);
+  margin: 7px 21px 10px 1px;
+  padding: 7px 4px;
+  border-radius: 7px 8px;
+  box-shadow: 2px 5px 4px rgba(97, 194, 36, 0.5);
+  transform: rotate(247deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box608 {
+  --cssB-v-608: 814752;
+  color: hsl(176, 4%, 36%);
+  background-color: hsl(356, 4%, 64%);
+  border: 4px solid hsl(266, 50%, 50%);
+  margin: 8px 24px 15px 8px;
+  padding: 8px 6px;
+  border-radius: 8px 1px;
+  box-shadow: 3px 6px 5px rgba(98, 196, 39, 0.6);
+  transform: rotate(248deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box609 {
+  --cssB-v-609: 822671;
+  color: hsl(213, 17%, 43%);
+  background-color: hsl(33, 17%, 57%);
+  border: 5px solid hsl(303, 50%, 50%);
+  margin: 9px 27px 20px 15px;
+  padding: 9px 8px;
+  border-radius: 9px 3px;
+  box-shadow: 4px 0px 6px rgba(99, 198, 42, 0.7);
+  transform: rotate(249deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box610 {
+  --cssB-v-610: 830590;
+  color: hsl(250, 30%, 50%);
+  background-color: hsl(70, 30%, 50%);
+  border: 1px solid hsl(340, 50%, 50%);
+  margin: 10px 0px 0px 4px;
+  padding: 10px 10px;
+  border-radius: 10px 5px;
+  box-shadow: 0px 1px 7px rgba(100, 200, 45, 0.8);
+  transform: rotate(250deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box611 {
+  --cssB-v-611: 838509;
+  color: hsl(287, 43%, 57%);
+  background-color: hsl(107, 43%, 43%);
+  border: 2px solid hsl(17, 50%, 50%);
+  margin: 11px 3px 5px 11px;
+  padding: 11px 12px;
+  border-radius: 11px 7px;
+  box-shadow: 1px 2px 8px rgba(101, 202, 48, 0.9);
+  transform: rotate(251deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box612 {
+  --cssB-v-612: 846428;
+  color: hsl(324, 56%, 64%);
+  background-color: hsl(144, 56%, 36%);
+  border: 3px solid hsl(54, 50%, 50%);
+  margin: 12px 6px 10px 0px;
+  padding: 12px 14px;
+  border-radius: 0px 0px;
+  box-shadow: 2px 3px 0px rgba(102, 204, 51, 0.1);
+  transform: rotate(252deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box613 {
+  --cssB-v-613: 854347;
+  color: hsl(1, 69%, 71%);
+  background-color: hsl(181, 69%, 29%);
+  border: 4px solid hsl(91, 50%, 50%);
+  margin: 13px 9px 15px 7px;
+  padding: 13px 16px;
+  border-radius: 1px 2px;
+  box-shadow: 3px 4px 1px rgba(103, 206, 54, 0.2);
+  transform: rotate(253deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box614 {
+  --cssB-v-614: 862266;
+  color: hsl(38, 82%, 78%);
+  background-color: hsl(218, 82%, 22%);
+  border: 5px solid hsl(128, 50%, 50%);
+  margin: 14px 12px 20px 14px;
+  padding: 14px 18px;
+  border-radius: 2px 4px;
+  box-shadow: 4px 5px 2px rgba(104, 208, 57, 0.3);
+  transform: rotate(254deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box615 {
+  --cssB-v-615: 870185;
+  color: hsl(75, 95%, 35%);
+  background-color: hsl(255, 95%, 65%);
+  border: 1px solid hsl(165, 50%, 50%);
+  margin: 15px 15px 0px 3px;
+  padding: 0px 20px;
+  border-radius: 3px 6px;
+  box-shadow: 0px 6px 3px rgba(105, 210, 60, 0.4);
+  transform: rotate(255deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box616 {
+  --cssB-v-616: 878104;
+  color: hsl(112, 8%, 42%);
+  background-color: hsl(292, 8%, 58%);
+  border: 2px solid hsl(202, 50%, 50%);
+  margin: 16px 18px 5px 10px;
+  padding: 1px 0px;
+  border-radius: 4px 8px;
+  box-shadow: 1px 0px 4px rgba(106, 212, 63, 0.5);
+  transform: rotate(256deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box617 {
+  --cssB-v-617: 886023;
+  color: hsl(149, 21%, 49%);
+  background-color: hsl(329, 21%, 51%);
+  border: 3px solid hsl(239, 50%, 50%);
+  margin: 17px 21px 10px 17px;
+  padding: 2px 2px;
+  border-radius: 5px 1px;
+  box-shadow: 2px 1px 5px rgba(107, 214, 66, 0.6);
+  transform: rotate(257deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box618 {
+  --cssB-v-618: 893942;
+  color: hsl(186, 34%, 56%);
+  background-color: hsl(6, 34%, 44%);
+  border: 4px solid hsl(276, 50%, 50%);
+  margin: 18px 24px 15px 6px;
+  padding: 3px 4px;
+  border-radius: 6px 3px;
+  box-shadow: 3px 2px 6px rgba(108, 216, 69, 0.7);
+  transform: rotate(258deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box619 {
+  --cssB-v-619: 901861;
+  color: hsl(223, 47%, 63%);
+  background-color: hsl(43, 47%, 37%);
+  border: 5px solid hsl(313, 50%, 50%);
+  margin: 19px 27px 20px 13px;
+  padding: 4px 6px;
+  border-radius: 7px 5px;
+  box-shadow: 4px 3px 7px rgba(109, 218, 72, 0.8);
+  transform: rotate(259deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box620 {
+  --cssB-v-620: 909780;
+  color: hsl(260, 60%, 70%);
+  background-color: hsl(80, 60%, 30%);
+  border: 1px solid hsl(350, 50%, 50%);
+  margin: 0px 0px 0px 2px;
+  padding: 5px 8px;
+  border-radius: 8px 7px;
+  box-shadow: 0px 4px 8px rgba(110, 220, 75, 0.9);
+  transform: rotate(260deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box621 {
+  --cssB-v-621: 917699;
+  color: hsl(297, 73%, 77%);
+  background-color: hsl(117, 73%, 23%);
+  border: 2px solid hsl(27, 50%, 50%);
+  margin: 1px 3px 5px 9px;
+  padding: 6px 10px;
+  border-radius: 9px 0px;
+  box-shadow: 1px 5px 0px rgba(111, 222, 78, 0.1);
+  transform: rotate(261deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box622 {
+  --cssB-v-622: 925618;
+  color: hsl(334, 86%, 34%);
+  background-color: hsl(154, 86%, 66%);
+  border: 3px solid hsl(64, 50%, 50%);
+  margin: 2px 6px 10px 16px;
+  padding: 7px 12px;
+  border-radius: 10px 2px;
+  box-shadow: 2px 6px 1px rgba(112, 224, 81, 0.2);
+  transform: rotate(262deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box623 {
+  --cssB-v-623: 933537;
+  color: hsl(11, 99%, 41%);
+  background-color: hsl(191, 99%, 59%);
+  border: 4px solid hsl(101, 50%, 50%);
+  margin: 3px 9px 15px 5px;
+  padding: 8px 14px;
+  border-radius: 11px 4px;
+  box-shadow: 3px 0px 2px rgba(113, 226, 84, 0.3);
+  transform: rotate(263deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box624 {
+  --cssB-v-624: 941456;
+  color: hsl(48, 12%, 48%);
+  background-color: hsl(228, 12%, 52%);
+  border: 5px solid hsl(138, 50%, 50%);
+  margin: 4px 12px 20px 12px;
+  padding: 9px 16px;
+  border-radius: 0px 6px;
+  box-shadow: 4px 1px 3px rgba(114, 228, 87, 0.4);
+  transform: rotate(264deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box625 {
+  --cssB-v-625: 949375;
+  color: hsl(85, 25%, 55%);
+  background-color: hsl(265, 25%, 45%);
+  border: 1px solid hsl(175, 50%, 50%);
+  margin: 5px 15px 0px 1px;
+  padding: 10px 18px;
+  border-radius: 1px 8px;
+  box-shadow: 0px 2px 4px rgba(115, 230, 90, 0.5);
+  transform: rotate(265deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box626 {
+  --cssB-v-626: 957294;
+  color: hsl(122, 38%, 62%);
+  background-color: hsl(302, 38%, 38%);
+  border: 2px solid hsl(212, 50%, 50%);
+  margin: 6px 18px 5px 8px;
+  padding: 11px 20px;
+  border-radius: 2px 1px;
+  box-shadow: 1px 3px 5px rgba(116, 232, 93, 0.6);
+  transform: rotate(266deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box627 {
+  --cssB-v-627: 965213;
+  color: hsl(159, 51%, 69%);
+  background-color: hsl(339, 51%, 31%);
+  border: 3px solid hsl(249, 50%, 50%);
+  margin: 7px 21px 10px 15px;
+  padding: 12px 0px;
+  border-radius: 3px 3px;
+  box-shadow: 2px 4px 6px rgba(117, 234, 96, 0.7);
+  transform: rotate(267deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box628 {
+  --cssB-v-628: 973132;
+  color: hsl(196, 64%, 76%);
+  background-color: hsl(16, 64%, 24%);
+  border: 4px solid hsl(286, 50%, 50%);
+  margin: 8px 24px 15px 4px;
+  padding: 13px 2px;
+  border-radius: 4px 5px;
+  box-shadow: 3px 5px 7px rgba(118, 236, 99, 0.8);
+  transform: rotate(268deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box629 {
+  --cssB-v-629: 981051;
+  color: hsl(233, 77%, 33%);
+  background-color: hsl(53, 77%, 67%);
+  border: 5px solid hsl(323, 50%, 50%);
+  margin: 9px 27px 20px 11px;
+  padding: 14px 4px;
+  border-radius: 5px 7px;
+  box-shadow: 4px 6px 8px rgba(119, 238, 102, 0.9);
+  transform: rotate(269deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box630 {
+  --cssB-v-630: 988970;
+  color: hsl(270, 90%, 40%);
+  background-color: hsl(90, 90%, 60%);
+  border: 1px solid hsl(0, 50%, 50%);
+  margin: 10px 0px 0px 0px;
+  padding: 0px 6px;
+  border-radius: 6px 0px;
+  box-shadow: 0px 0px 0px rgba(120, 240, 105, 0.1);
+  transform: rotate(270deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box631 {
+  --cssB-v-631: 996889;
+  color: hsl(307, 3%, 47%);
+  background-color: hsl(127, 3%, 53%);
+  border: 2px solid hsl(37, 50%, 50%);
+  margin: 11px 3px 5px 7px;
+  padding: 1px 8px;
+  border-radius: 7px 2px;
+  box-shadow: 1px 1px 1px rgba(121, 242, 108, 0.2);
+  transform: rotate(271deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box632 {
+  --cssB-v-632: 4808;
+  color: hsl(344, 16%, 54%);
+  background-color: hsl(164, 16%, 46%);
+  border: 3px solid hsl(74, 50%, 50%);
+  margin: 12px 6px 10px 14px;
+  padding: 2px 10px;
+  border-radius: 8px 4px;
+  box-shadow: 2px 2px 2px rgba(122, 244, 111, 0.3);
+  transform: rotate(272deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box633 {
+  --cssB-v-633: 12727;
+  color: hsl(21, 29%, 61%);
+  background-color: hsl(201, 29%, 39%);
+  border: 4px solid hsl(111, 50%, 50%);
+  margin: 13px 9px 15px 3px;
+  padding: 3px 12px;
+  border-radius: 9px 6px;
+  box-shadow: 3px 3px 3px rgba(123, 246, 114, 0.4);
+  transform: rotate(273deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box634 {
+  --cssB-v-634: 20646;
+  color: hsl(58, 42%, 68%);
+  background-color: hsl(238, 42%, 32%);
+  border: 5px solid hsl(148, 50%, 50%);
+  margin: 14px 12px 20px 10px;
+  padding: 4px 14px;
+  border-radius: 10px 8px;
+  box-shadow: 4px 4px 4px rgba(124, 248, 117, 0.5);
+  transform: rotate(274deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box635 {
+  --cssB-v-635: 28565;
+  color: hsl(95, 55%, 75%);
+  background-color: hsl(275, 55%, 25%);
+  border: 1px solid hsl(185, 50%, 50%);
+  margin: 15px 15px 0px 17px;
+  padding: 5px 16px;
+  border-radius: 11px 1px;
+  box-shadow: 0px 5px 5px rgba(125, 250, 120, 0.6);
+  transform: rotate(275deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box636 {
+  --cssB-v-636: 36484;
+  color: hsl(132, 68%, 32%);
+  background-color: hsl(312, 68%, 68%);
+  border: 2px solid hsl(222, 50%, 50%);
+  margin: 16px 18px 5px 6px;
+  padding: 6px 18px;
+  border-radius: 0px 3px;
+  box-shadow: 1px 6px 6px rgba(126, 252, 123, 0.7);
+  transform: rotate(276deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box637 {
+  --cssB-v-637: 44403;
+  color: hsl(169, 81%, 39%);
+  background-color: hsl(349, 81%, 61%);
+  border: 3px solid hsl(259, 50%, 50%);
+  margin: 17px 21px 10px 13px;
+  padding: 7px 20px;
+  border-radius: 1px 5px;
+  box-shadow: 2px 0px 7px rgba(127, 254, 126, 0.8);
+  transform: rotate(277deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box638 {
+  --cssB-v-638: 52322;
+  color: hsl(206, 94%, 46%);
+  background-color: hsl(26, 94%, 54%);
+  border: 4px solid hsl(296, 50%, 50%);
+  margin: 18px 24px 15px 2px;
+  padding: 8px 0px;
+  border-radius: 2px 7px;
+  box-shadow: 3px 1px 8px rgba(128, 1, 129, 0.9);
+  transform: rotate(278deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box639 {
+  --cssB-v-639: 60241;
+  color: hsl(243, 7%, 53%);
+  background-color: hsl(63, 7%, 47%);
+  border: 5px solid hsl(333, 50%, 50%);
+  margin: 19px 27px 20px 9px;
+  padding: 9px 2px;
+  border-radius: 3px 0px;
+  box-shadow: 4px 2px 0px rgba(129, 3, 132, 0.1);
+  transform: rotate(279deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box640 {
+  --cssB-v-640: 68160;
+  color: hsl(280, 20%, 60%);
+  background-color: hsl(100, 20%, 40%);
+  border: 1px solid hsl(10, 50%, 50%);
+  margin: 0px 0px 0px 16px;
+  padding: 10px 4px;
+  border-radius: 4px 2px;
+  box-shadow: 0px 3px 1px rgba(130, 5, 135, 0.2);
+  transform: rotate(280deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box641 {
+  --cssB-v-641: 76079;
+  color: hsl(317, 33%, 67%);
+  background-color: hsl(137, 33%, 33%);
+  border: 2px solid hsl(47, 50%, 50%);
+  margin: 1px 3px 5px 5px;
+  padding: 11px 6px;
+  border-radius: 5px 4px;
+  box-shadow: 1px 4px 2px rgba(131, 7, 138, 0.3);
+  transform: rotate(281deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box642 {
+  --cssB-v-642: 83998;
+  color: hsl(354, 46%, 74%);
+  background-color: hsl(174, 46%, 26%);
+  border: 3px solid hsl(84, 50%, 50%);
+  margin: 2px 6px 10px 12px;
+  padding: 12px 8px;
+  border-radius: 6px 6px;
+  box-shadow: 2px 5px 3px rgba(132, 9, 141, 0.4);
+  transform: rotate(282deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box643 {
+  --cssB-v-643: 91917;
+  color: hsl(31, 59%, 31%);
+  background-color: hsl(211, 59%, 69%);
+  border: 4px solid hsl(121, 50%, 50%);
+  margin: 3px 9px 15px 1px;
+  padding: 13px 10px;
+  border-radius: 7px 8px;
+  box-shadow: 3px 6px 4px rgba(133, 11, 144, 0.5);
+  transform: rotate(283deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box644 {
+  --cssB-v-644: 99836;
+  color: hsl(68, 72%, 38%);
+  background-color: hsl(248, 72%, 62%);
+  border: 5px solid hsl(158, 50%, 50%);
+  margin: 4px 12px 20px 8px;
+  padding: 14px 12px;
+  border-radius: 8px 1px;
+  box-shadow: 4px 0px 5px rgba(134, 13, 147, 0.6);
+  transform: rotate(284deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box645 {
+  --cssB-v-645: 107755;
+  color: hsl(105, 85%, 45%);
+  background-color: hsl(285, 85%, 55%);
+  border: 1px solid hsl(195, 50%, 50%);
+  margin: 5px 15px 0px 15px;
+  padding: 0px 14px;
+  border-radius: 9px 3px;
+  box-shadow: 0px 1px 6px rgba(135, 15, 150, 0.7);
+  transform: rotate(285deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box646 {
+  --cssB-v-646: 115674;
+  color: hsl(142, 98%, 52%);
+  background-color: hsl(322, 98%, 48%);
+  border: 2px solid hsl(232, 50%, 50%);
+  margin: 6px 18px 5px 4px;
+  padding: 1px 16px;
+  border-radius: 10px 5px;
+  box-shadow: 1px 2px 7px rgba(136, 17, 153, 0.8);
+  transform: rotate(286deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box647 {
+  --cssB-v-647: 123593;
+  color: hsl(179, 11%, 59%);
+  background-color: hsl(359, 11%, 41%);
+  border: 3px solid hsl(269, 50%, 50%);
+  margin: 7px 21px 10px 11px;
+  padding: 2px 18px;
+  border-radius: 11px 7px;
+  box-shadow: 2px 3px 8px rgba(137, 19, 156, 0.9);
+  transform: rotate(287deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box648 {
+  --cssB-v-648: 131512;
+  color: hsl(216, 24%, 66%);
+  background-color: hsl(36, 24%, 34%);
+  border: 4px solid hsl(306, 50%, 50%);
+  margin: 8px 24px 15px 0px;
+  padding: 3px 20px;
+  border-radius: 0px 0px;
+  box-shadow: 3px 4px 0px rgba(138, 21, 159, 0.1);
+  transform: rotate(288deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box649 {
+  --cssB-v-649: 139431;
+  color: hsl(253, 37%, 73%);
+  background-color: hsl(73, 37%, 27%);
+  border: 5px solid hsl(343, 50%, 50%);
+  margin: 9px 27px 20px 7px;
+  padding: 4px 0px;
+  border-radius: 1px 2px;
+  box-shadow: 4px 5px 1px rgba(139, 23, 162, 0.2);
+  transform: rotate(289deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box650 {
+  --cssB-v-650: 147350;
+  color: hsl(290, 50%, 30%);
+  background-color: hsl(110, 50%, 70%);
+  border: 1px solid hsl(20, 50%, 50%);
+  margin: 10px 0px 0px 14px;
+  padding: 5px 2px;
+  border-radius: 2px 4px;
+  box-shadow: 0px 6px 2px rgba(140, 25, 165, 0.3);
+  transform: rotate(290deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box651 {
+  --cssB-v-651: 155269;
+  color: hsl(327, 63%, 37%);
+  background-color: hsl(147, 63%, 63%);
+  border: 2px solid hsl(57, 50%, 50%);
+  margin: 11px 3px 5px 3px;
+  padding: 6px 4px;
+  border-radius: 3px 6px;
+  box-shadow: 1px 0px 3px rgba(141, 27, 168, 0.4);
+  transform: rotate(291deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box652 {
+  --cssB-v-652: 163188;
+  color: hsl(4, 76%, 44%);
+  background-color: hsl(184, 76%, 56%);
+  border: 3px solid hsl(94, 50%, 50%);
+  margin: 12px 6px 10px 10px;
+  padding: 7px 6px;
+  border-radius: 4px 8px;
+  box-shadow: 2px 1px 4px rgba(142, 29, 171, 0.5);
+  transform: rotate(292deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box653 {
+  --cssB-v-653: 171107;
+  color: hsl(41, 89%, 51%);
+  background-color: hsl(221, 89%, 49%);
+  border: 4px solid hsl(131, 50%, 50%);
+  margin: 13px 9px 15px 17px;
+  padding: 8px 8px;
+  border-radius: 5px 1px;
+  box-shadow: 3px 2px 5px rgba(143, 31, 174, 0.6);
+  transform: rotate(293deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box654 {
+  --cssB-v-654: 179026;
+  color: hsl(78, 2%, 58%);
+  background-color: hsl(258, 2%, 42%);
+  border: 5px solid hsl(168, 50%, 50%);
+  margin: 14px 12px 20px 6px;
+  padding: 9px 10px;
+  border-radius: 6px 3px;
+  box-shadow: 4px 3px 6px rgba(144, 33, 177, 0.7);
+  transform: rotate(294deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box655 {
+  --cssB-v-655: 186945;
+  color: hsl(115, 15%, 65%);
+  background-color: hsl(295, 15%, 35%);
+  border: 1px solid hsl(205, 50%, 50%);
+  margin: 15px 15px 0px 13px;
+  padding: 10px 12px;
+  border-radius: 7px 5px;
+  box-shadow: 0px 4px 7px rgba(145, 35, 180, 0.8);
+  transform: rotate(295deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box656 {
+  --cssB-v-656: 194864;
+  color: hsl(152, 28%, 72%);
+  background-color: hsl(332, 28%, 28%);
+  border: 2px solid hsl(242, 50%, 50%);
+  margin: 16px 18px 5px 2px;
+  padding: 11px 14px;
+  border-radius: 8px 7px;
+  box-shadow: 1px 5px 8px rgba(146, 37, 183, 0.9);
+  transform: rotate(296deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box657 {
+  --cssB-v-657: 202783;
+  color: hsl(189, 41%, 79%);
+  background-color: hsl(9, 41%, 21%);
+  border: 3px solid hsl(279, 50%, 50%);
+  margin: 17px 21px 10px 9px;
+  padding: 12px 16px;
+  border-radius: 9px 0px;
+  box-shadow: 2px 6px 0px rgba(147, 39, 186, 0.1);
+  transform: rotate(297deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box658 {
+  --cssB-v-658: 210702;
+  color: hsl(226, 54%, 36%);
+  background-color: hsl(46, 54%, 64%);
+  border: 4px solid hsl(316, 50%, 50%);
+  margin: 18px 24px 15px 16px;
+  padding: 13px 18px;
+  border-radius: 10px 2px;
+  box-shadow: 3px 0px 1px rgba(148, 41, 189, 0.2);
+  transform: rotate(298deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box659 {
+  --cssB-v-659: 218621;
+  color: hsl(263, 67%, 43%);
+  background-color: hsl(83, 67%, 57%);
+  border: 5px solid hsl(353, 50%, 50%);
+  margin: 19px 27px 20px 5px;
+  padding: 14px 20px;
+  border-radius: 11px 4px;
+  box-shadow: 4px 1px 2px rgba(149, 43, 192, 0.3);
+  transform: rotate(299deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box660 {
+  --cssB-v-660: 226540;
+  color: hsl(300, 80%, 50%);
+  background-color: hsl(120, 80%, 50%);
+  border: 1px solid hsl(30, 50%, 50%);
+  margin: 0px 0px 0px 12px;
+  padding: 0px 0px;
+  border-radius: 0px 6px;
+  box-shadow: 0px 2px 3px rgba(150, 45, 195, 0.4);
+  transform: rotate(300deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box661 {
+  --cssB-v-661: 234459;
+  color: hsl(337, 93%, 57%);
+  background-color: hsl(157, 93%, 43%);
+  border: 2px solid hsl(67, 50%, 50%);
+  margin: 1px 3px 5px 1px;
+  padding: 1px 2px;
+  border-radius: 1px 8px;
+  box-shadow: 1px 3px 4px rgba(151, 47, 198, 0.5);
+  transform: rotate(301deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box662 {
+  --cssB-v-662: 242378;
+  color: hsl(14, 6%, 64%);
+  background-color: hsl(194, 6%, 36%);
+  border: 3px solid hsl(104, 50%, 50%);
+  margin: 2px 6px 10px 8px;
+  padding: 2px 4px;
+  border-radius: 2px 1px;
+  box-shadow: 2px 4px 5px rgba(152, 49, 201, 0.6);
+  transform: rotate(302deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box663 {
+  --cssB-v-663: 250297;
+  color: hsl(51, 19%, 71%);
+  background-color: hsl(231, 19%, 29%);
+  border: 4px solid hsl(141, 50%, 50%);
+  margin: 3px 9px 15px 15px;
+  padding: 3px 6px;
+  border-radius: 3px 3px;
+  box-shadow: 3px 5px 6px rgba(153, 51, 204, 0.7);
+  transform: rotate(303deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box664 {
+  --cssB-v-664: 258216;
+  color: hsl(88, 32%, 78%);
+  background-color: hsl(268, 32%, 22%);
+  border: 5px solid hsl(178, 50%, 50%);
+  margin: 4px 12px 20px 4px;
+  padding: 4px 8px;
+  border-radius: 4px 5px;
+  box-shadow: 4px 6px 7px rgba(154, 53, 207, 0.8);
+  transform: rotate(304deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box665 {
+  --cssB-v-665: 266135;
+  color: hsl(125, 45%, 35%);
+  background-color: hsl(305, 45%, 65%);
+  border: 1px solid hsl(215, 50%, 50%);
+  margin: 5px 15px 0px 11px;
+  padding: 5px 10px;
+  border-radius: 5px 7px;
+  box-shadow: 0px 0px 8px rgba(155, 55, 210, 0.9);
+  transform: rotate(305deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box666 {
+  --cssB-v-666: 274054;
+  color: hsl(162, 58%, 42%);
+  background-color: hsl(342, 58%, 58%);
+  border: 2px solid hsl(252, 50%, 50%);
+  margin: 6px 18px 5px 0px;
+  padding: 6px 12px;
+  border-radius: 6px 0px;
+  box-shadow: 1px 1px 0px rgba(156, 57, 213, 0.1);
+  transform: rotate(306deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box667 {
+  --cssB-v-667: 281973;
+  color: hsl(199, 71%, 49%);
+  background-color: hsl(19, 71%, 51%);
+  border: 3px solid hsl(289, 50%, 50%);
+  margin: 7px 21px 10px 7px;
+  padding: 7px 14px;
+  border-radius: 7px 2px;
+  box-shadow: 2px 2px 1px rgba(157, 59, 216, 0.2);
+  transform: rotate(307deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box668 {
+  --cssB-v-668: 289892;
+  color: hsl(236, 84%, 56%);
+  background-color: hsl(56, 84%, 44%);
+  border: 4px solid hsl(326, 50%, 50%);
+  margin: 8px 24px 15px 14px;
+  padding: 8px 16px;
+  border-radius: 8px 4px;
+  box-shadow: 3px 3px 2px rgba(158, 61, 219, 0.3);
+  transform: rotate(308deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box669 {
+  --cssB-v-669: 297811;
+  color: hsl(273, 97%, 63%);
+  background-color: hsl(93, 97%, 37%);
+  border: 5px solid hsl(3, 50%, 50%);
+  margin: 9px 27px 20px 3px;
+  padding: 9px 18px;
+  border-radius: 9px 6px;
+  box-shadow: 4px 4px 3px rgba(159, 63, 222, 0.4);
+  transform: rotate(309deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box670 {
+  --cssB-v-670: 305730;
+  color: hsl(310, 10%, 70%);
+  background-color: hsl(130, 10%, 30%);
+  border: 1px solid hsl(40, 50%, 50%);
+  margin: 10px 0px 0px 10px;
+  padding: 10px 20px;
+  border-radius: 10px 8px;
+  box-shadow: 0px 5px 4px rgba(160, 65, 225, 0.5);
+  transform: rotate(310deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box671 {
+  --cssB-v-671: 313649;
+  color: hsl(347, 23%, 77%);
+  background-color: hsl(167, 23%, 23%);
+  border: 2px solid hsl(77, 50%, 50%);
+  margin: 11px 3px 5px 17px;
+  padding: 11px 0px;
+  border-radius: 11px 1px;
+  box-shadow: 1px 6px 5px rgba(161, 67, 228, 0.6);
+  transform: rotate(311deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box672 {
+  --cssB-v-672: 321568;
+  color: hsl(24, 36%, 34%);
+  background-color: hsl(204, 36%, 66%);
+  border: 3px solid hsl(114, 50%, 50%);
+  margin: 12px 6px 10px 6px;
+  padding: 12px 2px;
+  border-radius: 0px 3px;
+  box-shadow: 2px 0px 6px rgba(162, 69, 231, 0.7);
+  transform: rotate(312deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box673 {
+  --cssB-v-673: 329487;
+  color: hsl(61, 49%, 41%);
+  background-color: hsl(241, 49%, 59%);
+  border: 4px solid hsl(151, 50%, 50%);
+  margin: 13px 9px 15px 13px;
+  padding: 13px 4px;
+  border-radius: 1px 5px;
+  box-shadow: 3px 1px 7px rgba(163, 71, 234, 0.8);
+  transform: rotate(313deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box674 {
+  --cssB-v-674: 337406;
+  color: hsl(98, 62%, 48%);
+  background-color: hsl(278, 62%, 52%);
+  border: 5px solid hsl(188, 50%, 50%);
+  margin: 14px 12px 20px 2px;
+  padding: 14px 6px;
+  border-radius: 2px 7px;
+  box-shadow: 4px 2px 8px rgba(164, 73, 237, 0.9);
+  transform: rotate(314deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box675 {
+  --cssB-v-675: 345325;
+  color: hsl(135, 75%, 55%);
+  background-color: hsl(315, 75%, 45%);
+  border: 1px solid hsl(225, 50%, 50%);
+  margin: 15px 15px 0px 9px;
+  padding: 0px 8px;
+  border-radius: 3px 0px;
+  box-shadow: 0px 3px 0px rgba(165, 75, 240, 0.1);
+  transform: rotate(315deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box676 {
+  --cssB-v-676: 353244;
+  color: hsl(172, 88%, 62%);
+  background-color: hsl(352, 88%, 38%);
+  border: 2px solid hsl(262, 50%, 50%);
+  margin: 16px 18px 5px 16px;
+  padding: 1px 10px;
+  border-radius: 4px 2px;
+  box-shadow: 1px 4px 1px rgba(166, 77, 243, 0.2);
+  transform: rotate(316deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box677 {
+  --cssB-v-677: 361163;
+  color: hsl(209, 1%, 69%);
+  background-color: hsl(29, 1%, 31%);
+  border: 3px solid hsl(299, 50%, 50%);
+  margin: 17px 21px 10px 5px;
+  padding: 2px 12px;
+  border-radius: 5px 4px;
+  box-shadow: 2px 5px 2px rgba(167, 79, 246, 0.3);
+  transform: rotate(317deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box678 {
+  --cssB-v-678: 369082;
+  color: hsl(246, 14%, 76%);
+  background-color: hsl(66, 14%, 24%);
+  border: 4px solid hsl(336, 50%, 50%);
+  margin: 18px 24px 15px 12px;
+  padding: 3px 14px;
+  border-radius: 6px 6px;
+  box-shadow: 3px 6px 3px rgba(168, 81, 249, 0.4);
+  transform: rotate(318deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box679 {
+  --cssB-v-679: 377001;
+  color: hsl(283, 27%, 33%);
+  background-color: hsl(103, 27%, 67%);
+  border: 5px solid hsl(13, 50%, 50%);
+  margin: 19px 27px 20px 1px;
+  padding: 4px 16px;
+  border-radius: 7px 8px;
+  box-shadow: 4px 0px 4px rgba(169, 83, 252, 0.5);
+  transform: rotate(319deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box680 {
+  --cssB-v-680: 384920;
+  color: hsl(320, 40%, 40%);
+  background-color: hsl(140, 40%, 60%);
+  border: 1px solid hsl(50, 50%, 50%);
+  margin: 0px 0px 0px 8px;
+  padding: 5px 18px;
+  border-radius: 8px 1px;
+  box-shadow: 0px 1px 5px rgba(170, 85, 0, 0.6);
+  transform: rotate(320deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box681 {
+  --cssB-v-681: 392839;
+  color: hsl(357, 53%, 47%);
+  background-color: hsl(177, 53%, 53%);
+  border: 2px solid hsl(87, 50%, 50%);
+  margin: 1px 3px 5px 15px;
+  padding: 6px 20px;
+  border-radius: 9px 3px;
+  box-shadow: 1px 2px 6px rgba(171, 87, 3, 0.7);
+  transform: rotate(321deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box682 {
+  --cssB-v-682: 400758;
+  color: hsl(34, 66%, 54%);
+  background-color: hsl(214, 66%, 46%);
+  border: 3px solid hsl(124, 50%, 50%);
+  margin: 2px 6px 10px 4px;
+  padding: 7px 0px;
+  border-radius: 10px 5px;
+  box-shadow: 2px 3px 7px rgba(172, 89, 6, 0.8);
+  transform: rotate(322deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box683 {
+  --cssB-v-683: 408677;
+  color: hsl(71, 79%, 61%);
+  background-color: hsl(251, 79%, 39%);
+  border: 4px solid hsl(161, 50%, 50%);
+  margin: 3px 9px 15px 11px;
+  padding: 8px 2px;
+  border-radius: 11px 7px;
+  box-shadow: 3px 4px 8px rgba(173, 91, 9, 0.9);
+  transform: rotate(323deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box684 {
+  --cssB-v-684: 416596;
+  color: hsl(108, 92%, 68%);
+  background-color: hsl(288, 92%, 32%);
+  border: 5px solid hsl(198, 50%, 50%);
+  margin: 4px 12px 20px 0px;
+  padding: 9px 4px;
+  border-radius: 0px 0px;
+  box-shadow: 4px 5px 0px rgba(174, 93, 12, 0.1);
+  transform: rotate(324deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box685 {
+  --cssB-v-685: 424515;
+  color: hsl(145, 5%, 75%);
+  background-color: hsl(325, 5%, 25%);
+  border: 1px solid hsl(235, 50%, 50%);
+  margin: 5px 15px 0px 7px;
+  padding: 10px 6px;
+  border-radius: 1px 2px;
+  box-shadow: 0px 6px 1px rgba(175, 95, 15, 0.2);
+  transform: rotate(325deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box686 {
+  --cssB-v-686: 432434;
+  color: hsl(182, 18%, 32%);
+  background-color: hsl(2, 18%, 68%);
+  border: 2px solid hsl(272, 50%, 50%);
+  margin: 6px 18px 5px 14px;
+  padding: 11px 8px;
+  border-radius: 2px 4px;
+  box-shadow: 1px 0px 2px rgba(176, 97, 18, 0.3);
+  transform: rotate(326deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box687 {
+  --cssB-v-687: 440353;
+  color: hsl(219, 31%, 39%);
+  background-color: hsl(39, 31%, 61%);
+  border: 3px solid hsl(309, 50%, 50%);
+  margin: 7px 21px 10px 3px;
+  padding: 12px 10px;
+  border-radius: 3px 6px;
+  box-shadow: 2px 1px 3px rgba(177, 99, 21, 0.4);
+  transform: rotate(327deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box688 {
+  --cssB-v-688: 448272;
+  color: hsl(256, 44%, 46%);
+  background-color: hsl(76, 44%, 54%);
+  border: 4px solid hsl(346, 50%, 50%);
+  margin: 8px 24px 15px 10px;
+  padding: 13px 12px;
+  border-radius: 4px 8px;
+  box-shadow: 3px 2px 4px rgba(178, 101, 24, 0.5);
+  transform: rotate(328deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box689 {
+  --cssB-v-689: 456191;
+  color: hsl(293, 57%, 53%);
+  background-color: hsl(113, 57%, 47%);
+  border: 5px solid hsl(23, 50%, 50%);
+  margin: 9px 27px 20px 17px;
+  padding: 14px 14px;
+  border-radius: 5px 1px;
+  box-shadow: 4px 3px 5px rgba(179, 103, 27, 0.6);
+  transform: rotate(329deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box690 {
+  --cssB-v-690: 464110;
+  color: hsl(330, 70%, 60%);
+  background-color: hsl(150, 70%, 40%);
+  border: 1px solid hsl(60, 50%, 50%);
+  margin: 10px 0px 0px 6px;
+  padding: 0px 16px;
+  border-radius: 6px 3px;
+  box-shadow: 0px 4px 6px rgba(180, 105, 30, 0.7);
+  transform: rotate(330deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box691 {
+  --cssB-v-691: 472029;
+  color: hsl(7, 83%, 67%);
+  background-color: hsl(187, 83%, 33%);
+  border: 2px solid hsl(97, 50%, 50%);
+  margin: 11px 3px 5px 13px;
+  padding: 1px 18px;
+  border-radius: 7px 5px;
+  box-shadow: 1px 5px 7px rgba(181, 107, 33, 0.8);
+  transform: rotate(331deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box692 {
+  --cssB-v-692: 479948;
+  color: hsl(44, 96%, 74%);
+  background-color: hsl(224, 96%, 26%);
+  border: 3px solid hsl(134, 50%, 50%);
+  margin: 12px 6px 10px 2px;
+  padding: 2px 20px;
+  border-radius: 8px 7px;
+  box-shadow: 2px 6px 8px rgba(182, 109, 36, 0.9);
+  transform: rotate(332deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box693 {
+  --cssB-v-693: 487867;
+  color: hsl(81, 9%, 31%);
+  background-color: hsl(261, 9%, 69%);
+  border: 4px solid hsl(171, 50%, 50%);
+  margin: 13px 9px 15px 9px;
+  padding: 3px 0px;
+  border-radius: 9px 0px;
+  box-shadow: 3px 0px 0px rgba(183, 111, 39, 0.1);
+  transform: rotate(333deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box694 {
+  --cssB-v-694: 495786;
+  color: hsl(118, 22%, 38%);
+  background-color: hsl(298, 22%, 62%);
+  border: 5px solid hsl(208, 50%, 50%);
+  margin: 14px 12px 20px 16px;
+  padding: 4px 2px;
+  border-radius: 10px 2px;
+  box-shadow: 4px 1px 1px rgba(184, 113, 42, 0.2);
+  transform: rotate(334deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box695 {
+  --cssB-v-695: 503705;
+  color: hsl(155, 35%, 45%);
+  background-color: hsl(335, 35%, 55%);
+  border: 1px solid hsl(245, 50%, 50%);
+  margin: 15px 15px 0px 5px;
+  padding: 5px 4px;
+  border-radius: 11px 4px;
+  box-shadow: 0px 2px 2px rgba(185, 115, 45, 0.3);
+  transform: rotate(335deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box696 {
+  --cssB-v-696: 511624;
+  color: hsl(192, 48%, 52%);
+  background-color: hsl(12, 48%, 48%);
+  border: 2px solid hsl(282, 50%, 50%);
+  margin: 16px 18px 5px 12px;
+  padding: 6px 6px;
+  border-radius: 0px 6px;
+  box-shadow: 1px 3px 3px rgba(186, 117, 48, 0.4);
+  transform: rotate(336deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box697 {
+  --cssB-v-697: 519543;
+  color: hsl(229, 61%, 59%);
+  background-color: hsl(49, 61%, 41%);
+  border: 3px solid hsl(319, 50%, 50%);
+  margin: 17px 21px 10px 1px;
+  padding: 7px 8px;
+  border-radius: 1px 8px;
+  box-shadow: 2px 4px 4px rgba(187, 119, 51, 0.5);
+  transform: rotate(337deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box698 {
+  --cssB-v-698: 527462;
+  color: hsl(266, 74%, 66%);
+  background-color: hsl(86, 74%, 34%);
+  border: 4px solid hsl(356, 50%, 50%);
+  margin: 18px 24px 15px 8px;
+  padding: 8px 10px;
+  border-radius: 2px 1px;
+  box-shadow: 3px 5px 5px rgba(188, 121, 54, 0.6);
+  transform: rotate(338deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box699 {
+  --cssB-v-699: 535381;
+  color: hsl(303, 87%, 73%);
+  background-color: hsl(123, 87%, 27%);
+  border: 5px solid hsl(33, 50%, 50%);
+  margin: 19px 27px 20px 15px;
+  padding: 9px 12px;
+  border-radius: 3px 3px;
+  box-shadow: 4px 6px 6px rgba(189, 123, 57, 0.7);
+  transform: rotate(339deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box700 {
+  --cssB-v-700: 543300;
+  color: hsl(340, 0%, 30%);
+  background-color: hsl(160, 0%, 70%);
+  border: 1px solid hsl(70, 50%, 50%);
+  margin: 0px 0px 0px 4px;
+  padding: 10px 14px;
+  border-radius: 4px 5px;
+  box-shadow: 0px 0px 7px rgba(190, 125, 60, 0.8);
+  transform: rotate(340deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box701 {
+  --cssB-v-701: 551219;
+  color: hsl(17, 13%, 37%);
+  background-color: hsl(197, 13%, 63%);
+  border: 2px solid hsl(107, 50%, 50%);
+  margin: 1px 3px 5px 11px;
+  padding: 11px 16px;
+  border-radius: 5px 7px;
+  box-shadow: 1px 1px 8px rgba(191, 127, 63, 0.9);
+  transform: rotate(341deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box702 {
+  --cssB-v-702: 559138;
+  color: hsl(54, 26%, 44%);
+  background-color: hsl(234, 26%, 56%);
+  border: 3px solid hsl(144, 50%, 50%);
+  margin: 2px 6px 10px 0px;
+  padding: 12px 18px;
+  border-radius: 6px 0px;
+  box-shadow: 2px 2px 0px rgba(192, 129, 66, 0.1);
+  transform: rotate(342deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box703 {
+  --cssB-v-703: 567057;
+  color: hsl(91, 39%, 51%);
+  background-color: hsl(271, 39%, 49%);
+  border: 4px solid hsl(181, 50%, 50%);
+  margin: 3px 9px 15px 7px;
+  padding: 13px 20px;
+  border-radius: 7px 2px;
+  box-shadow: 3px 3px 1px rgba(193, 131, 69, 0.2);
+  transform: rotate(343deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box704 {
+  --cssB-v-704: 574976;
+  color: hsl(128, 52%, 58%);
+  background-color: hsl(308, 52%, 42%);
+  border: 5px solid hsl(218, 50%, 50%);
+  margin: 4px 12px 20px 14px;
+  padding: 14px 0px;
+  border-radius: 8px 4px;
+  box-shadow: 4px 4px 2px rgba(194, 133, 72, 0.3);
+  transform: rotate(344deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box705 {
+  --cssB-v-705: 582895;
+  color: hsl(165, 65%, 65%);
+  background-color: hsl(345, 65%, 35%);
+  border: 1px solid hsl(255, 50%, 50%);
+  margin: 5px 15px 0px 3px;
+  padding: 0px 2px;
+  border-radius: 9px 6px;
+  box-shadow: 0px 5px 3px rgba(195, 135, 75, 0.4);
+  transform: rotate(345deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box706 {
+  --cssB-v-706: 590814;
+  color: hsl(202, 78%, 72%);
+  background-color: hsl(22, 78%, 28%);
+  border: 2px solid hsl(292, 50%, 50%);
+  margin: 6px 18px 5px 10px;
+  padding: 1px 4px;
+  border-radius: 10px 8px;
+  box-shadow: 1px 6px 4px rgba(196, 137, 78, 0.5);
+  transform: rotate(346deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box707 {
+  --cssB-v-707: 598733;
+  color: hsl(239, 91%, 79%);
+  background-color: hsl(59, 91%, 21%);
+  border: 3px solid hsl(329, 50%, 50%);
+  margin: 7px 21px 10px 17px;
+  padding: 2px 6px;
+  border-radius: 11px 1px;
+  box-shadow: 2px 0px 5px rgba(197, 139, 81, 0.6);
+  transform: rotate(347deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box708 {
+  --cssB-v-708: 606652;
+  color: hsl(276, 4%, 36%);
+  background-color: hsl(96, 4%, 64%);
+  border: 4px solid hsl(6, 50%, 50%);
+  margin: 8px 24px 15px 6px;
+  padding: 3px 8px;
+  border-radius: 0px 3px;
+  box-shadow: 3px 1px 6px rgba(198, 141, 84, 0.7);
+  transform: rotate(348deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box709 {
+  --cssB-v-709: 614571;
+  color: hsl(313, 17%, 43%);
+  background-color: hsl(133, 17%, 57%);
+  border: 5px solid hsl(43, 50%, 50%);
+  margin: 9px 27px 20px 13px;
+  padding: 4px 10px;
+  border-radius: 1px 5px;
+  box-shadow: 4px 2px 7px rgba(199, 143, 87, 0.8);
+  transform: rotate(349deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box710 {
+  --cssB-v-710: 622490;
+  color: hsl(350, 30%, 50%);
+  background-color: hsl(170, 30%, 50%);
+  border: 1px solid hsl(80, 50%, 50%);
+  margin: 10px 0px 0px 2px;
+  padding: 5px 12px;
+  border-radius: 2px 7px;
+  box-shadow: 0px 3px 8px rgba(200, 145, 90, 0.9);
+  transform: rotate(350deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box711 {
+  --cssB-v-711: 630409;
+  color: hsl(27, 43%, 57%);
+  background-color: hsl(207, 43%, 43%);
+  border: 2px solid hsl(117, 50%, 50%);
+  margin: 11px 3px 5px 9px;
+  padding: 6px 14px;
+  border-radius: 3px 0px;
+  box-shadow: 1px 4px 0px rgba(201, 147, 93, 0.1);
+  transform: rotate(351deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box712 {
+  --cssB-v-712: 638328;
+  color: hsl(64, 56%, 64%);
+  background-color: hsl(244, 56%, 36%);
+  border: 3px solid hsl(154, 50%, 50%);
+  margin: 12px 6px 10px 16px;
+  padding: 7px 16px;
+  border-radius: 4px 2px;
+  box-shadow: 2px 5px 1px rgba(202, 149, 96, 0.2);
+  transform: rotate(352deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box713 {
+  --cssB-v-713: 646247;
+  color: hsl(101, 69%, 71%);
+  background-color: hsl(281, 69%, 29%);
+  border: 4px solid hsl(191, 50%, 50%);
+  margin: 13px 9px 15px 5px;
+  padding: 8px 18px;
+  border-radius: 5px 4px;
+  box-shadow: 3px 6px 2px rgba(203, 151, 99, 0.3);
+  transform: rotate(353deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box714 {
+  --cssB-v-714: 654166;
+  color: hsl(138, 82%, 78%);
+  background-color: hsl(318, 82%, 22%);
+  border: 5px solid hsl(228, 50%, 50%);
+  margin: 14px 12px 20px 12px;
+  padding: 9px 20px;
+  border-radius: 6px 6px;
+  box-shadow: 4px 0px 3px rgba(204, 153, 102, 0.4);
+  transform: rotate(354deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box715 {
+  --cssB-v-715: 662085;
+  color: hsl(175, 95%, 35%);
+  background-color: hsl(355, 95%, 65%);
+  border: 1px solid hsl(265, 50%, 50%);
+  margin: 15px 15px 0px 1px;
+  padding: 10px 0px;
+  border-radius: 7px 8px;
+  box-shadow: 0px 1px 4px rgba(205, 155, 105, 0.5);
+  transform: rotate(355deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box716 {
+  --cssB-v-716: 670004;
+  color: hsl(212, 8%, 42%);
+  background-color: hsl(32, 8%, 58%);
+  border: 2px solid hsl(302, 50%, 50%);
+  margin: 16px 18px 5px 8px;
+  padding: 11px 2px;
+  border-radius: 8px 1px;
+  box-shadow: 1px 2px 5px rgba(206, 157, 108, 0.6);
+  transform: rotate(356deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box717 {
+  --cssB-v-717: 677923;
+  color: hsl(249, 21%, 49%);
+  background-color: hsl(69, 21%, 51%);
+  border: 3px solid hsl(339, 50%, 50%);
+  margin: 17px 21px 10px 15px;
+  padding: 12px 4px;
+  border-radius: 9px 3px;
+  box-shadow: 2px 3px 6px rgba(207, 159, 111, 0.7);
+  transform: rotate(357deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box718 {
+  --cssB-v-718: 685842;
+  color: hsl(286, 34%, 56%);
+  background-color: hsl(106, 34%, 44%);
+  border: 4px solid hsl(16, 50%, 50%);
+  margin: 18px 24px 15px 4px;
+  padding: 13px 6px;
+  border-radius: 10px 5px;
+  box-shadow: 3px 4px 7px rgba(208, 161, 114, 0.8);
+  transform: rotate(358deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box719 {
+  --cssB-v-719: 693761;
+  color: hsl(323, 47%, 63%);
+  background-color: hsl(143, 47%, 37%);
+  border: 5px solid hsl(53, 50%, 50%);
+  margin: 19px 27px 20px 11px;
+  padding: 14px 8px;
+  border-radius: 11px 7px;
+  box-shadow: 4px 5px 8px rgba(209, 163, 117, 0.9);
+  transform: rotate(359deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box720 {
+  --cssB-v-720: 701680;
+  color: hsl(0, 60%, 70%);
+  background-color: hsl(180, 60%, 30%);
+  border: 1px solid hsl(90, 50%, 50%);
+  margin: 0px 0px 0px 0px;
+  padding: 0px 10px;
+  border-radius: 0px 0px;
+  box-shadow: 0px 6px 0px rgba(210, 165, 120, 0.1);
+  transform: rotate(0deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box721 {
+  --cssB-v-721: 709599;
+  color: hsl(37, 73%, 77%);
+  background-color: hsl(217, 73%, 23%);
+  border: 2px solid hsl(127, 50%, 50%);
+  margin: 1px 3px 5px 7px;
+  padding: 1px 12px;
+  border-radius: 1px 2px;
+  box-shadow: 1px 0px 1px rgba(211, 167, 123, 0.2);
+  transform: rotate(1deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box722 {
+  --cssB-v-722: 717518;
+  color: hsl(74, 86%, 34%);
+  background-color: hsl(254, 86%, 66%);
+  border: 3px solid hsl(164, 50%, 50%);
+  margin: 2px 6px 10px 14px;
+  padding: 2px 14px;
+  border-radius: 2px 4px;
+  box-shadow: 2px 1px 2px rgba(212, 169, 126, 0.3);
+  transform: rotate(2deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box723 {
+  --cssB-v-723: 725437;
+  color: hsl(111, 99%, 41%);
+  background-color: hsl(291, 99%, 59%);
+  border: 4px solid hsl(201, 50%, 50%);
+  margin: 3px 9px 15px 3px;
+  padding: 3px 16px;
+  border-radius: 3px 6px;
+  box-shadow: 3px 2px 3px rgba(213, 171, 129, 0.4);
+  transform: rotate(3deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box724 {
+  --cssB-v-724: 733356;
+  color: hsl(148, 12%, 48%);
+  background-color: hsl(328, 12%, 52%);
+  border: 5px solid hsl(238, 50%, 50%);
+  margin: 4px 12px 20px 10px;
+  padding: 4px 18px;
+  border-radius: 4px 8px;
+  box-shadow: 4px 3px 4px rgba(214, 173, 132, 0.5);
+  transform: rotate(4deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box725 {
+  --cssB-v-725: 741275;
+  color: hsl(185, 25%, 55%);
+  background-color: hsl(5, 25%, 45%);
+  border: 1px solid hsl(275, 50%, 50%);
+  margin: 5px 15px 0px 17px;
+  padding: 5px 20px;
+  border-radius: 5px 1px;
+  box-shadow: 0px 4px 5px rgba(215, 175, 135, 0.6);
+  transform: rotate(5deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box726 {
+  --cssB-v-726: 749194;
+  color: hsl(222, 38%, 62%);
+  background-color: hsl(42, 38%, 38%);
+  border: 2px solid hsl(312, 50%, 50%);
+  margin: 6px 18px 5px 6px;
+  padding: 6px 0px;
+  border-radius: 6px 3px;
+  box-shadow: 1px 5px 6px rgba(216, 177, 138, 0.7);
+  transform: rotate(6deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box727 {
+  --cssB-v-727: 757113;
+  color: hsl(259, 51%, 69%);
+  background-color: hsl(79, 51%, 31%);
+  border: 3px solid hsl(349, 50%, 50%);
+  margin: 7px 21px 10px 13px;
+  padding: 7px 2px;
+  border-radius: 7px 5px;
+  box-shadow: 2px 6px 7px rgba(217, 179, 141, 0.8);
+  transform: rotate(7deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box728 {
+  --cssB-v-728: 765032;
+  color: hsl(296, 64%, 76%);
+  background-color: hsl(116, 64%, 24%);
+  border: 4px solid hsl(26, 50%, 50%);
+  margin: 8px 24px 15px 2px;
+  padding: 8px 4px;
+  border-radius: 8px 7px;
+  box-shadow: 3px 0px 8px rgba(218, 181, 144, 0.9);
+  transform: rotate(8deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box729 {
+  --cssB-v-729: 772951;
+  color: hsl(333, 77%, 33%);
+  background-color: hsl(153, 77%, 67%);
+  border: 5px solid hsl(63, 50%, 50%);
+  margin: 9px 27px 20px 9px;
+  padding: 9px 6px;
+  border-radius: 9px 0px;
+  box-shadow: 4px 1px 0px rgba(219, 183, 147, 0.1);
+  transform: rotate(9deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box730 {
+  --cssB-v-730: 780870;
+  color: hsl(10, 90%, 40%);
+  background-color: hsl(190, 90%, 60%);
+  border: 1px solid hsl(100, 50%, 50%);
+  margin: 10px 0px 0px 16px;
+  padding: 10px 8px;
+  border-radius: 10px 2px;
+  box-shadow: 0px 2px 1px rgba(220, 185, 150, 0.2);
+  transform: rotate(10deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box731 {
+  --cssB-v-731: 788789;
+  color: hsl(47, 3%, 47%);
+  background-color: hsl(227, 3%, 53%);
+  border: 2px solid hsl(137, 50%, 50%);
+  margin: 11px 3px 5px 5px;
+  padding: 11px 10px;
+  border-radius: 11px 4px;
+  box-shadow: 1px 3px 2px rgba(221, 187, 153, 0.3);
+  transform: rotate(11deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box732 {
+  --cssB-v-732: 796708;
+  color: hsl(84, 16%, 54%);
+  background-color: hsl(264, 16%, 46%);
+  border: 3px solid hsl(174, 50%, 50%);
+  margin: 12px 6px 10px 12px;
+  padding: 12px 12px;
+  border-radius: 0px 6px;
+  box-shadow: 2px 4px 3px rgba(222, 189, 156, 0.4);
+  transform: rotate(12deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box733 {
+  --cssB-v-733: 804627;
+  color: hsl(121, 29%, 61%);
+  background-color: hsl(301, 29%, 39%);
+  border: 4px solid hsl(211, 50%, 50%);
+  margin: 13px 9px 15px 1px;
+  padding: 13px 14px;
+  border-radius: 1px 8px;
+  box-shadow: 3px 5px 4px rgba(223, 191, 159, 0.5);
+  transform: rotate(13deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box734 {
+  --cssB-v-734: 812546;
+  color: hsl(158, 42%, 68%);
+  background-color: hsl(338, 42%, 32%);
+  border: 5px solid hsl(248, 50%, 50%);
+  margin: 14px 12px 20px 8px;
+  padding: 14px 16px;
+  border-radius: 2px 1px;
+  box-shadow: 4px 6px 5px rgba(224, 193, 162, 0.6);
+  transform: rotate(14deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box735 {
+  --cssB-v-735: 820465;
+  color: hsl(195, 55%, 75%);
+  background-color: hsl(15, 55%, 25%);
+  border: 1px solid hsl(285, 50%, 50%);
+  margin: 15px 15px 0px 15px;
+  padding: 0px 18px;
+  border-radius: 3px 3px;
+  box-shadow: 0px 0px 6px rgba(225, 195, 165, 0.7);
+  transform: rotate(15deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box736 {
+  --cssB-v-736: 828384;
+  color: hsl(232, 68%, 32%);
+  background-color: hsl(52, 68%, 68%);
+  border: 2px solid hsl(322, 50%, 50%);
+  margin: 16px 18px 5px 4px;
+  padding: 1px 20px;
+  border-radius: 4px 5px;
+  box-shadow: 1px 1px 7px rgba(226, 197, 168, 0.8);
+  transform: rotate(16deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box737 {
+  --cssB-v-737: 836303;
+  color: hsl(269, 81%, 39%);
+  background-color: hsl(89, 81%, 61%);
+  border: 3px solid hsl(359, 50%, 50%);
+  margin: 17px 21px 10px 11px;
+  padding: 2px 0px;
+  border-radius: 5px 7px;
+  box-shadow: 2px 2px 8px rgba(227, 199, 171, 0.9);
+  transform: rotate(17deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box738 {
+  --cssB-v-738: 844222;
+  color: hsl(306, 94%, 46%);
+  background-color: hsl(126, 94%, 54%);
+  border: 4px solid hsl(36, 50%, 50%);
+  margin: 18px 24px 15px 0px;
+  padding: 3px 2px;
+  border-radius: 6px 0px;
+  box-shadow: 3px 3px 0px rgba(228, 201, 174, 0.1);
+  transform: rotate(18deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box739 {
+  --cssB-v-739: 852141;
+  color: hsl(343, 7%, 53%);
+  background-color: hsl(163, 7%, 47%);
+  border: 5px solid hsl(73, 50%, 50%);
+  margin: 19px 27px 20px 7px;
+  padding: 4px 4px;
+  border-radius: 7px 2px;
+  box-shadow: 4px 4px 1px rgba(229, 203, 177, 0.2);
+  transform: rotate(19deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box740 {
+  --cssB-v-740: 860060;
+  color: hsl(20, 20%, 60%);
+  background-color: hsl(200, 20%, 40%);
+  border: 1px solid hsl(110, 50%, 50%);
+  margin: 0px 0px 0px 14px;
+  padding: 5px 6px;
+  border-radius: 8px 4px;
+  box-shadow: 0px 5px 2px rgba(230, 205, 180, 0.3);
+  transform: rotate(20deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box741 {
+  --cssB-v-741: 867979;
+  color: hsl(57, 33%, 67%);
+  background-color: hsl(237, 33%, 33%);
+  border: 2px solid hsl(147, 50%, 50%);
+  margin: 1px 3px 5px 3px;
+  padding: 6px 8px;
+  border-radius: 9px 6px;
+  box-shadow: 1px 6px 3px rgba(231, 207, 183, 0.4);
+  transform: rotate(21deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box742 {
+  --cssB-v-742: 875898;
+  color: hsl(94, 46%, 74%);
+  background-color: hsl(274, 46%, 26%);
+  border: 3px solid hsl(184, 50%, 50%);
+  margin: 2px 6px 10px 10px;
+  padding: 7px 10px;
+  border-radius: 10px 8px;
+  box-shadow: 2px 0px 4px rgba(232, 209, 186, 0.5);
+  transform: rotate(22deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box743 {
+  --cssB-v-743: 883817;
+  color: hsl(131, 59%, 31%);
+  background-color: hsl(311, 59%, 69%);
+  border: 4px solid hsl(221, 50%, 50%);
+  margin: 3px 9px 15px 17px;
+  padding: 8px 12px;
+  border-radius: 11px 1px;
+  box-shadow: 3px 1px 5px rgba(233, 211, 189, 0.6);
+  transform: rotate(23deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box744 {
+  --cssB-v-744: 891736;
+  color: hsl(168, 72%, 38%);
+  background-color: hsl(348, 72%, 62%);
+  border: 5px solid hsl(258, 50%, 50%);
+  margin: 4px 12px 20px 6px;
+  padding: 9px 14px;
+  border-radius: 0px 3px;
+  box-shadow: 4px 2px 6px rgba(234, 213, 192, 0.7);
+  transform: rotate(24deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box745 {
+  --cssB-v-745: 899655;
+  color: hsl(205, 85%, 45%);
+  background-color: hsl(25, 85%, 55%);
+  border: 1px solid hsl(295, 50%, 50%);
+  margin: 5px 15px 0px 13px;
+  padding: 10px 16px;
+  border-radius: 1px 5px;
+  box-shadow: 0px 3px 7px rgba(235, 215, 195, 0.8);
+  transform: rotate(25deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box746 {
+  --cssB-v-746: 907574;
+  color: hsl(242, 98%, 52%);
+  background-color: hsl(62, 98%, 48%);
+  border: 2px solid hsl(332, 50%, 50%);
+  margin: 6px 18px 5px 2px;
+  padding: 11px 18px;
+  border-radius: 2px 7px;
+  box-shadow: 1px 4px 8px rgba(236, 217, 198, 0.9);
+  transform: rotate(26deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box747 {
+  --cssB-v-747: 915493;
+  color: hsl(279, 11%, 59%);
+  background-color: hsl(99, 11%, 41%);
+  border: 3px solid hsl(9, 50%, 50%);
+  margin: 7px 21px 10px 9px;
+  padding: 12px 20px;
+  border-radius: 3px 0px;
+  box-shadow: 2px 5px 0px rgba(237, 219, 201, 0.1);
+  transform: rotate(27deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box748 {
+  --cssB-v-748: 923412;
+  color: hsl(316, 24%, 66%);
+  background-color: hsl(136, 24%, 34%);
+  border: 4px solid hsl(46, 50%, 50%);
+  margin: 8px 24px 15px 16px;
+  padding: 13px 0px;
+  border-radius: 4px 2px;
+  box-shadow: 3px 6px 1px rgba(238, 221, 204, 0.2);
+  transform: rotate(28deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box749 {
+  --cssB-v-749: 931331;
+  color: hsl(353, 37%, 73%);
+  background-color: hsl(173, 37%, 27%);
+  border: 5px solid hsl(83, 50%, 50%);
+  margin: 9px 27px 20px 5px;
+  padding: 14px 2px;
+  border-radius: 5px 4px;
+  box-shadow: 4px 0px 2px rgba(239, 223, 207, 0.3);
+  transform: rotate(29deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box750 {
+  --cssB-v-750: 939250;
+  color: hsl(30, 50%, 30%);
+  background-color: hsl(210, 50%, 70%);
+  border: 1px solid hsl(120, 50%, 50%);
+  margin: 10px 0px 0px 12px;
+  padding: 0px 4px;
+  border-radius: 6px 6px;
+  box-shadow: 0px 1px 3px rgba(240, 225, 210, 0.4);
+  transform: rotate(30deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box751 {
+  --cssB-v-751: 947169;
+  color: hsl(67, 63%, 37%);
+  background-color: hsl(247, 63%, 63%);
+  border: 2px solid hsl(157, 50%, 50%);
+  margin: 11px 3px 5px 1px;
+  padding: 1px 6px;
+  border-radius: 7px 8px;
+  box-shadow: 1px 2px 4px rgba(241, 227, 213, 0.5);
+  transform: rotate(31deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box752 {
+  --cssB-v-752: 955088;
+  color: hsl(104, 76%, 44%);
+  background-color: hsl(284, 76%, 56%);
+  border: 3px solid hsl(194, 50%, 50%);
+  margin: 12px 6px 10px 8px;
+  padding: 2px 8px;
+  border-radius: 8px 1px;
+  box-shadow: 2px 3px 5px rgba(242, 229, 216, 0.6);
+  transform: rotate(32deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box753 {
+  --cssB-v-753: 963007;
+  color: hsl(141, 89%, 51%);
+  background-color: hsl(321, 89%, 49%);
+  border: 4px solid hsl(231, 50%, 50%);
+  margin: 13px 9px 15px 15px;
+  padding: 3px 10px;
+  border-radius: 9px 3px;
+  box-shadow: 3px 4px 6px rgba(243, 231, 219, 0.7);
+  transform: rotate(33deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box754 {
+  --cssB-v-754: 970926;
+  color: hsl(178, 2%, 58%);
+  background-color: hsl(358, 2%, 42%);
+  border: 5px solid hsl(268, 50%, 50%);
+  margin: 14px 12px 20px 4px;
+  padding: 4px 12px;
+  border-radius: 10px 5px;
+  box-shadow: 4px 5px 7px rgba(244, 233, 222, 0.8);
+  transform: rotate(34deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box755 {
+  --cssB-v-755: 978845;
+  color: hsl(215, 15%, 65%);
+  background-color: hsl(35, 15%, 35%);
+  border: 1px solid hsl(305, 50%, 50%);
+  margin: 15px 15px 0px 11px;
+  padding: 5px 14px;
+  border-radius: 11px 7px;
+  box-shadow: 0px 6px 8px rgba(245, 235, 225, 0.9);
+  transform: rotate(35deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box756 {
+  --cssB-v-756: 986764;
+  color: hsl(252, 28%, 72%);
+  background-color: hsl(72, 28%, 28%);
+  border: 2px solid hsl(342, 50%, 50%);
+  margin: 16px 18px 5px 0px;
+  padding: 6px 16px;
+  border-radius: 0px 0px;
+  box-shadow: 1px 0px 0px rgba(246, 237, 228, 0.1);
+  transform: rotate(36deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box757 {
+  --cssB-v-757: 994683;
+  color: hsl(289, 41%, 79%);
+  background-color: hsl(109, 41%, 21%);
+  border: 3px solid hsl(19, 50%, 50%);
+  margin: 17px 21px 10px 7px;
+  padding: 7px 18px;
+  border-radius: 1px 2px;
+  box-shadow: 2px 1px 1px rgba(247, 239, 231, 0.2);
+  transform: rotate(37deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box758 {
+  --cssB-v-758: 2602;
+  color: hsl(326, 54%, 36%);
+  background-color: hsl(146, 54%, 64%);
+  border: 4px solid hsl(56, 50%, 50%);
+  margin: 18px 24px 15px 14px;
+  padding: 8px 20px;
+  border-radius: 2px 4px;
+  box-shadow: 3px 2px 2px rgba(248, 241, 234, 0.3);
+  transform: rotate(38deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box759 {
+  --cssB-v-759: 10521;
+  color: hsl(3, 67%, 43%);
+  background-color: hsl(183, 67%, 57%);
+  border: 5px solid hsl(93, 50%, 50%);
+  margin: 19px 27px 20px 3px;
+  padding: 9px 0px;
+  border-radius: 3px 6px;
+  box-shadow: 4px 3px 3px rgba(249, 243, 237, 0.4);
+  transform: rotate(39deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box760 {
+  --cssB-v-760: 18440;
+  color: hsl(40, 80%, 50%);
+  background-color: hsl(220, 80%, 50%);
+  border: 1px solid hsl(130, 50%, 50%);
+  margin: 0px 0px 0px 10px;
+  padding: 10px 2px;
+  border-radius: 4px 8px;
+  box-shadow: 0px 4px 4px rgba(250, 245, 240, 0.5);
+  transform: rotate(40deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box761 {
+  --cssB-v-761: 26359;
+  color: hsl(77, 93%, 57%);
+  background-color: hsl(257, 93%, 43%);
+  border: 2px solid hsl(167, 50%, 50%);
+  margin: 1px 3px 5px 17px;
+  padding: 11px 4px;
+  border-radius: 5px 1px;
+  box-shadow: 1px 5px 5px rgba(251, 247, 243, 0.6);
+  transform: rotate(41deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box762 {
+  --cssB-v-762: 34278;
+  color: hsl(114, 6%, 64%);
+  background-color: hsl(294, 6%, 36%);
+  border: 3px solid hsl(204, 50%, 50%);
+  margin: 2px 6px 10px 6px;
+  padding: 12px 6px;
+  border-radius: 6px 3px;
+  box-shadow: 2px 6px 6px rgba(252, 249, 246, 0.7);
+  transform: rotate(42deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box763 {
+  --cssB-v-763: 42197;
+  color: hsl(151, 19%, 71%);
+  background-color: hsl(331, 19%, 29%);
+  border: 4px solid hsl(241, 50%, 50%);
+  margin: 3px 9px 15px 13px;
+  padding: 13px 8px;
+  border-radius: 7px 5px;
+  box-shadow: 3px 0px 7px rgba(253, 251, 249, 0.8);
+  transform: rotate(43deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box764 {
+  --cssB-v-764: 50116;
+  color: hsl(188, 32%, 78%);
+  background-color: hsl(8, 32%, 22%);
+  border: 5px solid hsl(278, 50%, 50%);
+  margin: 4px 12px 20px 2px;
+  padding: 14px 10px;
+  border-radius: 8px 7px;
+  box-shadow: 4px 1px 8px rgba(254, 253, 252, 0.9);
+  transform: rotate(44deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box765 {
+  --cssB-v-765: 58035;
+  color: hsl(225, 45%, 35%);
+  background-color: hsl(45, 45%, 65%);
+  border: 1px solid hsl(315, 50%, 50%);
+  margin: 5px 15px 0px 9px;
+  padding: 0px 12px;
+  border-radius: 9px 0px;
+  box-shadow: 0px 2px 0px rgba(0, 0, 0, 0.1);
+  transform: rotate(45deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box766 {
+  --cssB-v-766: 65954;
+  color: hsl(262, 58%, 42%);
+  background-color: hsl(82, 58%, 58%);
+  border: 2px solid hsl(352, 50%, 50%);
+  margin: 6px 18px 5px 16px;
+  padding: 1px 14px;
+  border-radius: 10px 2px;
+  box-shadow: 1px 3px 1px rgba(1, 2, 3, 0.2);
+  transform: rotate(46deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssB_box767 {
+  --cssB-v-767: 73873;
+  color: hsl(299, 71%, 49%);
+  background-color: hsl(119, 71%, 51%);
+  border: 3px solid hsl(29, 50%, 50%);
+  margin: 7px 21px 10px 5px;
+  padding: 2px 16px;
+  border-radius: 11px 4px;
+  box-shadow: 2px 4px 2px rgba(2, 4, 6, 0.3);
+  transform: rotate(47deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssB_box768 {
+  --cssB-v-768: 81792;
+  color: hsl(336, 84%, 56%);
+  background-color: hsl(156, 84%, 44%);
+  border: 4px solid hsl(66, 50%, 50%);
+  margin: 8px 24px 15px 12px;
+  padding: 3px 18px;
+  border-radius: 0px 6px;
+  box-shadow: 3px 5px 3px rgba(3, 6, 9, 0.4);
+  transform: rotate(48deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssB_box769 {
+  --cssB-v-769: 89711;
+  color: hsl(13, 97%, 63%);
+  background-color: hsl(193, 97%, 37%);
+  border: 5px solid hsl(103, 50%, 50%);
+  margin: 9px 27px 20px 1px;
+  padding: 4px 20px;
+  border-radius: 1px 8px;
+  box-shadow: 4px 6px 4px rgba(4, 8, 12, 0.5);
+  transform: rotate(49deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssB_box770 {
+  --cssB-v-770: 97630;
+  color: hsl(50, 10%, 70%);
+  background-color: hsl(230, 10%, 30%);
+  border: 1px solid hsl(140, 50%, 50%);
+  margin: 10px 0px 0px 8px;
+  padding: 5px 0px;
+  border-radius: 2px 1px;
+  box-shadow: 0px 0px 5px rgba(5, 10, 15, 0.6);
+  transform: rotate(50deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssB_box771 {
+  --cssB-v-771: 105549;
+  color: hsl(87, 23%, 77%);
+  background-color: hsl(267, 23%, 23%);
+  border: 2px solid hsl(177, 50%, 50%);
+  margin: 11px 3px 5px 15px;
+  padding: 6px 2px;
+  border-radius: 3px 3px;
+  box-shadow: 1px 1px 6px rgba(6, 12, 18, 0.7);
+  transform: rotate(51deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssB_box772 {
+  --cssB-v-772: 113468;
+  color: hsl(124, 36%, 34%);
+  background-color: hsl(304, 36%, 66%);
+  border: 3px solid hsl(214, 50%, 50%);
+  margin: 12px 6px 10px 4px;
+  padding: 7px 4px;
+  border-radius: 4px 5px;
+  box-shadow: 2px 2px 7px rgba(7, 14, 21, 0.8);
+  transform: rotate(52deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssB_box773 {
+  --cssB-v-773: 121387;
+  color: hsl(161, 49%, 41%);
+  background-color: hsl(341, 49%, 59%);
+  border: 4px solid hsl(251, 50%, 50%);
+  margin: 13px 9px 15px 11px;
+  padding: 8px 6px;
+  border-radius: 5px 7px;
+  box-shadow: 3px 3px 8px rgba(8, 16, 24, 0.9);
+  transform: rotate(53deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssB_box774 {
+  --cssB-v-774: 129306;
+  color: hsl(198, 62%, 48%);
+  background-color: hsl(18, 62%, 52%);
+  border: 5px solid hsl(288, 50%, 50%);
+  margin: 14px 12px 20px 0px;
+  padding: 9px 8px;
+  border-radius: 6px 0px;
+  box-shadow: 4px 4px 0px rgba(9, 18, 27, 0.1);
+  transform: rotate(54deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssB_box775 {
+  --cssB-v-775: 137225;
+  color: hsl(235, 75%, 55%);
+  background-color: hsl(55, 75%, 45%);
+  border: 1px solid hsl(325, 50%, 50%);
+  margin: 15px 15px 0px 7px;
+  padding: 10px 10px;
+  border-radius: 7px 2px;
+  box-shadow: 0px 5px 1px rgba(10, 20, 30, 0.2);
+  transform: rotate(55deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}

--- a/app/javascript/components/css-demo/cssShared.css
+++ b/app/javascript/components/css-demo/cssShared.css
@@ -1,0 +1,11358 @@
+/* cssShared ~300KB */
+.cssShared_sentinel::after { content: "SENTINEL_CSSSHARED"; }
+.cssShared_marker { outline-style: solid; outline-width: 7px; outline-color: hsl(119,80%,40%); }
+.cssShared_box0 {
+  --cssShared-v-0: 0;
+  color: hsl(0, 0%, 30%);
+  background-color: hsl(180, 0%, 70%);
+  border: 1px solid hsl(90, 50%, 50%);
+  margin: 0px 0px 0px 0px;
+  padding: 0px 0px;
+  border-radius: 0px 0px;
+  box-shadow: 0px 0px 0px rgba(0, 0, 0, 0.1);
+  transform: rotate(0deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box1 {
+  --cssShared-v-1: 7919;
+  color: hsl(37, 13%, 37%);
+  background-color: hsl(217, 13%, 63%);
+  border: 2px solid hsl(127, 50%, 50%);
+  margin: 1px 3px 5px 7px;
+  padding: 1px 2px;
+  border-radius: 1px 2px;
+  box-shadow: 1px 1px 1px rgba(1, 2, 3, 0.2);
+  transform: rotate(1deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box2 {
+  --cssShared-v-2: 15838;
+  color: hsl(74, 26%, 44%);
+  background-color: hsl(254, 26%, 56%);
+  border: 3px solid hsl(164, 50%, 50%);
+  margin: 2px 6px 10px 14px;
+  padding: 2px 4px;
+  border-radius: 2px 4px;
+  box-shadow: 2px 2px 2px rgba(2, 4, 6, 0.3);
+  transform: rotate(2deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box3 {
+  --cssShared-v-3: 23757;
+  color: hsl(111, 39%, 51%);
+  background-color: hsl(291, 39%, 49%);
+  border: 4px solid hsl(201, 50%, 50%);
+  margin: 3px 9px 15px 3px;
+  padding: 3px 6px;
+  border-radius: 3px 6px;
+  box-shadow: 3px 3px 3px rgba(3, 6, 9, 0.4);
+  transform: rotate(3deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box4 {
+  --cssShared-v-4: 31676;
+  color: hsl(148, 52%, 58%);
+  background-color: hsl(328, 52%, 42%);
+  border: 5px solid hsl(238, 50%, 50%);
+  margin: 4px 12px 20px 10px;
+  padding: 4px 8px;
+  border-radius: 4px 8px;
+  box-shadow: 4px 4px 4px rgba(4, 8, 12, 0.5);
+  transform: rotate(4deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box5 {
+  --cssShared-v-5: 39595;
+  color: hsl(185, 65%, 65%);
+  background-color: hsl(5, 65%, 35%);
+  border: 1px solid hsl(275, 50%, 50%);
+  margin: 5px 15px 0px 17px;
+  padding: 5px 10px;
+  border-radius: 5px 1px;
+  box-shadow: 0px 5px 5px rgba(5, 10, 15, 0.6);
+  transform: rotate(5deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box6 {
+  --cssShared-v-6: 47514;
+  color: hsl(222, 78%, 72%);
+  background-color: hsl(42, 78%, 28%);
+  border: 2px solid hsl(312, 50%, 50%);
+  margin: 6px 18px 5px 6px;
+  padding: 6px 12px;
+  border-radius: 6px 3px;
+  box-shadow: 1px 6px 6px rgba(6, 12, 18, 0.7);
+  transform: rotate(6deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box7 {
+  --cssShared-v-7: 55433;
+  color: hsl(259, 91%, 79%);
+  background-color: hsl(79, 91%, 21%);
+  border: 3px solid hsl(349, 50%, 50%);
+  margin: 7px 21px 10px 13px;
+  padding: 7px 14px;
+  border-radius: 7px 5px;
+  box-shadow: 2px 0px 7px rgba(7, 14, 21, 0.8);
+  transform: rotate(7deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box8 {
+  --cssShared-v-8: 63352;
+  color: hsl(296, 4%, 36%);
+  background-color: hsl(116, 4%, 64%);
+  border: 4px solid hsl(26, 50%, 50%);
+  margin: 8px 24px 15px 2px;
+  padding: 8px 16px;
+  border-radius: 8px 7px;
+  box-shadow: 3px 1px 8px rgba(8, 16, 24, 0.9);
+  transform: rotate(8deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box9 {
+  --cssShared-v-9: 71271;
+  color: hsl(333, 17%, 43%);
+  background-color: hsl(153, 17%, 57%);
+  border: 5px solid hsl(63, 50%, 50%);
+  margin: 9px 27px 20px 9px;
+  padding: 9px 18px;
+  border-radius: 9px 0px;
+  box-shadow: 4px 2px 0px rgba(9, 18, 27, 0.1);
+  transform: rotate(9deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box10 {
+  --cssShared-v-10: 79190;
+  color: hsl(10, 30%, 50%);
+  background-color: hsl(190, 30%, 50%);
+  border: 1px solid hsl(100, 50%, 50%);
+  margin: 10px 0px 0px 16px;
+  padding: 10px 20px;
+  border-radius: 10px 2px;
+  box-shadow: 0px 3px 1px rgba(10, 20, 30, 0.2);
+  transform: rotate(10deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box11 {
+  --cssShared-v-11: 87109;
+  color: hsl(47, 43%, 57%);
+  background-color: hsl(227, 43%, 43%);
+  border: 2px solid hsl(137, 50%, 50%);
+  margin: 11px 3px 5px 5px;
+  padding: 11px 0px;
+  border-radius: 11px 4px;
+  box-shadow: 1px 4px 2px rgba(11, 22, 33, 0.3);
+  transform: rotate(11deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box12 {
+  --cssShared-v-12: 95028;
+  color: hsl(84, 56%, 64%);
+  background-color: hsl(264, 56%, 36%);
+  border: 3px solid hsl(174, 50%, 50%);
+  margin: 12px 6px 10px 12px;
+  padding: 12px 2px;
+  border-radius: 0px 6px;
+  box-shadow: 2px 5px 3px rgba(12, 24, 36, 0.4);
+  transform: rotate(12deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box13 {
+  --cssShared-v-13: 102947;
+  color: hsl(121, 69%, 71%);
+  background-color: hsl(301, 69%, 29%);
+  border: 4px solid hsl(211, 50%, 50%);
+  margin: 13px 9px 15px 1px;
+  padding: 13px 4px;
+  border-radius: 1px 8px;
+  box-shadow: 3px 6px 4px rgba(13, 26, 39, 0.5);
+  transform: rotate(13deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box14 {
+  --cssShared-v-14: 110866;
+  color: hsl(158, 82%, 78%);
+  background-color: hsl(338, 82%, 22%);
+  border: 5px solid hsl(248, 50%, 50%);
+  margin: 14px 12px 20px 8px;
+  padding: 14px 6px;
+  border-radius: 2px 1px;
+  box-shadow: 4px 0px 5px rgba(14, 28, 42, 0.6);
+  transform: rotate(14deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box15 {
+  --cssShared-v-15: 118785;
+  color: hsl(195, 95%, 35%);
+  background-color: hsl(15, 95%, 65%);
+  border: 1px solid hsl(285, 50%, 50%);
+  margin: 15px 15px 0px 15px;
+  padding: 0px 8px;
+  border-radius: 3px 3px;
+  box-shadow: 0px 1px 6px rgba(15, 30, 45, 0.7);
+  transform: rotate(15deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box16 {
+  --cssShared-v-16: 126704;
+  color: hsl(232, 8%, 42%);
+  background-color: hsl(52, 8%, 58%);
+  border: 2px solid hsl(322, 50%, 50%);
+  margin: 16px 18px 5px 4px;
+  padding: 1px 10px;
+  border-radius: 4px 5px;
+  box-shadow: 1px 2px 7px rgba(16, 32, 48, 0.8);
+  transform: rotate(16deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box17 {
+  --cssShared-v-17: 134623;
+  color: hsl(269, 21%, 49%);
+  background-color: hsl(89, 21%, 51%);
+  border: 3px solid hsl(359, 50%, 50%);
+  margin: 17px 21px 10px 11px;
+  padding: 2px 12px;
+  border-radius: 5px 7px;
+  box-shadow: 2px 3px 8px rgba(17, 34, 51, 0.9);
+  transform: rotate(17deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box18 {
+  --cssShared-v-18: 142542;
+  color: hsl(306, 34%, 56%);
+  background-color: hsl(126, 34%, 44%);
+  border: 4px solid hsl(36, 50%, 50%);
+  margin: 18px 24px 15px 0px;
+  padding: 3px 14px;
+  border-radius: 6px 0px;
+  box-shadow: 3px 4px 0px rgba(18, 36, 54, 0.1);
+  transform: rotate(18deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box19 {
+  --cssShared-v-19: 150461;
+  color: hsl(343, 47%, 63%);
+  background-color: hsl(163, 47%, 37%);
+  border: 5px solid hsl(73, 50%, 50%);
+  margin: 19px 27px 20px 7px;
+  padding: 4px 16px;
+  border-radius: 7px 2px;
+  box-shadow: 4px 5px 1px rgba(19, 38, 57, 0.2);
+  transform: rotate(19deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box20 {
+  --cssShared-v-20: 158380;
+  color: hsl(20, 60%, 70%);
+  background-color: hsl(200, 60%, 30%);
+  border: 1px solid hsl(110, 50%, 50%);
+  margin: 0px 0px 0px 14px;
+  padding: 5px 18px;
+  border-radius: 8px 4px;
+  box-shadow: 0px 6px 2px rgba(20, 40, 60, 0.3);
+  transform: rotate(20deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box21 {
+  --cssShared-v-21: 166299;
+  color: hsl(57, 73%, 77%);
+  background-color: hsl(237, 73%, 23%);
+  border: 2px solid hsl(147, 50%, 50%);
+  margin: 1px 3px 5px 3px;
+  padding: 6px 20px;
+  border-radius: 9px 6px;
+  box-shadow: 1px 0px 3px rgba(21, 42, 63, 0.4);
+  transform: rotate(21deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box22 {
+  --cssShared-v-22: 174218;
+  color: hsl(94, 86%, 34%);
+  background-color: hsl(274, 86%, 66%);
+  border: 3px solid hsl(184, 50%, 50%);
+  margin: 2px 6px 10px 10px;
+  padding: 7px 0px;
+  border-radius: 10px 8px;
+  box-shadow: 2px 1px 4px rgba(22, 44, 66, 0.5);
+  transform: rotate(22deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box23 {
+  --cssShared-v-23: 182137;
+  color: hsl(131, 99%, 41%);
+  background-color: hsl(311, 99%, 59%);
+  border: 4px solid hsl(221, 50%, 50%);
+  margin: 3px 9px 15px 17px;
+  padding: 8px 2px;
+  border-radius: 11px 1px;
+  box-shadow: 3px 2px 5px rgba(23, 46, 69, 0.6);
+  transform: rotate(23deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box24 {
+  --cssShared-v-24: 190056;
+  color: hsl(168, 12%, 48%);
+  background-color: hsl(348, 12%, 52%);
+  border: 5px solid hsl(258, 50%, 50%);
+  margin: 4px 12px 20px 6px;
+  padding: 9px 4px;
+  border-radius: 0px 3px;
+  box-shadow: 4px 3px 6px rgba(24, 48, 72, 0.7);
+  transform: rotate(24deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box25 {
+  --cssShared-v-25: 197975;
+  color: hsl(205, 25%, 55%);
+  background-color: hsl(25, 25%, 45%);
+  border: 1px solid hsl(295, 50%, 50%);
+  margin: 5px 15px 0px 13px;
+  padding: 10px 6px;
+  border-radius: 1px 5px;
+  box-shadow: 0px 4px 7px rgba(25, 50, 75, 0.8);
+  transform: rotate(25deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box26 {
+  --cssShared-v-26: 205894;
+  color: hsl(242, 38%, 62%);
+  background-color: hsl(62, 38%, 38%);
+  border: 2px solid hsl(332, 50%, 50%);
+  margin: 6px 18px 5px 2px;
+  padding: 11px 8px;
+  border-radius: 2px 7px;
+  box-shadow: 1px 5px 8px rgba(26, 52, 78, 0.9);
+  transform: rotate(26deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box27 {
+  --cssShared-v-27: 213813;
+  color: hsl(279, 51%, 69%);
+  background-color: hsl(99, 51%, 31%);
+  border: 3px solid hsl(9, 50%, 50%);
+  margin: 7px 21px 10px 9px;
+  padding: 12px 10px;
+  border-radius: 3px 0px;
+  box-shadow: 2px 6px 0px rgba(27, 54, 81, 0.1);
+  transform: rotate(27deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box28 {
+  --cssShared-v-28: 221732;
+  color: hsl(316, 64%, 76%);
+  background-color: hsl(136, 64%, 24%);
+  border: 4px solid hsl(46, 50%, 50%);
+  margin: 8px 24px 15px 16px;
+  padding: 13px 12px;
+  border-radius: 4px 2px;
+  box-shadow: 3px 0px 1px rgba(28, 56, 84, 0.2);
+  transform: rotate(28deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box29 {
+  --cssShared-v-29: 229651;
+  color: hsl(353, 77%, 33%);
+  background-color: hsl(173, 77%, 67%);
+  border: 5px solid hsl(83, 50%, 50%);
+  margin: 9px 27px 20px 5px;
+  padding: 14px 14px;
+  border-radius: 5px 4px;
+  box-shadow: 4px 1px 2px rgba(29, 58, 87, 0.3);
+  transform: rotate(29deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box30 {
+  --cssShared-v-30: 237570;
+  color: hsl(30, 90%, 40%);
+  background-color: hsl(210, 90%, 60%);
+  border: 1px solid hsl(120, 50%, 50%);
+  margin: 10px 0px 0px 12px;
+  padding: 0px 16px;
+  border-radius: 6px 6px;
+  box-shadow: 0px 2px 3px rgba(30, 60, 90, 0.4);
+  transform: rotate(30deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box31 {
+  --cssShared-v-31: 245489;
+  color: hsl(67, 3%, 47%);
+  background-color: hsl(247, 3%, 53%);
+  border: 2px solid hsl(157, 50%, 50%);
+  margin: 11px 3px 5px 1px;
+  padding: 1px 18px;
+  border-radius: 7px 8px;
+  box-shadow: 1px 3px 4px rgba(31, 62, 93, 0.5);
+  transform: rotate(31deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box32 {
+  --cssShared-v-32: 253408;
+  color: hsl(104, 16%, 54%);
+  background-color: hsl(284, 16%, 46%);
+  border: 3px solid hsl(194, 50%, 50%);
+  margin: 12px 6px 10px 8px;
+  padding: 2px 20px;
+  border-radius: 8px 1px;
+  box-shadow: 2px 4px 5px rgba(32, 64, 96, 0.6);
+  transform: rotate(32deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box33 {
+  --cssShared-v-33: 261327;
+  color: hsl(141, 29%, 61%);
+  background-color: hsl(321, 29%, 39%);
+  border: 4px solid hsl(231, 50%, 50%);
+  margin: 13px 9px 15px 15px;
+  padding: 3px 0px;
+  border-radius: 9px 3px;
+  box-shadow: 3px 5px 6px rgba(33, 66, 99, 0.7);
+  transform: rotate(33deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box34 {
+  --cssShared-v-34: 269246;
+  color: hsl(178, 42%, 68%);
+  background-color: hsl(358, 42%, 32%);
+  border: 5px solid hsl(268, 50%, 50%);
+  margin: 14px 12px 20px 4px;
+  padding: 4px 2px;
+  border-radius: 10px 5px;
+  box-shadow: 4px 6px 7px rgba(34, 68, 102, 0.8);
+  transform: rotate(34deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box35 {
+  --cssShared-v-35: 277165;
+  color: hsl(215, 55%, 75%);
+  background-color: hsl(35, 55%, 25%);
+  border: 1px solid hsl(305, 50%, 50%);
+  margin: 15px 15px 0px 11px;
+  padding: 5px 4px;
+  border-radius: 11px 7px;
+  box-shadow: 0px 0px 8px rgba(35, 70, 105, 0.9);
+  transform: rotate(35deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box36 {
+  --cssShared-v-36: 285084;
+  color: hsl(252, 68%, 32%);
+  background-color: hsl(72, 68%, 68%);
+  border: 2px solid hsl(342, 50%, 50%);
+  margin: 16px 18px 5px 0px;
+  padding: 6px 6px;
+  border-radius: 0px 0px;
+  box-shadow: 1px 1px 0px rgba(36, 72, 108, 0.1);
+  transform: rotate(36deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box37 {
+  --cssShared-v-37: 293003;
+  color: hsl(289, 81%, 39%);
+  background-color: hsl(109, 81%, 61%);
+  border: 3px solid hsl(19, 50%, 50%);
+  margin: 17px 21px 10px 7px;
+  padding: 7px 8px;
+  border-radius: 1px 2px;
+  box-shadow: 2px 2px 1px rgba(37, 74, 111, 0.2);
+  transform: rotate(37deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box38 {
+  --cssShared-v-38: 300922;
+  color: hsl(326, 94%, 46%);
+  background-color: hsl(146, 94%, 54%);
+  border: 4px solid hsl(56, 50%, 50%);
+  margin: 18px 24px 15px 14px;
+  padding: 8px 10px;
+  border-radius: 2px 4px;
+  box-shadow: 3px 3px 2px rgba(38, 76, 114, 0.3);
+  transform: rotate(38deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box39 {
+  --cssShared-v-39: 308841;
+  color: hsl(3, 7%, 53%);
+  background-color: hsl(183, 7%, 47%);
+  border: 5px solid hsl(93, 50%, 50%);
+  margin: 19px 27px 20px 3px;
+  padding: 9px 12px;
+  border-radius: 3px 6px;
+  box-shadow: 4px 4px 3px rgba(39, 78, 117, 0.4);
+  transform: rotate(39deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box40 {
+  --cssShared-v-40: 316760;
+  color: hsl(40, 20%, 60%);
+  background-color: hsl(220, 20%, 40%);
+  border: 1px solid hsl(130, 50%, 50%);
+  margin: 0px 0px 0px 10px;
+  padding: 10px 14px;
+  border-radius: 4px 8px;
+  box-shadow: 0px 5px 4px rgba(40, 80, 120, 0.5);
+  transform: rotate(40deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box41 {
+  --cssShared-v-41: 324679;
+  color: hsl(77, 33%, 67%);
+  background-color: hsl(257, 33%, 33%);
+  border: 2px solid hsl(167, 50%, 50%);
+  margin: 1px 3px 5px 17px;
+  padding: 11px 16px;
+  border-radius: 5px 1px;
+  box-shadow: 1px 6px 5px rgba(41, 82, 123, 0.6);
+  transform: rotate(41deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box42 {
+  --cssShared-v-42: 332598;
+  color: hsl(114, 46%, 74%);
+  background-color: hsl(294, 46%, 26%);
+  border: 3px solid hsl(204, 50%, 50%);
+  margin: 2px 6px 10px 6px;
+  padding: 12px 18px;
+  border-radius: 6px 3px;
+  box-shadow: 2px 0px 6px rgba(42, 84, 126, 0.7);
+  transform: rotate(42deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box43 {
+  --cssShared-v-43: 340517;
+  color: hsl(151, 59%, 31%);
+  background-color: hsl(331, 59%, 69%);
+  border: 4px solid hsl(241, 50%, 50%);
+  margin: 3px 9px 15px 13px;
+  padding: 13px 20px;
+  border-radius: 7px 5px;
+  box-shadow: 3px 1px 7px rgba(43, 86, 129, 0.8);
+  transform: rotate(43deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box44 {
+  --cssShared-v-44: 348436;
+  color: hsl(188, 72%, 38%);
+  background-color: hsl(8, 72%, 62%);
+  border: 5px solid hsl(278, 50%, 50%);
+  margin: 4px 12px 20px 2px;
+  padding: 14px 0px;
+  border-radius: 8px 7px;
+  box-shadow: 4px 2px 8px rgba(44, 88, 132, 0.9);
+  transform: rotate(44deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box45 {
+  --cssShared-v-45: 356355;
+  color: hsl(225, 85%, 45%);
+  background-color: hsl(45, 85%, 55%);
+  border: 1px solid hsl(315, 50%, 50%);
+  margin: 5px 15px 0px 9px;
+  padding: 0px 2px;
+  border-radius: 9px 0px;
+  box-shadow: 0px 3px 0px rgba(45, 90, 135, 0.1);
+  transform: rotate(45deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box46 {
+  --cssShared-v-46: 364274;
+  color: hsl(262, 98%, 52%);
+  background-color: hsl(82, 98%, 48%);
+  border: 2px solid hsl(352, 50%, 50%);
+  margin: 6px 18px 5px 16px;
+  padding: 1px 4px;
+  border-radius: 10px 2px;
+  box-shadow: 1px 4px 1px rgba(46, 92, 138, 0.2);
+  transform: rotate(46deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box47 {
+  --cssShared-v-47: 372193;
+  color: hsl(299, 11%, 59%);
+  background-color: hsl(119, 11%, 41%);
+  border: 3px solid hsl(29, 50%, 50%);
+  margin: 7px 21px 10px 5px;
+  padding: 2px 6px;
+  border-radius: 11px 4px;
+  box-shadow: 2px 5px 2px rgba(47, 94, 141, 0.3);
+  transform: rotate(47deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box48 {
+  --cssShared-v-48: 380112;
+  color: hsl(336, 24%, 66%);
+  background-color: hsl(156, 24%, 34%);
+  border: 4px solid hsl(66, 50%, 50%);
+  margin: 8px 24px 15px 12px;
+  padding: 3px 8px;
+  border-radius: 0px 6px;
+  box-shadow: 3px 6px 3px rgba(48, 96, 144, 0.4);
+  transform: rotate(48deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box49 {
+  --cssShared-v-49: 388031;
+  color: hsl(13, 37%, 73%);
+  background-color: hsl(193, 37%, 27%);
+  border: 5px solid hsl(103, 50%, 50%);
+  margin: 9px 27px 20px 1px;
+  padding: 4px 10px;
+  border-radius: 1px 8px;
+  box-shadow: 4px 0px 4px rgba(49, 98, 147, 0.5);
+  transform: rotate(49deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box50 {
+  --cssShared-v-50: 395950;
+  color: hsl(50, 50%, 30%);
+  background-color: hsl(230, 50%, 70%);
+  border: 1px solid hsl(140, 50%, 50%);
+  margin: 10px 0px 0px 8px;
+  padding: 5px 12px;
+  border-radius: 2px 1px;
+  box-shadow: 0px 1px 5px rgba(50, 100, 150, 0.6);
+  transform: rotate(50deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box51 {
+  --cssShared-v-51: 403869;
+  color: hsl(87, 63%, 37%);
+  background-color: hsl(267, 63%, 63%);
+  border: 2px solid hsl(177, 50%, 50%);
+  margin: 11px 3px 5px 15px;
+  padding: 6px 14px;
+  border-radius: 3px 3px;
+  box-shadow: 1px 2px 6px rgba(51, 102, 153, 0.7);
+  transform: rotate(51deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box52 {
+  --cssShared-v-52: 411788;
+  color: hsl(124, 76%, 44%);
+  background-color: hsl(304, 76%, 56%);
+  border: 3px solid hsl(214, 50%, 50%);
+  margin: 12px 6px 10px 4px;
+  padding: 7px 16px;
+  border-radius: 4px 5px;
+  box-shadow: 2px 3px 7px rgba(52, 104, 156, 0.8);
+  transform: rotate(52deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box53 {
+  --cssShared-v-53: 419707;
+  color: hsl(161, 89%, 51%);
+  background-color: hsl(341, 89%, 49%);
+  border: 4px solid hsl(251, 50%, 50%);
+  margin: 13px 9px 15px 11px;
+  padding: 8px 18px;
+  border-radius: 5px 7px;
+  box-shadow: 3px 4px 8px rgba(53, 106, 159, 0.9);
+  transform: rotate(53deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box54 {
+  --cssShared-v-54: 427626;
+  color: hsl(198, 2%, 58%);
+  background-color: hsl(18, 2%, 42%);
+  border: 5px solid hsl(288, 50%, 50%);
+  margin: 14px 12px 20px 0px;
+  padding: 9px 20px;
+  border-radius: 6px 0px;
+  box-shadow: 4px 5px 0px rgba(54, 108, 162, 0.1);
+  transform: rotate(54deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box55 {
+  --cssShared-v-55: 435545;
+  color: hsl(235, 15%, 65%);
+  background-color: hsl(55, 15%, 35%);
+  border: 1px solid hsl(325, 50%, 50%);
+  margin: 15px 15px 0px 7px;
+  padding: 10px 0px;
+  border-radius: 7px 2px;
+  box-shadow: 0px 6px 1px rgba(55, 110, 165, 0.2);
+  transform: rotate(55deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box56 {
+  --cssShared-v-56: 443464;
+  color: hsl(272, 28%, 72%);
+  background-color: hsl(92, 28%, 28%);
+  border: 2px solid hsl(2, 50%, 50%);
+  margin: 16px 18px 5px 14px;
+  padding: 11px 2px;
+  border-radius: 8px 4px;
+  box-shadow: 1px 0px 2px rgba(56, 112, 168, 0.3);
+  transform: rotate(56deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box57 {
+  --cssShared-v-57: 451383;
+  color: hsl(309, 41%, 79%);
+  background-color: hsl(129, 41%, 21%);
+  border: 3px solid hsl(39, 50%, 50%);
+  margin: 17px 21px 10px 3px;
+  padding: 12px 4px;
+  border-radius: 9px 6px;
+  box-shadow: 2px 1px 3px rgba(57, 114, 171, 0.4);
+  transform: rotate(57deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box58 {
+  --cssShared-v-58: 459302;
+  color: hsl(346, 54%, 36%);
+  background-color: hsl(166, 54%, 64%);
+  border: 4px solid hsl(76, 50%, 50%);
+  margin: 18px 24px 15px 10px;
+  padding: 13px 6px;
+  border-radius: 10px 8px;
+  box-shadow: 3px 2px 4px rgba(58, 116, 174, 0.5);
+  transform: rotate(58deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box59 {
+  --cssShared-v-59: 467221;
+  color: hsl(23, 67%, 43%);
+  background-color: hsl(203, 67%, 57%);
+  border: 5px solid hsl(113, 50%, 50%);
+  margin: 19px 27px 20px 17px;
+  padding: 14px 8px;
+  border-radius: 11px 1px;
+  box-shadow: 4px 3px 5px rgba(59, 118, 177, 0.6);
+  transform: rotate(59deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box60 {
+  --cssShared-v-60: 475140;
+  color: hsl(60, 80%, 50%);
+  background-color: hsl(240, 80%, 50%);
+  border: 1px solid hsl(150, 50%, 50%);
+  margin: 0px 0px 0px 6px;
+  padding: 0px 10px;
+  border-radius: 0px 3px;
+  box-shadow: 0px 4px 6px rgba(60, 120, 180, 0.7);
+  transform: rotate(60deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box61 {
+  --cssShared-v-61: 483059;
+  color: hsl(97, 93%, 57%);
+  background-color: hsl(277, 93%, 43%);
+  border: 2px solid hsl(187, 50%, 50%);
+  margin: 1px 3px 5px 13px;
+  padding: 1px 12px;
+  border-radius: 1px 5px;
+  box-shadow: 1px 5px 7px rgba(61, 122, 183, 0.8);
+  transform: rotate(61deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box62 {
+  --cssShared-v-62: 490978;
+  color: hsl(134, 6%, 64%);
+  background-color: hsl(314, 6%, 36%);
+  border: 3px solid hsl(224, 50%, 50%);
+  margin: 2px 6px 10px 2px;
+  padding: 2px 14px;
+  border-radius: 2px 7px;
+  box-shadow: 2px 6px 8px rgba(62, 124, 186, 0.9);
+  transform: rotate(62deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box63 {
+  --cssShared-v-63: 498897;
+  color: hsl(171, 19%, 71%);
+  background-color: hsl(351, 19%, 29%);
+  border: 4px solid hsl(261, 50%, 50%);
+  margin: 3px 9px 15px 9px;
+  padding: 3px 16px;
+  border-radius: 3px 0px;
+  box-shadow: 3px 0px 0px rgba(63, 126, 189, 0.1);
+  transform: rotate(63deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box64 {
+  --cssShared-v-64: 506816;
+  color: hsl(208, 32%, 78%);
+  background-color: hsl(28, 32%, 22%);
+  border: 5px solid hsl(298, 50%, 50%);
+  margin: 4px 12px 20px 16px;
+  padding: 4px 18px;
+  border-radius: 4px 2px;
+  box-shadow: 4px 1px 1px rgba(64, 128, 192, 0.2);
+  transform: rotate(64deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box65 {
+  --cssShared-v-65: 514735;
+  color: hsl(245, 45%, 35%);
+  background-color: hsl(65, 45%, 65%);
+  border: 1px solid hsl(335, 50%, 50%);
+  margin: 5px 15px 0px 5px;
+  padding: 5px 20px;
+  border-radius: 5px 4px;
+  box-shadow: 0px 2px 2px rgba(65, 130, 195, 0.3);
+  transform: rotate(65deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box66 {
+  --cssShared-v-66: 522654;
+  color: hsl(282, 58%, 42%);
+  background-color: hsl(102, 58%, 58%);
+  border: 2px solid hsl(12, 50%, 50%);
+  margin: 6px 18px 5px 12px;
+  padding: 6px 0px;
+  border-radius: 6px 6px;
+  box-shadow: 1px 3px 3px rgba(66, 132, 198, 0.4);
+  transform: rotate(66deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box67 {
+  --cssShared-v-67: 530573;
+  color: hsl(319, 71%, 49%);
+  background-color: hsl(139, 71%, 51%);
+  border: 3px solid hsl(49, 50%, 50%);
+  margin: 7px 21px 10px 1px;
+  padding: 7px 2px;
+  border-radius: 7px 8px;
+  box-shadow: 2px 4px 4px rgba(67, 134, 201, 0.5);
+  transform: rotate(67deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box68 {
+  --cssShared-v-68: 538492;
+  color: hsl(356, 84%, 56%);
+  background-color: hsl(176, 84%, 44%);
+  border: 4px solid hsl(86, 50%, 50%);
+  margin: 8px 24px 15px 8px;
+  padding: 8px 4px;
+  border-radius: 8px 1px;
+  box-shadow: 3px 5px 5px rgba(68, 136, 204, 0.6);
+  transform: rotate(68deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box69 {
+  --cssShared-v-69: 546411;
+  color: hsl(33, 97%, 63%);
+  background-color: hsl(213, 97%, 37%);
+  border: 5px solid hsl(123, 50%, 50%);
+  margin: 9px 27px 20px 15px;
+  padding: 9px 6px;
+  border-radius: 9px 3px;
+  box-shadow: 4px 6px 6px rgba(69, 138, 207, 0.7);
+  transform: rotate(69deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box70 {
+  --cssShared-v-70: 554330;
+  color: hsl(70, 10%, 70%);
+  background-color: hsl(250, 10%, 30%);
+  border: 1px solid hsl(160, 50%, 50%);
+  margin: 10px 0px 0px 4px;
+  padding: 10px 8px;
+  border-radius: 10px 5px;
+  box-shadow: 0px 0px 7px rgba(70, 140, 210, 0.8);
+  transform: rotate(70deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box71 {
+  --cssShared-v-71: 562249;
+  color: hsl(107, 23%, 77%);
+  background-color: hsl(287, 23%, 23%);
+  border: 2px solid hsl(197, 50%, 50%);
+  margin: 11px 3px 5px 11px;
+  padding: 11px 10px;
+  border-radius: 11px 7px;
+  box-shadow: 1px 1px 8px rgba(71, 142, 213, 0.9);
+  transform: rotate(71deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box72 {
+  --cssShared-v-72: 570168;
+  color: hsl(144, 36%, 34%);
+  background-color: hsl(324, 36%, 66%);
+  border: 3px solid hsl(234, 50%, 50%);
+  margin: 12px 6px 10px 0px;
+  padding: 12px 12px;
+  border-radius: 0px 0px;
+  box-shadow: 2px 2px 0px rgba(72, 144, 216, 0.1);
+  transform: rotate(72deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box73 {
+  --cssShared-v-73: 578087;
+  color: hsl(181, 49%, 41%);
+  background-color: hsl(1, 49%, 59%);
+  border: 4px solid hsl(271, 50%, 50%);
+  margin: 13px 9px 15px 7px;
+  padding: 13px 14px;
+  border-radius: 1px 2px;
+  box-shadow: 3px 3px 1px rgba(73, 146, 219, 0.2);
+  transform: rotate(73deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box74 {
+  --cssShared-v-74: 586006;
+  color: hsl(218, 62%, 48%);
+  background-color: hsl(38, 62%, 52%);
+  border: 5px solid hsl(308, 50%, 50%);
+  margin: 14px 12px 20px 14px;
+  padding: 14px 16px;
+  border-radius: 2px 4px;
+  box-shadow: 4px 4px 2px rgba(74, 148, 222, 0.3);
+  transform: rotate(74deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box75 {
+  --cssShared-v-75: 593925;
+  color: hsl(255, 75%, 55%);
+  background-color: hsl(75, 75%, 45%);
+  border: 1px solid hsl(345, 50%, 50%);
+  margin: 15px 15px 0px 3px;
+  padding: 0px 18px;
+  border-radius: 3px 6px;
+  box-shadow: 0px 5px 3px rgba(75, 150, 225, 0.4);
+  transform: rotate(75deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box76 {
+  --cssShared-v-76: 601844;
+  color: hsl(292, 88%, 62%);
+  background-color: hsl(112, 88%, 38%);
+  border: 2px solid hsl(22, 50%, 50%);
+  margin: 16px 18px 5px 10px;
+  padding: 1px 20px;
+  border-radius: 4px 8px;
+  box-shadow: 1px 6px 4px rgba(76, 152, 228, 0.5);
+  transform: rotate(76deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box77 {
+  --cssShared-v-77: 609763;
+  color: hsl(329, 1%, 69%);
+  background-color: hsl(149, 1%, 31%);
+  border: 3px solid hsl(59, 50%, 50%);
+  margin: 17px 21px 10px 17px;
+  padding: 2px 0px;
+  border-radius: 5px 1px;
+  box-shadow: 2px 0px 5px rgba(77, 154, 231, 0.6);
+  transform: rotate(77deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box78 {
+  --cssShared-v-78: 617682;
+  color: hsl(6, 14%, 76%);
+  background-color: hsl(186, 14%, 24%);
+  border: 4px solid hsl(96, 50%, 50%);
+  margin: 18px 24px 15px 6px;
+  padding: 3px 2px;
+  border-radius: 6px 3px;
+  box-shadow: 3px 1px 6px rgba(78, 156, 234, 0.7);
+  transform: rotate(78deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box79 {
+  --cssShared-v-79: 625601;
+  color: hsl(43, 27%, 33%);
+  background-color: hsl(223, 27%, 67%);
+  border: 5px solid hsl(133, 50%, 50%);
+  margin: 19px 27px 20px 13px;
+  padding: 4px 4px;
+  border-radius: 7px 5px;
+  box-shadow: 4px 2px 7px rgba(79, 158, 237, 0.8);
+  transform: rotate(79deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box80 {
+  --cssShared-v-80: 633520;
+  color: hsl(80, 40%, 40%);
+  background-color: hsl(260, 40%, 60%);
+  border: 1px solid hsl(170, 50%, 50%);
+  margin: 0px 0px 0px 2px;
+  padding: 5px 6px;
+  border-radius: 8px 7px;
+  box-shadow: 0px 3px 8px rgba(80, 160, 240, 0.9);
+  transform: rotate(80deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box81 {
+  --cssShared-v-81: 641439;
+  color: hsl(117, 53%, 47%);
+  background-color: hsl(297, 53%, 53%);
+  border: 2px solid hsl(207, 50%, 50%);
+  margin: 1px 3px 5px 9px;
+  padding: 6px 8px;
+  border-radius: 9px 0px;
+  box-shadow: 1px 4px 0px rgba(81, 162, 243, 0.1);
+  transform: rotate(81deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box82 {
+  --cssShared-v-82: 649358;
+  color: hsl(154, 66%, 54%);
+  background-color: hsl(334, 66%, 46%);
+  border: 3px solid hsl(244, 50%, 50%);
+  margin: 2px 6px 10px 16px;
+  padding: 7px 10px;
+  border-radius: 10px 2px;
+  box-shadow: 2px 5px 1px rgba(82, 164, 246, 0.2);
+  transform: rotate(82deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box83 {
+  --cssShared-v-83: 657277;
+  color: hsl(191, 79%, 61%);
+  background-color: hsl(11, 79%, 39%);
+  border: 4px solid hsl(281, 50%, 50%);
+  margin: 3px 9px 15px 5px;
+  padding: 8px 12px;
+  border-radius: 11px 4px;
+  box-shadow: 3px 6px 2px rgba(83, 166, 249, 0.3);
+  transform: rotate(83deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box84 {
+  --cssShared-v-84: 665196;
+  color: hsl(228, 92%, 68%);
+  background-color: hsl(48, 92%, 32%);
+  border: 5px solid hsl(318, 50%, 50%);
+  margin: 4px 12px 20px 12px;
+  padding: 9px 14px;
+  border-radius: 0px 6px;
+  box-shadow: 4px 0px 3px rgba(84, 168, 252, 0.4);
+  transform: rotate(84deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box85 {
+  --cssShared-v-85: 673115;
+  color: hsl(265, 5%, 75%);
+  background-color: hsl(85, 5%, 25%);
+  border: 1px solid hsl(355, 50%, 50%);
+  margin: 5px 15px 0px 1px;
+  padding: 10px 16px;
+  border-radius: 1px 8px;
+  box-shadow: 0px 1px 4px rgba(85, 170, 0, 0.5);
+  transform: rotate(85deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box86 {
+  --cssShared-v-86: 681034;
+  color: hsl(302, 18%, 32%);
+  background-color: hsl(122, 18%, 68%);
+  border: 2px solid hsl(32, 50%, 50%);
+  margin: 6px 18px 5px 8px;
+  padding: 11px 18px;
+  border-radius: 2px 1px;
+  box-shadow: 1px 2px 5px rgba(86, 172, 3, 0.6);
+  transform: rotate(86deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box87 {
+  --cssShared-v-87: 688953;
+  color: hsl(339, 31%, 39%);
+  background-color: hsl(159, 31%, 61%);
+  border: 3px solid hsl(69, 50%, 50%);
+  margin: 7px 21px 10px 15px;
+  padding: 12px 20px;
+  border-radius: 3px 3px;
+  box-shadow: 2px 3px 6px rgba(87, 174, 6, 0.7);
+  transform: rotate(87deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box88 {
+  --cssShared-v-88: 696872;
+  color: hsl(16, 44%, 46%);
+  background-color: hsl(196, 44%, 54%);
+  border: 4px solid hsl(106, 50%, 50%);
+  margin: 8px 24px 15px 4px;
+  padding: 13px 0px;
+  border-radius: 4px 5px;
+  box-shadow: 3px 4px 7px rgba(88, 176, 9, 0.8);
+  transform: rotate(88deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box89 {
+  --cssShared-v-89: 704791;
+  color: hsl(53, 57%, 53%);
+  background-color: hsl(233, 57%, 47%);
+  border: 5px solid hsl(143, 50%, 50%);
+  margin: 9px 27px 20px 11px;
+  padding: 14px 2px;
+  border-radius: 5px 7px;
+  box-shadow: 4px 5px 8px rgba(89, 178, 12, 0.9);
+  transform: rotate(89deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box90 {
+  --cssShared-v-90: 712710;
+  color: hsl(90, 70%, 60%);
+  background-color: hsl(270, 70%, 40%);
+  border: 1px solid hsl(180, 50%, 50%);
+  margin: 10px 0px 0px 0px;
+  padding: 0px 4px;
+  border-radius: 6px 0px;
+  box-shadow: 0px 6px 0px rgba(90, 180, 15, 0.1);
+  transform: rotate(90deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box91 {
+  --cssShared-v-91: 720629;
+  color: hsl(127, 83%, 67%);
+  background-color: hsl(307, 83%, 33%);
+  border: 2px solid hsl(217, 50%, 50%);
+  margin: 11px 3px 5px 7px;
+  padding: 1px 6px;
+  border-radius: 7px 2px;
+  box-shadow: 1px 0px 1px rgba(91, 182, 18, 0.2);
+  transform: rotate(91deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box92 {
+  --cssShared-v-92: 728548;
+  color: hsl(164, 96%, 74%);
+  background-color: hsl(344, 96%, 26%);
+  border: 3px solid hsl(254, 50%, 50%);
+  margin: 12px 6px 10px 14px;
+  padding: 2px 8px;
+  border-radius: 8px 4px;
+  box-shadow: 2px 1px 2px rgba(92, 184, 21, 0.3);
+  transform: rotate(92deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box93 {
+  --cssShared-v-93: 736467;
+  color: hsl(201, 9%, 31%);
+  background-color: hsl(21, 9%, 69%);
+  border: 4px solid hsl(291, 50%, 50%);
+  margin: 13px 9px 15px 3px;
+  padding: 3px 10px;
+  border-radius: 9px 6px;
+  box-shadow: 3px 2px 3px rgba(93, 186, 24, 0.4);
+  transform: rotate(93deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box94 {
+  --cssShared-v-94: 744386;
+  color: hsl(238, 22%, 38%);
+  background-color: hsl(58, 22%, 62%);
+  border: 5px solid hsl(328, 50%, 50%);
+  margin: 14px 12px 20px 10px;
+  padding: 4px 12px;
+  border-radius: 10px 8px;
+  box-shadow: 4px 3px 4px rgba(94, 188, 27, 0.5);
+  transform: rotate(94deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box95 {
+  --cssShared-v-95: 752305;
+  color: hsl(275, 35%, 45%);
+  background-color: hsl(95, 35%, 55%);
+  border: 1px solid hsl(5, 50%, 50%);
+  margin: 15px 15px 0px 17px;
+  padding: 5px 14px;
+  border-radius: 11px 1px;
+  box-shadow: 0px 4px 5px rgba(95, 190, 30, 0.6);
+  transform: rotate(95deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box96 {
+  --cssShared-v-96: 760224;
+  color: hsl(312, 48%, 52%);
+  background-color: hsl(132, 48%, 48%);
+  border: 2px solid hsl(42, 50%, 50%);
+  margin: 16px 18px 5px 6px;
+  padding: 6px 16px;
+  border-radius: 0px 3px;
+  box-shadow: 1px 5px 6px rgba(96, 192, 33, 0.7);
+  transform: rotate(96deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box97 {
+  --cssShared-v-97: 768143;
+  color: hsl(349, 61%, 59%);
+  background-color: hsl(169, 61%, 41%);
+  border: 3px solid hsl(79, 50%, 50%);
+  margin: 17px 21px 10px 13px;
+  padding: 7px 18px;
+  border-radius: 1px 5px;
+  box-shadow: 2px 6px 7px rgba(97, 194, 36, 0.8);
+  transform: rotate(97deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box98 {
+  --cssShared-v-98: 776062;
+  color: hsl(26, 74%, 66%);
+  background-color: hsl(206, 74%, 34%);
+  border: 4px solid hsl(116, 50%, 50%);
+  margin: 18px 24px 15px 2px;
+  padding: 8px 20px;
+  border-radius: 2px 7px;
+  box-shadow: 3px 0px 8px rgba(98, 196, 39, 0.9);
+  transform: rotate(98deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box99 {
+  --cssShared-v-99: 783981;
+  color: hsl(63, 87%, 73%);
+  background-color: hsl(243, 87%, 27%);
+  border: 5px solid hsl(153, 50%, 50%);
+  margin: 19px 27px 20px 9px;
+  padding: 9px 0px;
+  border-radius: 3px 0px;
+  box-shadow: 4px 1px 0px rgba(99, 198, 42, 0.1);
+  transform: rotate(99deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box100 {
+  --cssShared-v-100: 791900;
+  color: hsl(100, 0%, 30%);
+  background-color: hsl(280, 0%, 70%);
+  border: 1px solid hsl(190, 50%, 50%);
+  margin: 0px 0px 0px 16px;
+  padding: 10px 2px;
+  border-radius: 4px 2px;
+  box-shadow: 0px 2px 1px rgba(100, 200, 45, 0.2);
+  transform: rotate(100deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box101 {
+  --cssShared-v-101: 799819;
+  color: hsl(137, 13%, 37%);
+  background-color: hsl(317, 13%, 63%);
+  border: 2px solid hsl(227, 50%, 50%);
+  margin: 1px 3px 5px 5px;
+  padding: 11px 4px;
+  border-radius: 5px 4px;
+  box-shadow: 1px 3px 2px rgba(101, 202, 48, 0.3);
+  transform: rotate(101deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box102 {
+  --cssShared-v-102: 807738;
+  color: hsl(174, 26%, 44%);
+  background-color: hsl(354, 26%, 56%);
+  border: 3px solid hsl(264, 50%, 50%);
+  margin: 2px 6px 10px 12px;
+  padding: 12px 6px;
+  border-radius: 6px 6px;
+  box-shadow: 2px 4px 3px rgba(102, 204, 51, 0.4);
+  transform: rotate(102deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box103 {
+  --cssShared-v-103: 815657;
+  color: hsl(211, 39%, 51%);
+  background-color: hsl(31, 39%, 49%);
+  border: 4px solid hsl(301, 50%, 50%);
+  margin: 3px 9px 15px 1px;
+  padding: 13px 8px;
+  border-radius: 7px 8px;
+  box-shadow: 3px 5px 4px rgba(103, 206, 54, 0.5);
+  transform: rotate(103deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box104 {
+  --cssShared-v-104: 823576;
+  color: hsl(248, 52%, 58%);
+  background-color: hsl(68, 52%, 42%);
+  border: 5px solid hsl(338, 50%, 50%);
+  margin: 4px 12px 20px 8px;
+  padding: 14px 10px;
+  border-radius: 8px 1px;
+  box-shadow: 4px 6px 5px rgba(104, 208, 57, 0.6);
+  transform: rotate(104deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box105 {
+  --cssShared-v-105: 831495;
+  color: hsl(285, 65%, 65%);
+  background-color: hsl(105, 65%, 35%);
+  border: 1px solid hsl(15, 50%, 50%);
+  margin: 5px 15px 0px 15px;
+  padding: 0px 12px;
+  border-radius: 9px 3px;
+  box-shadow: 0px 0px 6px rgba(105, 210, 60, 0.7);
+  transform: rotate(105deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box106 {
+  --cssShared-v-106: 839414;
+  color: hsl(322, 78%, 72%);
+  background-color: hsl(142, 78%, 28%);
+  border: 2px solid hsl(52, 50%, 50%);
+  margin: 6px 18px 5px 4px;
+  padding: 1px 14px;
+  border-radius: 10px 5px;
+  box-shadow: 1px 1px 7px rgba(106, 212, 63, 0.8);
+  transform: rotate(106deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box107 {
+  --cssShared-v-107: 847333;
+  color: hsl(359, 91%, 79%);
+  background-color: hsl(179, 91%, 21%);
+  border: 3px solid hsl(89, 50%, 50%);
+  margin: 7px 21px 10px 11px;
+  padding: 2px 16px;
+  border-radius: 11px 7px;
+  box-shadow: 2px 2px 8px rgba(107, 214, 66, 0.9);
+  transform: rotate(107deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box108 {
+  --cssShared-v-108: 855252;
+  color: hsl(36, 4%, 36%);
+  background-color: hsl(216, 4%, 64%);
+  border: 4px solid hsl(126, 50%, 50%);
+  margin: 8px 24px 15px 0px;
+  padding: 3px 18px;
+  border-radius: 0px 0px;
+  box-shadow: 3px 3px 0px rgba(108, 216, 69, 0.1);
+  transform: rotate(108deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box109 {
+  --cssShared-v-109: 863171;
+  color: hsl(73, 17%, 43%);
+  background-color: hsl(253, 17%, 57%);
+  border: 5px solid hsl(163, 50%, 50%);
+  margin: 9px 27px 20px 7px;
+  padding: 4px 20px;
+  border-radius: 1px 2px;
+  box-shadow: 4px 4px 1px rgba(109, 218, 72, 0.2);
+  transform: rotate(109deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box110 {
+  --cssShared-v-110: 871090;
+  color: hsl(110, 30%, 50%);
+  background-color: hsl(290, 30%, 50%);
+  border: 1px solid hsl(200, 50%, 50%);
+  margin: 10px 0px 0px 14px;
+  padding: 5px 0px;
+  border-radius: 2px 4px;
+  box-shadow: 0px 5px 2px rgba(110, 220, 75, 0.3);
+  transform: rotate(110deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box111 {
+  --cssShared-v-111: 879009;
+  color: hsl(147, 43%, 57%);
+  background-color: hsl(327, 43%, 43%);
+  border: 2px solid hsl(237, 50%, 50%);
+  margin: 11px 3px 5px 3px;
+  padding: 6px 2px;
+  border-radius: 3px 6px;
+  box-shadow: 1px 6px 3px rgba(111, 222, 78, 0.4);
+  transform: rotate(111deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box112 {
+  --cssShared-v-112: 886928;
+  color: hsl(184, 56%, 64%);
+  background-color: hsl(4, 56%, 36%);
+  border: 3px solid hsl(274, 50%, 50%);
+  margin: 12px 6px 10px 10px;
+  padding: 7px 4px;
+  border-radius: 4px 8px;
+  box-shadow: 2px 0px 4px rgba(112, 224, 81, 0.5);
+  transform: rotate(112deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box113 {
+  --cssShared-v-113: 894847;
+  color: hsl(221, 69%, 71%);
+  background-color: hsl(41, 69%, 29%);
+  border: 4px solid hsl(311, 50%, 50%);
+  margin: 13px 9px 15px 17px;
+  padding: 8px 6px;
+  border-radius: 5px 1px;
+  box-shadow: 3px 1px 5px rgba(113, 226, 84, 0.6);
+  transform: rotate(113deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box114 {
+  --cssShared-v-114: 902766;
+  color: hsl(258, 82%, 78%);
+  background-color: hsl(78, 82%, 22%);
+  border: 5px solid hsl(348, 50%, 50%);
+  margin: 14px 12px 20px 6px;
+  padding: 9px 8px;
+  border-radius: 6px 3px;
+  box-shadow: 4px 2px 6px rgba(114, 228, 87, 0.7);
+  transform: rotate(114deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box115 {
+  --cssShared-v-115: 910685;
+  color: hsl(295, 95%, 35%);
+  background-color: hsl(115, 95%, 65%);
+  border: 1px solid hsl(25, 50%, 50%);
+  margin: 15px 15px 0px 13px;
+  padding: 10px 10px;
+  border-radius: 7px 5px;
+  box-shadow: 0px 3px 7px rgba(115, 230, 90, 0.8);
+  transform: rotate(115deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box116 {
+  --cssShared-v-116: 918604;
+  color: hsl(332, 8%, 42%);
+  background-color: hsl(152, 8%, 58%);
+  border: 2px solid hsl(62, 50%, 50%);
+  margin: 16px 18px 5px 2px;
+  padding: 11px 12px;
+  border-radius: 8px 7px;
+  box-shadow: 1px 4px 8px rgba(116, 232, 93, 0.9);
+  transform: rotate(116deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box117 {
+  --cssShared-v-117: 926523;
+  color: hsl(9, 21%, 49%);
+  background-color: hsl(189, 21%, 51%);
+  border: 3px solid hsl(99, 50%, 50%);
+  margin: 17px 21px 10px 9px;
+  padding: 12px 14px;
+  border-radius: 9px 0px;
+  box-shadow: 2px 5px 0px rgba(117, 234, 96, 0.1);
+  transform: rotate(117deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box118 {
+  --cssShared-v-118: 934442;
+  color: hsl(46, 34%, 56%);
+  background-color: hsl(226, 34%, 44%);
+  border: 4px solid hsl(136, 50%, 50%);
+  margin: 18px 24px 15px 16px;
+  padding: 13px 16px;
+  border-radius: 10px 2px;
+  box-shadow: 3px 6px 1px rgba(118, 236, 99, 0.2);
+  transform: rotate(118deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box119 {
+  --cssShared-v-119: 942361;
+  color: hsl(83, 47%, 63%);
+  background-color: hsl(263, 47%, 37%);
+  border: 5px solid hsl(173, 50%, 50%);
+  margin: 19px 27px 20px 5px;
+  padding: 14px 18px;
+  border-radius: 11px 4px;
+  box-shadow: 4px 0px 2px rgba(119, 238, 102, 0.3);
+  transform: rotate(119deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box120 {
+  --cssShared-v-120: 950280;
+  color: hsl(120, 60%, 70%);
+  background-color: hsl(300, 60%, 30%);
+  border: 1px solid hsl(210, 50%, 50%);
+  margin: 0px 0px 0px 12px;
+  padding: 0px 20px;
+  border-radius: 0px 6px;
+  box-shadow: 0px 1px 3px rgba(120, 240, 105, 0.4);
+  transform: rotate(120deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box121 {
+  --cssShared-v-121: 958199;
+  color: hsl(157, 73%, 77%);
+  background-color: hsl(337, 73%, 23%);
+  border: 2px solid hsl(247, 50%, 50%);
+  margin: 1px 3px 5px 1px;
+  padding: 1px 0px;
+  border-radius: 1px 8px;
+  box-shadow: 1px 2px 4px rgba(121, 242, 108, 0.5);
+  transform: rotate(121deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box122 {
+  --cssShared-v-122: 966118;
+  color: hsl(194, 86%, 34%);
+  background-color: hsl(14, 86%, 66%);
+  border: 3px solid hsl(284, 50%, 50%);
+  margin: 2px 6px 10px 8px;
+  padding: 2px 2px;
+  border-radius: 2px 1px;
+  box-shadow: 2px 3px 5px rgba(122, 244, 111, 0.6);
+  transform: rotate(122deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box123 {
+  --cssShared-v-123: 974037;
+  color: hsl(231, 99%, 41%);
+  background-color: hsl(51, 99%, 59%);
+  border: 4px solid hsl(321, 50%, 50%);
+  margin: 3px 9px 15px 15px;
+  padding: 3px 4px;
+  border-radius: 3px 3px;
+  box-shadow: 3px 4px 6px rgba(123, 246, 114, 0.7);
+  transform: rotate(123deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box124 {
+  --cssShared-v-124: 981956;
+  color: hsl(268, 12%, 48%);
+  background-color: hsl(88, 12%, 52%);
+  border: 5px solid hsl(358, 50%, 50%);
+  margin: 4px 12px 20px 4px;
+  padding: 4px 6px;
+  border-radius: 4px 5px;
+  box-shadow: 4px 5px 7px rgba(124, 248, 117, 0.8);
+  transform: rotate(124deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box125 {
+  --cssShared-v-125: 989875;
+  color: hsl(305, 25%, 55%);
+  background-color: hsl(125, 25%, 45%);
+  border: 1px solid hsl(35, 50%, 50%);
+  margin: 5px 15px 0px 11px;
+  padding: 5px 8px;
+  border-radius: 5px 7px;
+  box-shadow: 0px 6px 8px rgba(125, 250, 120, 0.9);
+  transform: rotate(125deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box126 {
+  --cssShared-v-126: 997794;
+  color: hsl(342, 38%, 62%);
+  background-color: hsl(162, 38%, 38%);
+  border: 2px solid hsl(72, 50%, 50%);
+  margin: 6px 18px 5px 0px;
+  padding: 6px 10px;
+  border-radius: 6px 0px;
+  box-shadow: 1px 0px 0px rgba(126, 252, 123, 0.1);
+  transform: rotate(126deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box127 {
+  --cssShared-v-127: 5713;
+  color: hsl(19, 51%, 69%);
+  background-color: hsl(199, 51%, 31%);
+  border: 3px solid hsl(109, 50%, 50%);
+  margin: 7px 21px 10px 7px;
+  padding: 7px 12px;
+  border-radius: 7px 2px;
+  box-shadow: 2px 1px 1px rgba(127, 254, 126, 0.2);
+  transform: rotate(127deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box128 {
+  --cssShared-v-128: 13632;
+  color: hsl(56, 64%, 76%);
+  background-color: hsl(236, 64%, 24%);
+  border: 4px solid hsl(146, 50%, 50%);
+  margin: 8px 24px 15px 14px;
+  padding: 8px 14px;
+  border-radius: 8px 4px;
+  box-shadow: 3px 2px 2px rgba(128, 1, 129, 0.3);
+  transform: rotate(128deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box129 {
+  --cssShared-v-129: 21551;
+  color: hsl(93, 77%, 33%);
+  background-color: hsl(273, 77%, 67%);
+  border: 5px solid hsl(183, 50%, 50%);
+  margin: 9px 27px 20px 3px;
+  padding: 9px 16px;
+  border-radius: 9px 6px;
+  box-shadow: 4px 3px 3px rgba(129, 3, 132, 0.4);
+  transform: rotate(129deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box130 {
+  --cssShared-v-130: 29470;
+  color: hsl(130, 90%, 40%);
+  background-color: hsl(310, 90%, 60%);
+  border: 1px solid hsl(220, 50%, 50%);
+  margin: 10px 0px 0px 10px;
+  padding: 10px 18px;
+  border-radius: 10px 8px;
+  box-shadow: 0px 4px 4px rgba(130, 5, 135, 0.5);
+  transform: rotate(130deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box131 {
+  --cssShared-v-131: 37389;
+  color: hsl(167, 3%, 47%);
+  background-color: hsl(347, 3%, 53%);
+  border: 2px solid hsl(257, 50%, 50%);
+  margin: 11px 3px 5px 17px;
+  padding: 11px 20px;
+  border-radius: 11px 1px;
+  box-shadow: 1px 5px 5px rgba(131, 7, 138, 0.6);
+  transform: rotate(131deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box132 {
+  --cssShared-v-132: 45308;
+  color: hsl(204, 16%, 54%);
+  background-color: hsl(24, 16%, 46%);
+  border: 3px solid hsl(294, 50%, 50%);
+  margin: 12px 6px 10px 6px;
+  padding: 12px 0px;
+  border-radius: 0px 3px;
+  box-shadow: 2px 6px 6px rgba(132, 9, 141, 0.7);
+  transform: rotate(132deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box133 {
+  --cssShared-v-133: 53227;
+  color: hsl(241, 29%, 61%);
+  background-color: hsl(61, 29%, 39%);
+  border: 4px solid hsl(331, 50%, 50%);
+  margin: 13px 9px 15px 13px;
+  padding: 13px 2px;
+  border-radius: 1px 5px;
+  box-shadow: 3px 0px 7px rgba(133, 11, 144, 0.8);
+  transform: rotate(133deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box134 {
+  --cssShared-v-134: 61146;
+  color: hsl(278, 42%, 68%);
+  background-color: hsl(98, 42%, 32%);
+  border: 5px solid hsl(8, 50%, 50%);
+  margin: 14px 12px 20px 2px;
+  padding: 14px 4px;
+  border-radius: 2px 7px;
+  box-shadow: 4px 1px 8px rgba(134, 13, 147, 0.9);
+  transform: rotate(134deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box135 {
+  --cssShared-v-135: 69065;
+  color: hsl(315, 55%, 75%);
+  background-color: hsl(135, 55%, 25%);
+  border: 1px solid hsl(45, 50%, 50%);
+  margin: 15px 15px 0px 9px;
+  padding: 0px 6px;
+  border-radius: 3px 0px;
+  box-shadow: 0px 2px 0px rgba(135, 15, 150, 0.1);
+  transform: rotate(135deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box136 {
+  --cssShared-v-136: 76984;
+  color: hsl(352, 68%, 32%);
+  background-color: hsl(172, 68%, 68%);
+  border: 2px solid hsl(82, 50%, 50%);
+  margin: 16px 18px 5px 16px;
+  padding: 1px 8px;
+  border-radius: 4px 2px;
+  box-shadow: 1px 3px 1px rgba(136, 17, 153, 0.2);
+  transform: rotate(136deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box137 {
+  --cssShared-v-137: 84903;
+  color: hsl(29, 81%, 39%);
+  background-color: hsl(209, 81%, 61%);
+  border: 3px solid hsl(119, 50%, 50%);
+  margin: 17px 21px 10px 5px;
+  padding: 2px 10px;
+  border-radius: 5px 4px;
+  box-shadow: 2px 4px 2px rgba(137, 19, 156, 0.3);
+  transform: rotate(137deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box138 {
+  --cssShared-v-138: 92822;
+  color: hsl(66, 94%, 46%);
+  background-color: hsl(246, 94%, 54%);
+  border: 4px solid hsl(156, 50%, 50%);
+  margin: 18px 24px 15px 12px;
+  padding: 3px 12px;
+  border-radius: 6px 6px;
+  box-shadow: 3px 5px 3px rgba(138, 21, 159, 0.4);
+  transform: rotate(138deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box139 {
+  --cssShared-v-139: 100741;
+  color: hsl(103, 7%, 53%);
+  background-color: hsl(283, 7%, 47%);
+  border: 5px solid hsl(193, 50%, 50%);
+  margin: 19px 27px 20px 1px;
+  padding: 4px 14px;
+  border-radius: 7px 8px;
+  box-shadow: 4px 6px 4px rgba(139, 23, 162, 0.5);
+  transform: rotate(139deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box140 {
+  --cssShared-v-140: 108660;
+  color: hsl(140, 20%, 60%);
+  background-color: hsl(320, 20%, 40%);
+  border: 1px solid hsl(230, 50%, 50%);
+  margin: 0px 0px 0px 8px;
+  padding: 5px 16px;
+  border-radius: 8px 1px;
+  box-shadow: 0px 0px 5px rgba(140, 25, 165, 0.6);
+  transform: rotate(140deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box141 {
+  --cssShared-v-141: 116579;
+  color: hsl(177, 33%, 67%);
+  background-color: hsl(357, 33%, 33%);
+  border: 2px solid hsl(267, 50%, 50%);
+  margin: 1px 3px 5px 15px;
+  padding: 6px 18px;
+  border-radius: 9px 3px;
+  box-shadow: 1px 1px 6px rgba(141, 27, 168, 0.7);
+  transform: rotate(141deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box142 {
+  --cssShared-v-142: 124498;
+  color: hsl(214, 46%, 74%);
+  background-color: hsl(34, 46%, 26%);
+  border: 3px solid hsl(304, 50%, 50%);
+  margin: 2px 6px 10px 4px;
+  padding: 7px 20px;
+  border-radius: 10px 5px;
+  box-shadow: 2px 2px 7px rgba(142, 29, 171, 0.8);
+  transform: rotate(142deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box143 {
+  --cssShared-v-143: 132417;
+  color: hsl(251, 59%, 31%);
+  background-color: hsl(71, 59%, 69%);
+  border: 4px solid hsl(341, 50%, 50%);
+  margin: 3px 9px 15px 11px;
+  padding: 8px 0px;
+  border-radius: 11px 7px;
+  box-shadow: 3px 3px 8px rgba(143, 31, 174, 0.9);
+  transform: rotate(143deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box144 {
+  --cssShared-v-144: 140336;
+  color: hsl(288, 72%, 38%);
+  background-color: hsl(108, 72%, 62%);
+  border: 5px solid hsl(18, 50%, 50%);
+  margin: 4px 12px 20px 0px;
+  padding: 9px 2px;
+  border-radius: 0px 0px;
+  box-shadow: 4px 4px 0px rgba(144, 33, 177, 0.1);
+  transform: rotate(144deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box145 {
+  --cssShared-v-145: 148255;
+  color: hsl(325, 85%, 45%);
+  background-color: hsl(145, 85%, 55%);
+  border: 1px solid hsl(55, 50%, 50%);
+  margin: 5px 15px 0px 7px;
+  padding: 10px 4px;
+  border-radius: 1px 2px;
+  box-shadow: 0px 5px 1px rgba(145, 35, 180, 0.2);
+  transform: rotate(145deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box146 {
+  --cssShared-v-146: 156174;
+  color: hsl(2, 98%, 52%);
+  background-color: hsl(182, 98%, 48%);
+  border: 2px solid hsl(92, 50%, 50%);
+  margin: 6px 18px 5px 14px;
+  padding: 11px 6px;
+  border-radius: 2px 4px;
+  box-shadow: 1px 6px 2px rgba(146, 37, 183, 0.3);
+  transform: rotate(146deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box147 {
+  --cssShared-v-147: 164093;
+  color: hsl(39, 11%, 59%);
+  background-color: hsl(219, 11%, 41%);
+  border: 3px solid hsl(129, 50%, 50%);
+  margin: 7px 21px 10px 3px;
+  padding: 12px 8px;
+  border-radius: 3px 6px;
+  box-shadow: 2px 0px 3px rgba(147, 39, 186, 0.4);
+  transform: rotate(147deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box148 {
+  --cssShared-v-148: 172012;
+  color: hsl(76, 24%, 66%);
+  background-color: hsl(256, 24%, 34%);
+  border: 4px solid hsl(166, 50%, 50%);
+  margin: 8px 24px 15px 10px;
+  padding: 13px 10px;
+  border-radius: 4px 8px;
+  box-shadow: 3px 1px 4px rgba(148, 41, 189, 0.5);
+  transform: rotate(148deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box149 {
+  --cssShared-v-149: 179931;
+  color: hsl(113, 37%, 73%);
+  background-color: hsl(293, 37%, 27%);
+  border: 5px solid hsl(203, 50%, 50%);
+  margin: 9px 27px 20px 17px;
+  padding: 14px 12px;
+  border-radius: 5px 1px;
+  box-shadow: 4px 2px 5px rgba(149, 43, 192, 0.6);
+  transform: rotate(149deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box150 {
+  --cssShared-v-150: 187850;
+  color: hsl(150, 50%, 30%);
+  background-color: hsl(330, 50%, 70%);
+  border: 1px solid hsl(240, 50%, 50%);
+  margin: 10px 0px 0px 6px;
+  padding: 0px 14px;
+  border-radius: 6px 3px;
+  box-shadow: 0px 3px 6px rgba(150, 45, 195, 0.7);
+  transform: rotate(150deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box151 {
+  --cssShared-v-151: 195769;
+  color: hsl(187, 63%, 37%);
+  background-color: hsl(7, 63%, 63%);
+  border: 2px solid hsl(277, 50%, 50%);
+  margin: 11px 3px 5px 13px;
+  padding: 1px 16px;
+  border-radius: 7px 5px;
+  box-shadow: 1px 4px 7px rgba(151, 47, 198, 0.8);
+  transform: rotate(151deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box152 {
+  --cssShared-v-152: 203688;
+  color: hsl(224, 76%, 44%);
+  background-color: hsl(44, 76%, 56%);
+  border: 3px solid hsl(314, 50%, 50%);
+  margin: 12px 6px 10px 2px;
+  padding: 2px 18px;
+  border-radius: 8px 7px;
+  box-shadow: 2px 5px 8px rgba(152, 49, 201, 0.9);
+  transform: rotate(152deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box153 {
+  --cssShared-v-153: 211607;
+  color: hsl(261, 89%, 51%);
+  background-color: hsl(81, 89%, 49%);
+  border: 4px solid hsl(351, 50%, 50%);
+  margin: 13px 9px 15px 9px;
+  padding: 3px 20px;
+  border-radius: 9px 0px;
+  box-shadow: 3px 6px 0px rgba(153, 51, 204, 0.1);
+  transform: rotate(153deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box154 {
+  --cssShared-v-154: 219526;
+  color: hsl(298, 2%, 58%);
+  background-color: hsl(118, 2%, 42%);
+  border: 5px solid hsl(28, 50%, 50%);
+  margin: 14px 12px 20px 16px;
+  padding: 4px 0px;
+  border-radius: 10px 2px;
+  box-shadow: 4px 0px 1px rgba(154, 53, 207, 0.2);
+  transform: rotate(154deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box155 {
+  --cssShared-v-155: 227445;
+  color: hsl(335, 15%, 65%);
+  background-color: hsl(155, 15%, 35%);
+  border: 1px solid hsl(65, 50%, 50%);
+  margin: 15px 15px 0px 5px;
+  padding: 5px 2px;
+  border-radius: 11px 4px;
+  box-shadow: 0px 1px 2px rgba(155, 55, 210, 0.3);
+  transform: rotate(155deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box156 {
+  --cssShared-v-156: 235364;
+  color: hsl(12, 28%, 72%);
+  background-color: hsl(192, 28%, 28%);
+  border: 2px solid hsl(102, 50%, 50%);
+  margin: 16px 18px 5px 12px;
+  padding: 6px 4px;
+  border-radius: 0px 6px;
+  box-shadow: 1px 2px 3px rgba(156, 57, 213, 0.4);
+  transform: rotate(156deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box157 {
+  --cssShared-v-157: 243283;
+  color: hsl(49, 41%, 79%);
+  background-color: hsl(229, 41%, 21%);
+  border: 3px solid hsl(139, 50%, 50%);
+  margin: 17px 21px 10px 1px;
+  padding: 7px 6px;
+  border-radius: 1px 8px;
+  box-shadow: 2px 3px 4px rgba(157, 59, 216, 0.5);
+  transform: rotate(157deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box158 {
+  --cssShared-v-158: 251202;
+  color: hsl(86, 54%, 36%);
+  background-color: hsl(266, 54%, 64%);
+  border: 4px solid hsl(176, 50%, 50%);
+  margin: 18px 24px 15px 8px;
+  padding: 8px 8px;
+  border-radius: 2px 1px;
+  box-shadow: 3px 4px 5px rgba(158, 61, 219, 0.6);
+  transform: rotate(158deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box159 {
+  --cssShared-v-159: 259121;
+  color: hsl(123, 67%, 43%);
+  background-color: hsl(303, 67%, 57%);
+  border: 5px solid hsl(213, 50%, 50%);
+  margin: 19px 27px 20px 15px;
+  padding: 9px 10px;
+  border-radius: 3px 3px;
+  box-shadow: 4px 5px 6px rgba(159, 63, 222, 0.7);
+  transform: rotate(159deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box160 {
+  --cssShared-v-160: 267040;
+  color: hsl(160, 80%, 50%);
+  background-color: hsl(340, 80%, 50%);
+  border: 1px solid hsl(250, 50%, 50%);
+  margin: 0px 0px 0px 4px;
+  padding: 10px 12px;
+  border-radius: 4px 5px;
+  box-shadow: 0px 6px 7px rgba(160, 65, 225, 0.8);
+  transform: rotate(160deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box161 {
+  --cssShared-v-161: 274959;
+  color: hsl(197, 93%, 57%);
+  background-color: hsl(17, 93%, 43%);
+  border: 2px solid hsl(287, 50%, 50%);
+  margin: 1px 3px 5px 11px;
+  padding: 11px 14px;
+  border-radius: 5px 7px;
+  box-shadow: 1px 0px 8px rgba(161, 67, 228, 0.9);
+  transform: rotate(161deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box162 {
+  --cssShared-v-162: 282878;
+  color: hsl(234, 6%, 64%);
+  background-color: hsl(54, 6%, 36%);
+  border: 3px solid hsl(324, 50%, 50%);
+  margin: 2px 6px 10px 0px;
+  padding: 12px 16px;
+  border-radius: 6px 0px;
+  box-shadow: 2px 1px 0px rgba(162, 69, 231, 0.1);
+  transform: rotate(162deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box163 {
+  --cssShared-v-163: 290797;
+  color: hsl(271, 19%, 71%);
+  background-color: hsl(91, 19%, 29%);
+  border: 4px solid hsl(1, 50%, 50%);
+  margin: 3px 9px 15px 7px;
+  padding: 13px 18px;
+  border-radius: 7px 2px;
+  box-shadow: 3px 2px 1px rgba(163, 71, 234, 0.2);
+  transform: rotate(163deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box164 {
+  --cssShared-v-164: 298716;
+  color: hsl(308, 32%, 78%);
+  background-color: hsl(128, 32%, 22%);
+  border: 5px solid hsl(38, 50%, 50%);
+  margin: 4px 12px 20px 14px;
+  padding: 14px 20px;
+  border-radius: 8px 4px;
+  box-shadow: 4px 3px 2px rgba(164, 73, 237, 0.3);
+  transform: rotate(164deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box165 {
+  --cssShared-v-165: 306635;
+  color: hsl(345, 45%, 35%);
+  background-color: hsl(165, 45%, 65%);
+  border: 1px solid hsl(75, 50%, 50%);
+  margin: 5px 15px 0px 3px;
+  padding: 0px 0px;
+  border-radius: 9px 6px;
+  box-shadow: 0px 4px 3px rgba(165, 75, 240, 0.4);
+  transform: rotate(165deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box166 {
+  --cssShared-v-166: 314554;
+  color: hsl(22, 58%, 42%);
+  background-color: hsl(202, 58%, 58%);
+  border: 2px solid hsl(112, 50%, 50%);
+  margin: 6px 18px 5px 10px;
+  padding: 1px 2px;
+  border-radius: 10px 8px;
+  box-shadow: 1px 5px 4px rgba(166, 77, 243, 0.5);
+  transform: rotate(166deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box167 {
+  --cssShared-v-167: 322473;
+  color: hsl(59, 71%, 49%);
+  background-color: hsl(239, 71%, 51%);
+  border: 3px solid hsl(149, 50%, 50%);
+  margin: 7px 21px 10px 17px;
+  padding: 2px 4px;
+  border-radius: 11px 1px;
+  box-shadow: 2px 6px 5px rgba(167, 79, 246, 0.6);
+  transform: rotate(167deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box168 {
+  --cssShared-v-168: 330392;
+  color: hsl(96, 84%, 56%);
+  background-color: hsl(276, 84%, 44%);
+  border: 4px solid hsl(186, 50%, 50%);
+  margin: 8px 24px 15px 6px;
+  padding: 3px 6px;
+  border-radius: 0px 3px;
+  box-shadow: 3px 0px 6px rgba(168, 81, 249, 0.7);
+  transform: rotate(168deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box169 {
+  --cssShared-v-169: 338311;
+  color: hsl(133, 97%, 63%);
+  background-color: hsl(313, 97%, 37%);
+  border: 5px solid hsl(223, 50%, 50%);
+  margin: 9px 27px 20px 13px;
+  padding: 4px 8px;
+  border-radius: 1px 5px;
+  box-shadow: 4px 1px 7px rgba(169, 83, 252, 0.8);
+  transform: rotate(169deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box170 {
+  --cssShared-v-170: 346230;
+  color: hsl(170, 10%, 70%);
+  background-color: hsl(350, 10%, 30%);
+  border: 1px solid hsl(260, 50%, 50%);
+  margin: 10px 0px 0px 2px;
+  padding: 5px 10px;
+  border-radius: 2px 7px;
+  box-shadow: 0px 2px 8px rgba(170, 85, 0, 0.9);
+  transform: rotate(170deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box171 {
+  --cssShared-v-171: 354149;
+  color: hsl(207, 23%, 77%);
+  background-color: hsl(27, 23%, 23%);
+  border: 2px solid hsl(297, 50%, 50%);
+  margin: 11px 3px 5px 9px;
+  padding: 6px 12px;
+  border-radius: 3px 0px;
+  box-shadow: 1px 3px 0px rgba(171, 87, 3, 0.1);
+  transform: rotate(171deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box172 {
+  --cssShared-v-172: 362068;
+  color: hsl(244, 36%, 34%);
+  background-color: hsl(64, 36%, 66%);
+  border: 3px solid hsl(334, 50%, 50%);
+  margin: 12px 6px 10px 16px;
+  padding: 7px 14px;
+  border-radius: 4px 2px;
+  box-shadow: 2px 4px 1px rgba(172, 89, 6, 0.2);
+  transform: rotate(172deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box173 {
+  --cssShared-v-173: 369987;
+  color: hsl(281, 49%, 41%);
+  background-color: hsl(101, 49%, 59%);
+  border: 4px solid hsl(11, 50%, 50%);
+  margin: 13px 9px 15px 5px;
+  padding: 8px 16px;
+  border-radius: 5px 4px;
+  box-shadow: 3px 5px 2px rgba(173, 91, 9, 0.3);
+  transform: rotate(173deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box174 {
+  --cssShared-v-174: 377906;
+  color: hsl(318, 62%, 48%);
+  background-color: hsl(138, 62%, 52%);
+  border: 5px solid hsl(48, 50%, 50%);
+  margin: 14px 12px 20px 12px;
+  padding: 9px 18px;
+  border-radius: 6px 6px;
+  box-shadow: 4px 6px 3px rgba(174, 93, 12, 0.4);
+  transform: rotate(174deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box175 {
+  --cssShared-v-175: 385825;
+  color: hsl(355, 75%, 55%);
+  background-color: hsl(175, 75%, 45%);
+  border: 1px solid hsl(85, 50%, 50%);
+  margin: 15px 15px 0px 1px;
+  padding: 10px 20px;
+  border-radius: 7px 8px;
+  box-shadow: 0px 0px 4px rgba(175, 95, 15, 0.5);
+  transform: rotate(175deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box176 {
+  --cssShared-v-176: 393744;
+  color: hsl(32, 88%, 62%);
+  background-color: hsl(212, 88%, 38%);
+  border: 2px solid hsl(122, 50%, 50%);
+  margin: 16px 18px 5px 8px;
+  padding: 11px 0px;
+  border-radius: 8px 1px;
+  box-shadow: 1px 1px 5px rgba(176, 97, 18, 0.6);
+  transform: rotate(176deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box177 {
+  --cssShared-v-177: 401663;
+  color: hsl(69, 1%, 69%);
+  background-color: hsl(249, 1%, 31%);
+  border: 3px solid hsl(159, 50%, 50%);
+  margin: 17px 21px 10px 15px;
+  padding: 12px 2px;
+  border-radius: 9px 3px;
+  box-shadow: 2px 2px 6px rgba(177, 99, 21, 0.7);
+  transform: rotate(177deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box178 {
+  --cssShared-v-178: 409582;
+  color: hsl(106, 14%, 76%);
+  background-color: hsl(286, 14%, 24%);
+  border: 4px solid hsl(196, 50%, 50%);
+  margin: 18px 24px 15px 4px;
+  padding: 13px 4px;
+  border-radius: 10px 5px;
+  box-shadow: 3px 3px 7px rgba(178, 101, 24, 0.8);
+  transform: rotate(178deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box179 {
+  --cssShared-v-179: 417501;
+  color: hsl(143, 27%, 33%);
+  background-color: hsl(323, 27%, 67%);
+  border: 5px solid hsl(233, 50%, 50%);
+  margin: 19px 27px 20px 11px;
+  padding: 14px 6px;
+  border-radius: 11px 7px;
+  box-shadow: 4px 4px 8px rgba(179, 103, 27, 0.9);
+  transform: rotate(179deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box180 {
+  --cssShared-v-180: 425420;
+  color: hsl(180, 40%, 40%);
+  background-color: hsl(0, 40%, 60%);
+  border: 1px solid hsl(270, 50%, 50%);
+  margin: 0px 0px 0px 0px;
+  padding: 0px 8px;
+  border-radius: 0px 0px;
+  box-shadow: 0px 5px 0px rgba(180, 105, 30, 0.1);
+  transform: rotate(180deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box181 {
+  --cssShared-v-181: 433339;
+  color: hsl(217, 53%, 47%);
+  background-color: hsl(37, 53%, 53%);
+  border: 2px solid hsl(307, 50%, 50%);
+  margin: 1px 3px 5px 7px;
+  padding: 1px 10px;
+  border-radius: 1px 2px;
+  box-shadow: 1px 6px 1px rgba(181, 107, 33, 0.2);
+  transform: rotate(181deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box182 {
+  --cssShared-v-182: 441258;
+  color: hsl(254, 66%, 54%);
+  background-color: hsl(74, 66%, 46%);
+  border: 3px solid hsl(344, 50%, 50%);
+  margin: 2px 6px 10px 14px;
+  padding: 2px 12px;
+  border-radius: 2px 4px;
+  box-shadow: 2px 0px 2px rgba(182, 109, 36, 0.3);
+  transform: rotate(182deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box183 {
+  --cssShared-v-183: 449177;
+  color: hsl(291, 79%, 61%);
+  background-color: hsl(111, 79%, 39%);
+  border: 4px solid hsl(21, 50%, 50%);
+  margin: 3px 9px 15px 3px;
+  padding: 3px 14px;
+  border-radius: 3px 6px;
+  box-shadow: 3px 1px 3px rgba(183, 111, 39, 0.4);
+  transform: rotate(183deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box184 {
+  --cssShared-v-184: 457096;
+  color: hsl(328, 92%, 68%);
+  background-color: hsl(148, 92%, 32%);
+  border: 5px solid hsl(58, 50%, 50%);
+  margin: 4px 12px 20px 10px;
+  padding: 4px 16px;
+  border-radius: 4px 8px;
+  box-shadow: 4px 2px 4px rgba(184, 113, 42, 0.5);
+  transform: rotate(184deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box185 {
+  --cssShared-v-185: 465015;
+  color: hsl(5, 5%, 75%);
+  background-color: hsl(185, 5%, 25%);
+  border: 1px solid hsl(95, 50%, 50%);
+  margin: 5px 15px 0px 17px;
+  padding: 5px 18px;
+  border-radius: 5px 1px;
+  box-shadow: 0px 3px 5px rgba(185, 115, 45, 0.6);
+  transform: rotate(185deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box186 {
+  --cssShared-v-186: 472934;
+  color: hsl(42, 18%, 32%);
+  background-color: hsl(222, 18%, 68%);
+  border: 2px solid hsl(132, 50%, 50%);
+  margin: 6px 18px 5px 6px;
+  padding: 6px 20px;
+  border-radius: 6px 3px;
+  box-shadow: 1px 4px 6px rgba(186, 117, 48, 0.7);
+  transform: rotate(186deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box187 {
+  --cssShared-v-187: 480853;
+  color: hsl(79, 31%, 39%);
+  background-color: hsl(259, 31%, 61%);
+  border: 3px solid hsl(169, 50%, 50%);
+  margin: 7px 21px 10px 13px;
+  padding: 7px 0px;
+  border-radius: 7px 5px;
+  box-shadow: 2px 5px 7px rgba(187, 119, 51, 0.8);
+  transform: rotate(187deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box188 {
+  --cssShared-v-188: 488772;
+  color: hsl(116, 44%, 46%);
+  background-color: hsl(296, 44%, 54%);
+  border: 4px solid hsl(206, 50%, 50%);
+  margin: 8px 24px 15px 2px;
+  padding: 8px 2px;
+  border-radius: 8px 7px;
+  box-shadow: 3px 6px 8px rgba(188, 121, 54, 0.9);
+  transform: rotate(188deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box189 {
+  --cssShared-v-189: 496691;
+  color: hsl(153, 57%, 53%);
+  background-color: hsl(333, 57%, 47%);
+  border: 5px solid hsl(243, 50%, 50%);
+  margin: 9px 27px 20px 9px;
+  padding: 9px 4px;
+  border-radius: 9px 0px;
+  box-shadow: 4px 0px 0px rgba(189, 123, 57, 0.1);
+  transform: rotate(189deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box190 {
+  --cssShared-v-190: 504610;
+  color: hsl(190, 70%, 60%);
+  background-color: hsl(10, 70%, 40%);
+  border: 1px solid hsl(280, 50%, 50%);
+  margin: 10px 0px 0px 16px;
+  padding: 10px 6px;
+  border-radius: 10px 2px;
+  box-shadow: 0px 1px 1px rgba(190, 125, 60, 0.2);
+  transform: rotate(190deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box191 {
+  --cssShared-v-191: 512529;
+  color: hsl(227, 83%, 67%);
+  background-color: hsl(47, 83%, 33%);
+  border: 2px solid hsl(317, 50%, 50%);
+  margin: 11px 3px 5px 5px;
+  padding: 11px 8px;
+  border-radius: 11px 4px;
+  box-shadow: 1px 2px 2px rgba(191, 127, 63, 0.3);
+  transform: rotate(191deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box192 {
+  --cssShared-v-192: 520448;
+  color: hsl(264, 96%, 74%);
+  background-color: hsl(84, 96%, 26%);
+  border: 3px solid hsl(354, 50%, 50%);
+  margin: 12px 6px 10px 12px;
+  padding: 12px 10px;
+  border-radius: 0px 6px;
+  box-shadow: 2px 3px 3px rgba(192, 129, 66, 0.4);
+  transform: rotate(192deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box193 {
+  --cssShared-v-193: 528367;
+  color: hsl(301, 9%, 31%);
+  background-color: hsl(121, 9%, 69%);
+  border: 4px solid hsl(31, 50%, 50%);
+  margin: 13px 9px 15px 1px;
+  padding: 13px 12px;
+  border-radius: 1px 8px;
+  box-shadow: 3px 4px 4px rgba(193, 131, 69, 0.5);
+  transform: rotate(193deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box194 {
+  --cssShared-v-194: 536286;
+  color: hsl(338, 22%, 38%);
+  background-color: hsl(158, 22%, 62%);
+  border: 5px solid hsl(68, 50%, 50%);
+  margin: 14px 12px 20px 8px;
+  padding: 14px 14px;
+  border-radius: 2px 1px;
+  box-shadow: 4px 5px 5px rgba(194, 133, 72, 0.6);
+  transform: rotate(194deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box195 {
+  --cssShared-v-195: 544205;
+  color: hsl(15, 35%, 45%);
+  background-color: hsl(195, 35%, 55%);
+  border: 1px solid hsl(105, 50%, 50%);
+  margin: 15px 15px 0px 15px;
+  padding: 0px 16px;
+  border-radius: 3px 3px;
+  box-shadow: 0px 6px 6px rgba(195, 135, 75, 0.7);
+  transform: rotate(195deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box196 {
+  --cssShared-v-196: 552124;
+  color: hsl(52, 48%, 52%);
+  background-color: hsl(232, 48%, 48%);
+  border: 2px solid hsl(142, 50%, 50%);
+  margin: 16px 18px 5px 4px;
+  padding: 1px 18px;
+  border-radius: 4px 5px;
+  box-shadow: 1px 0px 7px rgba(196, 137, 78, 0.8);
+  transform: rotate(196deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box197 {
+  --cssShared-v-197: 560043;
+  color: hsl(89, 61%, 59%);
+  background-color: hsl(269, 61%, 41%);
+  border: 3px solid hsl(179, 50%, 50%);
+  margin: 17px 21px 10px 11px;
+  padding: 2px 20px;
+  border-radius: 5px 7px;
+  box-shadow: 2px 1px 8px rgba(197, 139, 81, 0.9);
+  transform: rotate(197deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box198 {
+  --cssShared-v-198: 567962;
+  color: hsl(126, 74%, 66%);
+  background-color: hsl(306, 74%, 34%);
+  border: 4px solid hsl(216, 50%, 50%);
+  margin: 18px 24px 15px 0px;
+  padding: 3px 0px;
+  border-radius: 6px 0px;
+  box-shadow: 3px 2px 0px rgba(198, 141, 84, 0.1);
+  transform: rotate(198deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box199 {
+  --cssShared-v-199: 575881;
+  color: hsl(163, 87%, 73%);
+  background-color: hsl(343, 87%, 27%);
+  border: 5px solid hsl(253, 50%, 50%);
+  margin: 19px 27px 20px 7px;
+  padding: 4px 2px;
+  border-radius: 7px 2px;
+  box-shadow: 4px 3px 1px rgba(199, 143, 87, 0.2);
+  transform: rotate(199deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box200 {
+  --cssShared-v-200: 583800;
+  color: hsl(200, 0%, 30%);
+  background-color: hsl(20, 0%, 70%);
+  border: 1px solid hsl(290, 50%, 50%);
+  margin: 0px 0px 0px 14px;
+  padding: 5px 4px;
+  border-radius: 8px 4px;
+  box-shadow: 0px 4px 2px rgba(200, 145, 90, 0.3);
+  transform: rotate(200deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box201 {
+  --cssShared-v-201: 591719;
+  color: hsl(237, 13%, 37%);
+  background-color: hsl(57, 13%, 63%);
+  border: 2px solid hsl(327, 50%, 50%);
+  margin: 1px 3px 5px 3px;
+  padding: 6px 6px;
+  border-radius: 9px 6px;
+  box-shadow: 1px 5px 3px rgba(201, 147, 93, 0.4);
+  transform: rotate(201deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box202 {
+  --cssShared-v-202: 599638;
+  color: hsl(274, 26%, 44%);
+  background-color: hsl(94, 26%, 56%);
+  border: 3px solid hsl(4, 50%, 50%);
+  margin: 2px 6px 10px 10px;
+  padding: 7px 8px;
+  border-radius: 10px 8px;
+  box-shadow: 2px 6px 4px rgba(202, 149, 96, 0.5);
+  transform: rotate(202deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box203 {
+  --cssShared-v-203: 607557;
+  color: hsl(311, 39%, 51%);
+  background-color: hsl(131, 39%, 49%);
+  border: 4px solid hsl(41, 50%, 50%);
+  margin: 3px 9px 15px 17px;
+  padding: 8px 10px;
+  border-radius: 11px 1px;
+  box-shadow: 3px 0px 5px rgba(203, 151, 99, 0.6);
+  transform: rotate(203deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box204 {
+  --cssShared-v-204: 615476;
+  color: hsl(348, 52%, 58%);
+  background-color: hsl(168, 52%, 42%);
+  border: 5px solid hsl(78, 50%, 50%);
+  margin: 4px 12px 20px 6px;
+  padding: 9px 12px;
+  border-radius: 0px 3px;
+  box-shadow: 4px 1px 6px rgba(204, 153, 102, 0.7);
+  transform: rotate(204deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box205 {
+  --cssShared-v-205: 623395;
+  color: hsl(25, 65%, 65%);
+  background-color: hsl(205, 65%, 35%);
+  border: 1px solid hsl(115, 50%, 50%);
+  margin: 5px 15px 0px 13px;
+  padding: 10px 14px;
+  border-radius: 1px 5px;
+  box-shadow: 0px 2px 7px rgba(205, 155, 105, 0.8);
+  transform: rotate(205deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box206 {
+  --cssShared-v-206: 631314;
+  color: hsl(62, 78%, 72%);
+  background-color: hsl(242, 78%, 28%);
+  border: 2px solid hsl(152, 50%, 50%);
+  margin: 6px 18px 5px 2px;
+  padding: 11px 16px;
+  border-radius: 2px 7px;
+  box-shadow: 1px 3px 8px rgba(206, 157, 108, 0.9);
+  transform: rotate(206deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box207 {
+  --cssShared-v-207: 639233;
+  color: hsl(99, 91%, 79%);
+  background-color: hsl(279, 91%, 21%);
+  border: 3px solid hsl(189, 50%, 50%);
+  margin: 7px 21px 10px 9px;
+  padding: 12px 18px;
+  border-radius: 3px 0px;
+  box-shadow: 2px 4px 0px rgba(207, 159, 111, 0.1);
+  transform: rotate(207deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box208 {
+  --cssShared-v-208: 647152;
+  color: hsl(136, 4%, 36%);
+  background-color: hsl(316, 4%, 64%);
+  border: 4px solid hsl(226, 50%, 50%);
+  margin: 8px 24px 15px 16px;
+  padding: 13px 20px;
+  border-radius: 4px 2px;
+  box-shadow: 3px 5px 1px rgba(208, 161, 114, 0.2);
+  transform: rotate(208deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box209 {
+  --cssShared-v-209: 655071;
+  color: hsl(173, 17%, 43%);
+  background-color: hsl(353, 17%, 57%);
+  border: 5px solid hsl(263, 50%, 50%);
+  margin: 9px 27px 20px 5px;
+  padding: 14px 0px;
+  border-radius: 5px 4px;
+  box-shadow: 4px 6px 2px rgba(209, 163, 117, 0.3);
+  transform: rotate(209deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box210 {
+  --cssShared-v-210: 662990;
+  color: hsl(210, 30%, 50%);
+  background-color: hsl(30, 30%, 50%);
+  border: 1px solid hsl(300, 50%, 50%);
+  margin: 10px 0px 0px 12px;
+  padding: 0px 2px;
+  border-radius: 6px 6px;
+  box-shadow: 0px 0px 3px rgba(210, 165, 120, 0.4);
+  transform: rotate(210deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box211 {
+  --cssShared-v-211: 670909;
+  color: hsl(247, 43%, 57%);
+  background-color: hsl(67, 43%, 43%);
+  border: 2px solid hsl(337, 50%, 50%);
+  margin: 11px 3px 5px 1px;
+  padding: 1px 4px;
+  border-radius: 7px 8px;
+  box-shadow: 1px 1px 4px rgba(211, 167, 123, 0.5);
+  transform: rotate(211deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box212 {
+  --cssShared-v-212: 678828;
+  color: hsl(284, 56%, 64%);
+  background-color: hsl(104, 56%, 36%);
+  border: 3px solid hsl(14, 50%, 50%);
+  margin: 12px 6px 10px 8px;
+  padding: 2px 6px;
+  border-radius: 8px 1px;
+  box-shadow: 2px 2px 5px rgba(212, 169, 126, 0.6);
+  transform: rotate(212deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box213 {
+  --cssShared-v-213: 686747;
+  color: hsl(321, 69%, 71%);
+  background-color: hsl(141, 69%, 29%);
+  border: 4px solid hsl(51, 50%, 50%);
+  margin: 13px 9px 15px 15px;
+  padding: 3px 8px;
+  border-radius: 9px 3px;
+  box-shadow: 3px 3px 6px rgba(213, 171, 129, 0.7);
+  transform: rotate(213deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box214 {
+  --cssShared-v-214: 694666;
+  color: hsl(358, 82%, 78%);
+  background-color: hsl(178, 82%, 22%);
+  border: 5px solid hsl(88, 50%, 50%);
+  margin: 14px 12px 20px 4px;
+  padding: 4px 10px;
+  border-radius: 10px 5px;
+  box-shadow: 4px 4px 7px rgba(214, 173, 132, 0.8);
+  transform: rotate(214deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box215 {
+  --cssShared-v-215: 702585;
+  color: hsl(35, 95%, 35%);
+  background-color: hsl(215, 95%, 65%);
+  border: 1px solid hsl(125, 50%, 50%);
+  margin: 15px 15px 0px 11px;
+  padding: 5px 12px;
+  border-radius: 11px 7px;
+  box-shadow: 0px 5px 8px rgba(215, 175, 135, 0.9);
+  transform: rotate(215deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box216 {
+  --cssShared-v-216: 710504;
+  color: hsl(72, 8%, 42%);
+  background-color: hsl(252, 8%, 58%);
+  border: 2px solid hsl(162, 50%, 50%);
+  margin: 16px 18px 5px 0px;
+  padding: 6px 14px;
+  border-radius: 0px 0px;
+  box-shadow: 1px 6px 0px rgba(216, 177, 138, 0.1);
+  transform: rotate(216deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box217 {
+  --cssShared-v-217: 718423;
+  color: hsl(109, 21%, 49%);
+  background-color: hsl(289, 21%, 51%);
+  border: 3px solid hsl(199, 50%, 50%);
+  margin: 17px 21px 10px 7px;
+  padding: 7px 16px;
+  border-radius: 1px 2px;
+  box-shadow: 2px 0px 1px rgba(217, 179, 141, 0.2);
+  transform: rotate(217deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box218 {
+  --cssShared-v-218: 726342;
+  color: hsl(146, 34%, 56%);
+  background-color: hsl(326, 34%, 44%);
+  border: 4px solid hsl(236, 50%, 50%);
+  margin: 18px 24px 15px 14px;
+  padding: 8px 18px;
+  border-radius: 2px 4px;
+  box-shadow: 3px 1px 2px rgba(218, 181, 144, 0.3);
+  transform: rotate(218deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box219 {
+  --cssShared-v-219: 734261;
+  color: hsl(183, 47%, 63%);
+  background-color: hsl(3, 47%, 37%);
+  border: 5px solid hsl(273, 50%, 50%);
+  margin: 19px 27px 20px 3px;
+  padding: 9px 20px;
+  border-radius: 3px 6px;
+  box-shadow: 4px 2px 3px rgba(219, 183, 147, 0.4);
+  transform: rotate(219deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box220 {
+  --cssShared-v-220: 742180;
+  color: hsl(220, 60%, 70%);
+  background-color: hsl(40, 60%, 30%);
+  border: 1px solid hsl(310, 50%, 50%);
+  margin: 0px 0px 0px 10px;
+  padding: 10px 0px;
+  border-radius: 4px 8px;
+  box-shadow: 0px 3px 4px rgba(220, 185, 150, 0.5);
+  transform: rotate(220deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box221 {
+  --cssShared-v-221: 750099;
+  color: hsl(257, 73%, 77%);
+  background-color: hsl(77, 73%, 23%);
+  border: 2px solid hsl(347, 50%, 50%);
+  margin: 1px 3px 5px 17px;
+  padding: 11px 2px;
+  border-radius: 5px 1px;
+  box-shadow: 1px 4px 5px rgba(221, 187, 153, 0.6);
+  transform: rotate(221deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box222 {
+  --cssShared-v-222: 758018;
+  color: hsl(294, 86%, 34%);
+  background-color: hsl(114, 86%, 66%);
+  border: 3px solid hsl(24, 50%, 50%);
+  margin: 2px 6px 10px 6px;
+  padding: 12px 4px;
+  border-radius: 6px 3px;
+  box-shadow: 2px 5px 6px rgba(222, 189, 156, 0.7);
+  transform: rotate(222deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box223 {
+  --cssShared-v-223: 765937;
+  color: hsl(331, 99%, 41%);
+  background-color: hsl(151, 99%, 59%);
+  border: 4px solid hsl(61, 50%, 50%);
+  margin: 3px 9px 15px 13px;
+  padding: 13px 6px;
+  border-radius: 7px 5px;
+  box-shadow: 3px 6px 7px rgba(223, 191, 159, 0.8);
+  transform: rotate(223deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box224 {
+  --cssShared-v-224: 773856;
+  color: hsl(8, 12%, 48%);
+  background-color: hsl(188, 12%, 52%);
+  border: 5px solid hsl(98, 50%, 50%);
+  margin: 4px 12px 20px 2px;
+  padding: 14px 8px;
+  border-radius: 8px 7px;
+  box-shadow: 4px 0px 8px rgba(224, 193, 162, 0.9);
+  transform: rotate(224deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box225 {
+  --cssShared-v-225: 781775;
+  color: hsl(45, 25%, 55%);
+  background-color: hsl(225, 25%, 45%);
+  border: 1px solid hsl(135, 50%, 50%);
+  margin: 5px 15px 0px 9px;
+  padding: 0px 10px;
+  border-radius: 9px 0px;
+  box-shadow: 0px 1px 0px rgba(225, 195, 165, 0.1);
+  transform: rotate(225deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box226 {
+  --cssShared-v-226: 789694;
+  color: hsl(82, 38%, 62%);
+  background-color: hsl(262, 38%, 38%);
+  border: 2px solid hsl(172, 50%, 50%);
+  margin: 6px 18px 5px 16px;
+  padding: 1px 12px;
+  border-radius: 10px 2px;
+  box-shadow: 1px 2px 1px rgba(226, 197, 168, 0.2);
+  transform: rotate(226deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box227 {
+  --cssShared-v-227: 797613;
+  color: hsl(119, 51%, 69%);
+  background-color: hsl(299, 51%, 31%);
+  border: 3px solid hsl(209, 50%, 50%);
+  margin: 7px 21px 10px 5px;
+  padding: 2px 14px;
+  border-radius: 11px 4px;
+  box-shadow: 2px 3px 2px rgba(227, 199, 171, 0.3);
+  transform: rotate(227deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box228 {
+  --cssShared-v-228: 805532;
+  color: hsl(156, 64%, 76%);
+  background-color: hsl(336, 64%, 24%);
+  border: 4px solid hsl(246, 50%, 50%);
+  margin: 8px 24px 15px 12px;
+  padding: 3px 16px;
+  border-radius: 0px 6px;
+  box-shadow: 3px 4px 3px rgba(228, 201, 174, 0.4);
+  transform: rotate(228deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box229 {
+  --cssShared-v-229: 813451;
+  color: hsl(193, 77%, 33%);
+  background-color: hsl(13, 77%, 67%);
+  border: 5px solid hsl(283, 50%, 50%);
+  margin: 9px 27px 20px 1px;
+  padding: 4px 18px;
+  border-radius: 1px 8px;
+  box-shadow: 4px 5px 4px rgba(229, 203, 177, 0.5);
+  transform: rotate(229deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box230 {
+  --cssShared-v-230: 821370;
+  color: hsl(230, 90%, 40%);
+  background-color: hsl(50, 90%, 60%);
+  border: 1px solid hsl(320, 50%, 50%);
+  margin: 10px 0px 0px 8px;
+  padding: 5px 20px;
+  border-radius: 2px 1px;
+  box-shadow: 0px 6px 5px rgba(230, 205, 180, 0.6);
+  transform: rotate(230deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box231 {
+  --cssShared-v-231: 829289;
+  color: hsl(267, 3%, 47%);
+  background-color: hsl(87, 3%, 53%);
+  border: 2px solid hsl(357, 50%, 50%);
+  margin: 11px 3px 5px 15px;
+  padding: 6px 0px;
+  border-radius: 3px 3px;
+  box-shadow: 1px 0px 6px rgba(231, 207, 183, 0.7);
+  transform: rotate(231deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box232 {
+  --cssShared-v-232: 837208;
+  color: hsl(304, 16%, 54%);
+  background-color: hsl(124, 16%, 46%);
+  border: 3px solid hsl(34, 50%, 50%);
+  margin: 12px 6px 10px 4px;
+  padding: 7px 2px;
+  border-radius: 4px 5px;
+  box-shadow: 2px 1px 7px rgba(232, 209, 186, 0.8);
+  transform: rotate(232deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box233 {
+  --cssShared-v-233: 845127;
+  color: hsl(341, 29%, 61%);
+  background-color: hsl(161, 29%, 39%);
+  border: 4px solid hsl(71, 50%, 50%);
+  margin: 13px 9px 15px 11px;
+  padding: 8px 4px;
+  border-radius: 5px 7px;
+  box-shadow: 3px 2px 8px rgba(233, 211, 189, 0.9);
+  transform: rotate(233deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box234 {
+  --cssShared-v-234: 853046;
+  color: hsl(18, 42%, 68%);
+  background-color: hsl(198, 42%, 32%);
+  border: 5px solid hsl(108, 50%, 50%);
+  margin: 14px 12px 20px 0px;
+  padding: 9px 6px;
+  border-radius: 6px 0px;
+  box-shadow: 4px 3px 0px rgba(234, 213, 192, 0.1);
+  transform: rotate(234deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box235 {
+  --cssShared-v-235: 860965;
+  color: hsl(55, 55%, 75%);
+  background-color: hsl(235, 55%, 25%);
+  border: 1px solid hsl(145, 50%, 50%);
+  margin: 15px 15px 0px 7px;
+  padding: 10px 8px;
+  border-radius: 7px 2px;
+  box-shadow: 0px 4px 1px rgba(235, 215, 195, 0.2);
+  transform: rotate(235deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box236 {
+  --cssShared-v-236: 868884;
+  color: hsl(92, 68%, 32%);
+  background-color: hsl(272, 68%, 68%);
+  border: 2px solid hsl(182, 50%, 50%);
+  margin: 16px 18px 5px 14px;
+  padding: 11px 10px;
+  border-radius: 8px 4px;
+  box-shadow: 1px 5px 2px rgba(236, 217, 198, 0.3);
+  transform: rotate(236deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box237 {
+  --cssShared-v-237: 876803;
+  color: hsl(129, 81%, 39%);
+  background-color: hsl(309, 81%, 61%);
+  border: 3px solid hsl(219, 50%, 50%);
+  margin: 17px 21px 10px 3px;
+  padding: 12px 12px;
+  border-radius: 9px 6px;
+  box-shadow: 2px 6px 3px rgba(237, 219, 201, 0.4);
+  transform: rotate(237deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box238 {
+  --cssShared-v-238: 884722;
+  color: hsl(166, 94%, 46%);
+  background-color: hsl(346, 94%, 54%);
+  border: 4px solid hsl(256, 50%, 50%);
+  margin: 18px 24px 15px 10px;
+  padding: 13px 14px;
+  border-radius: 10px 8px;
+  box-shadow: 3px 0px 4px rgba(238, 221, 204, 0.5);
+  transform: rotate(238deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box239 {
+  --cssShared-v-239: 892641;
+  color: hsl(203, 7%, 53%);
+  background-color: hsl(23, 7%, 47%);
+  border: 5px solid hsl(293, 50%, 50%);
+  margin: 19px 27px 20px 17px;
+  padding: 14px 16px;
+  border-radius: 11px 1px;
+  box-shadow: 4px 1px 5px rgba(239, 223, 207, 0.6);
+  transform: rotate(239deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box240 {
+  --cssShared-v-240: 900560;
+  color: hsl(240, 20%, 60%);
+  background-color: hsl(60, 20%, 40%);
+  border: 1px solid hsl(330, 50%, 50%);
+  margin: 0px 0px 0px 6px;
+  padding: 0px 18px;
+  border-radius: 0px 3px;
+  box-shadow: 0px 2px 6px rgba(240, 225, 210, 0.7);
+  transform: rotate(240deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box241 {
+  --cssShared-v-241: 908479;
+  color: hsl(277, 33%, 67%);
+  background-color: hsl(97, 33%, 33%);
+  border: 2px solid hsl(7, 50%, 50%);
+  margin: 1px 3px 5px 13px;
+  padding: 1px 20px;
+  border-radius: 1px 5px;
+  box-shadow: 1px 3px 7px rgba(241, 227, 213, 0.8);
+  transform: rotate(241deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box242 {
+  --cssShared-v-242: 916398;
+  color: hsl(314, 46%, 74%);
+  background-color: hsl(134, 46%, 26%);
+  border: 3px solid hsl(44, 50%, 50%);
+  margin: 2px 6px 10px 2px;
+  padding: 2px 0px;
+  border-radius: 2px 7px;
+  box-shadow: 2px 4px 8px rgba(242, 229, 216, 0.9);
+  transform: rotate(242deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box243 {
+  --cssShared-v-243: 924317;
+  color: hsl(351, 59%, 31%);
+  background-color: hsl(171, 59%, 69%);
+  border: 4px solid hsl(81, 50%, 50%);
+  margin: 3px 9px 15px 9px;
+  padding: 3px 2px;
+  border-radius: 3px 0px;
+  box-shadow: 3px 5px 0px rgba(243, 231, 219, 0.1);
+  transform: rotate(243deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box244 {
+  --cssShared-v-244: 932236;
+  color: hsl(28, 72%, 38%);
+  background-color: hsl(208, 72%, 62%);
+  border: 5px solid hsl(118, 50%, 50%);
+  margin: 4px 12px 20px 16px;
+  padding: 4px 4px;
+  border-radius: 4px 2px;
+  box-shadow: 4px 6px 1px rgba(244, 233, 222, 0.2);
+  transform: rotate(244deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box245 {
+  --cssShared-v-245: 940155;
+  color: hsl(65, 85%, 45%);
+  background-color: hsl(245, 85%, 55%);
+  border: 1px solid hsl(155, 50%, 50%);
+  margin: 5px 15px 0px 5px;
+  padding: 5px 6px;
+  border-radius: 5px 4px;
+  box-shadow: 0px 0px 2px rgba(245, 235, 225, 0.3);
+  transform: rotate(245deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box246 {
+  --cssShared-v-246: 948074;
+  color: hsl(102, 98%, 52%);
+  background-color: hsl(282, 98%, 48%);
+  border: 2px solid hsl(192, 50%, 50%);
+  margin: 6px 18px 5px 12px;
+  padding: 6px 8px;
+  border-radius: 6px 6px;
+  box-shadow: 1px 1px 3px rgba(246, 237, 228, 0.4);
+  transform: rotate(246deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box247 {
+  --cssShared-v-247: 955993;
+  color: hsl(139, 11%, 59%);
+  background-color: hsl(319, 11%, 41%);
+  border: 3px solid hsl(229, 50%, 50%);
+  margin: 7px 21px 10px 1px;
+  padding: 7px 10px;
+  border-radius: 7px 8px;
+  box-shadow: 2px 2px 4px rgba(247, 239, 231, 0.5);
+  transform: rotate(247deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box248 {
+  --cssShared-v-248: 963912;
+  color: hsl(176, 24%, 66%);
+  background-color: hsl(356, 24%, 34%);
+  border: 4px solid hsl(266, 50%, 50%);
+  margin: 8px 24px 15px 8px;
+  padding: 8px 12px;
+  border-radius: 8px 1px;
+  box-shadow: 3px 3px 5px rgba(248, 241, 234, 0.6);
+  transform: rotate(248deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box249 {
+  --cssShared-v-249: 971831;
+  color: hsl(213, 37%, 73%);
+  background-color: hsl(33, 37%, 27%);
+  border: 5px solid hsl(303, 50%, 50%);
+  margin: 9px 27px 20px 15px;
+  padding: 9px 14px;
+  border-radius: 9px 3px;
+  box-shadow: 4px 4px 6px rgba(249, 243, 237, 0.7);
+  transform: rotate(249deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box250 {
+  --cssShared-v-250: 979750;
+  color: hsl(250, 50%, 30%);
+  background-color: hsl(70, 50%, 70%);
+  border: 1px solid hsl(340, 50%, 50%);
+  margin: 10px 0px 0px 4px;
+  padding: 10px 16px;
+  border-radius: 10px 5px;
+  box-shadow: 0px 5px 7px rgba(250, 245, 240, 0.8);
+  transform: rotate(250deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box251 {
+  --cssShared-v-251: 987669;
+  color: hsl(287, 63%, 37%);
+  background-color: hsl(107, 63%, 63%);
+  border: 2px solid hsl(17, 50%, 50%);
+  margin: 11px 3px 5px 11px;
+  padding: 11px 18px;
+  border-radius: 11px 7px;
+  box-shadow: 1px 6px 8px rgba(251, 247, 243, 0.9);
+  transform: rotate(251deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box252 {
+  --cssShared-v-252: 995588;
+  color: hsl(324, 76%, 44%);
+  background-color: hsl(144, 76%, 56%);
+  border: 3px solid hsl(54, 50%, 50%);
+  margin: 12px 6px 10px 0px;
+  padding: 12px 20px;
+  border-radius: 0px 0px;
+  box-shadow: 2px 0px 0px rgba(252, 249, 246, 0.1);
+  transform: rotate(252deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box253 {
+  --cssShared-v-253: 3507;
+  color: hsl(1, 89%, 51%);
+  background-color: hsl(181, 89%, 49%);
+  border: 4px solid hsl(91, 50%, 50%);
+  margin: 13px 9px 15px 7px;
+  padding: 13px 0px;
+  border-radius: 1px 2px;
+  box-shadow: 3px 1px 1px rgba(253, 251, 249, 0.2);
+  transform: rotate(253deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box254 {
+  --cssShared-v-254: 11426;
+  color: hsl(38, 2%, 58%);
+  background-color: hsl(218, 2%, 42%);
+  border: 5px solid hsl(128, 50%, 50%);
+  margin: 14px 12px 20px 14px;
+  padding: 14px 2px;
+  border-radius: 2px 4px;
+  box-shadow: 4px 2px 2px rgba(254, 253, 252, 0.3);
+  transform: rotate(254deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box255 {
+  --cssShared-v-255: 19345;
+  color: hsl(75, 15%, 65%);
+  background-color: hsl(255, 15%, 35%);
+  border: 1px solid hsl(165, 50%, 50%);
+  margin: 15px 15px 0px 3px;
+  padding: 0px 4px;
+  border-radius: 3px 6px;
+  box-shadow: 0px 3px 3px rgba(0, 0, 0, 0.4);
+  transform: rotate(255deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box256 {
+  --cssShared-v-256: 27264;
+  color: hsl(112, 28%, 72%);
+  background-color: hsl(292, 28%, 28%);
+  border: 2px solid hsl(202, 50%, 50%);
+  margin: 16px 18px 5px 10px;
+  padding: 1px 6px;
+  border-radius: 4px 8px;
+  box-shadow: 1px 4px 4px rgba(1, 2, 3, 0.5);
+  transform: rotate(256deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box257 {
+  --cssShared-v-257: 35183;
+  color: hsl(149, 41%, 79%);
+  background-color: hsl(329, 41%, 21%);
+  border: 3px solid hsl(239, 50%, 50%);
+  margin: 17px 21px 10px 17px;
+  padding: 2px 8px;
+  border-radius: 5px 1px;
+  box-shadow: 2px 5px 5px rgba(2, 4, 6, 0.6);
+  transform: rotate(257deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box258 {
+  --cssShared-v-258: 43102;
+  color: hsl(186, 54%, 36%);
+  background-color: hsl(6, 54%, 64%);
+  border: 4px solid hsl(276, 50%, 50%);
+  margin: 18px 24px 15px 6px;
+  padding: 3px 10px;
+  border-radius: 6px 3px;
+  box-shadow: 3px 6px 6px rgba(3, 6, 9, 0.7);
+  transform: rotate(258deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box259 {
+  --cssShared-v-259: 51021;
+  color: hsl(223, 67%, 43%);
+  background-color: hsl(43, 67%, 57%);
+  border: 5px solid hsl(313, 50%, 50%);
+  margin: 19px 27px 20px 13px;
+  padding: 4px 12px;
+  border-radius: 7px 5px;
+  box-shadow: 4px 0px 7px rgba(4, 8, 12, 0.8);
+  transform: rotate(259deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box260 {
+  --cssShared-v-260: 58940;
+  color: hsl(260, 80%, 50%);
+  background-color: hsl(80, 80%, 50%);
+  border: 1px solid hsl(350, 50%, 50%);
+  margin: 0px 0px 0px 2px;
+  padding: 5px 14px;
+  border-radius: 8px 7px;
+  box-shadow: 0px 1px 8px rgba(5, 10, 15, 0.9);
+  transform: rotate(260deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box261 {
+  --cssShared-v-261: 66859;
+  color: hsl(297, 93%, 57%);
+  background-color: hsl(117, 93%, 43%);
+  border: 2px solid hsl(27, 50%, 50%);
+  margin: 1px 3px 5px 9px;
+  padding: 6px 16px;
+  border-radius: 9px 0px;
+  box-shadow: 1px 2px 0px rgba(6, 12, 18, 0.1);
+  transform: rotate(261deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box262 {
+  --cssShared-v-262: 74778;
+  color: hsl(334, 6%, 64%);
+  background-color: hsl(154, 6%, 36%);
+  border: 3px solid hsl(64, 50%, 50%);
+  margin: 2px 6px 10px 16px;
+  padding: 7px 18px;
+  border-radius: 10px 2px;
+  box-shadow: 2px 3px 1px rgba(7, 14, 21, 0.2);
+  transform: rotate(262deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box263 {
+  --cssShared-v-263: 82697;
+  color: hsl(11, 19%, 71%);
+  background-color: hsl(191, 19%, 29%);
+  border: 4px solid hsl(101, 50%, 50%);
+  margin: 3px 9px 15px 5px;
+  padding: 8px 20px;
+  border-radius: 11px 4px;
+  box-shadow: 3px 4px 2px rgba(8, 16, 24, 0.3);
+  transform: rotate(263deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box264 {
+  --cssShared-v-264: 90616;
+  color: hsl(48, 32%, 78%);
+  background-color: hsl(228, 32%, 22%);
+  border: 5px solid hsl(138, 50%, 50%);
+  margin: 4px 12px 20px 12px;
+  padding: 9px 0px;
+  border-radius: 0px 6px;
+  box-shadow: 4px 5px 3px rgba(9, 18, 27, 0.4);
+  transform: rotate(264deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box265 {
+  --cssShared-v-265: 98535;
+  color: hsl(85, 45%, 35%);
+  background-color: hsl(265, 45%, 65%);
+  border: 1px solid hsl(175, 50%, 50%);
+  margin: 5px 15px 0px 1px;
+  padding: 10px 2px;
+  border-radius: 1px 8px;
+  box-shadow: 0px 6px 4px rgba(10, 20, 30, 0.5);
+  transform: rotate(265deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box266 {
+  --cssShared-v-266: 106454;
+  color: hsl(122, 58%, 42%);
+  background-color: hsl(302, 58%, 58%);
+  border: 2px solid hsl(212, 50%, 50%);
+  margin: 6px 18px 5px 8px;
+  padding: 11px 4px;
+  border-radius: 2px 1px;
+  box-shadow: 1px 0px 5px rgba(11, 22, 33, 0.6);
+  transform: rotate(266deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box267 {
+  --cssShared-v-267: 114373;
+  color: hsl(159, 71%, 49%);
+  background-color: hsl(339, 71%, 51%);
+  border: 3px solid hsl(249, 50%, 50%);
+  margin: 7px 21px 10px 15px;
+  padding: 12px 6px;
+  border-radius: 3px 3px;
+  box-shadow: 2px 1px 6px rgba(12, 24, 36, 0.7);
+  transform: rotate(267deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box268 {
+  --cssShared-v-268: 122292;
+  color: hsl(196, 84%, 56%);
+  background-color: hsl(16, 84%, 44%);
+  border: 4px solid hsl(286, 50%, 50%);
+  margin: 8px 24px 15px 4px;
+  padding: 13px 8px;
+  border-radius: 4px 5px;
+  box-shadow: 3px 2px 7px rgba(13, 26, 39, 0.8);
+  transform: rotate(268deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box269 {
+  --cssShared-v-269: 130211;
+  color: hsl(233, 97%, 63%);
+  background-color: hsl(53, 97%, 37%);
+  border: 5px solid hsl(323, 50%, 50%);
+  margin: 9px 27px 20px 11px;
+  padding: 14px 10px;
+  border-radius: 5px 7px;
+  box-shadow: 4px 3px 8px rgba(14, 28, 42, 0.9);
+  transform: rotate(269deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box270 {
+  --cssShared-v-270: 138130;
+  color: hsl(270, 10%, 70%);
+  background-color: hsl(90, 10%, 30%);
+  border: 1px solid hsl(0, 50%, 50%);
+  margin: 10px 0px 0px 0px;
+  padding: 0px 12px;
+  border-radius: 6px 0px;
+  box-shadow: 0px 4px 0px rgba(15, 30, 45, 0.1);
+  transform: rotate(270deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box271 {
+  --cssShared-v-271: 146049;
+  color: hsl(307, 23%, 77%);
+  background-color: hsl(127, 23%, 23%);
+  border: 2px solid hsl(37, 50%, 50%);
+  margin: 11px 3px 5px 7px;
+  padding: 1px 14px;
+  border-radius: 7px 2px;
+  box-shadow: 1px 5px 1px rgba(16, 32, 48, 0.2);
+  transform: rotate(271deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box272 {
+  --cssShared-v-272: 153968;
+  color: hsl(344, 36%, 34%);
+  background-color: hsl(164, 36%, 66%);
+  border: 3px solid hsl(74, 50%, 50%);
+  margin: 12px 6px 10px 14px;
+  padding: 2px 16px;
+  border-radius: 8px 4px;
+  box-shadow: 2px 6px 2px rgba(17, 34, 51, 0.3);
+  transform: rotate(272deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box273 {
+  --cssShared-v-273: 161887;
+  color: hsl(21, 49%, 41%);
+  background-color: hsl(201, 49%, 59%);
+  border: 4px solid hsl(111, 50%, 50%);
+  margin: 13px 9px 15px 3px;
+  padding: 3px 18px;
+  border-radius: 9px 6px;
+  box-shadow: 3px 0px 3px rgba(18, 36, 54, 0.4);
+  transform: rotate(273deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box274 {
+  --cssShared-v-274: 169806;
+  color: hsl(58, 62%, 48%);
+  background-color: hsl(238, 62%, 52%);
+  border: 5px solid hsl(148, 50%, 50%);
+  margin: 14px 12px 20px 10px;
+  padding: 4px 20px;
+  border-radius: 10px 8px;
+  box-shadow: 4px 1px 4px rgba(19, 38, 57, 0.5);
+  transform: rotate(274deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box275 {
+  --cssShared-v-275: 177725;
+  color: hsl(95, 75%, 55%);
+  background-color: hsl(275, 75%, 45%);
+  border: 1px solid hsl(185, 50%, 50%);
+  margin: 15px 15px 0px 17px;
+  padding: 5px 0px;
+  border-radius: 11px 1px;
+  box-shadow: 0px 2px 5px rgba(20, 40, 60, 0.6);
+  transform: rotate(275deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box276 {
+  --cssShared-v-276: 185644;
+  color: hsl(132, 88%, 62%);
+  background-color: hsl(312, 88%, 38%);
+  border: 2px solid hsl(222, 50%, 50%);
+  margin: 16px 18px 5px 6px;
+  padding: 6px 2px;
+  border-radius: 0px 3px;
+  box-shadow: 1px 3px 6px rgba(21, 42, 63, 0.7);
+  transform: rotate(276deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box277 {
+  --cssShared-v-277: 193563;
+  color: hsl(169, 1%, 69%);
+  background-color: hsl(349, 1%, 31%);
+  border: 3px solid hsl(259, 50%, 50%);
+  margin: 17px 21px 10px 13px;
+  padding: 7px 4px;
+  border-radius: 1px 5px;
+  box-shadow: 2px 4px 7px rgba(22, 44, 66, 0.8);
+  transform: rotate(277deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box278 {
+  --cssShared-v-278: 201482;
+  color: hsl(206, 14%, 76%);
+  background-color: hsl(26, 14%, 24%);
+  border: 4px solid hsl(296, 50%, 50%);
+  margin: 18px 24px 15px 2px;
+  padding: 8px 6px;
+  border-radius: 2px 7px;
+  box-shadow: 3px 5px 8px rgba(23, 46, 69, 0.9);
+  transform: rotate(278deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box279 {
+  --cssShared-v-279: 209401;
+  color: hsl(243, 27%, 33%);
+  background-color: hsl(63, 27%, 67%);
+  border: 5px solid hsl(333, 50%, 50%);
+  margin: 19px 27px 20px 9px;
+  padding: 9px 8px;
+  border-radius: 3px 0px;
+  box-shadow: 4px 6px 0px rgba(24, 48, 72, 0.1);
+  transform: rotate(279deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box280 {
+  --cssShared-v-280: 217320;
+  color: hsl(280, 40%, 40%);
+  background-color: hsl(100, 40%, 60%);
+  border: 1px solid hsl(10, 50%, 50%);
+  margin: 0px 0px 0px 16px;
+  padding: 10px 10px;
+  border-radius: 4px 2px;
+  box-shadow: 0px 0px 1px rgba(25, 50, 75, 0.2);
+  transform: rotate(280deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box281 {
+  --cssShared-v-281: 225239;
+  color: hsl(317, 53%, 47%);
+  background-color: hsl(137, 53%, 53%);
+  border: 2px solid hsl(47, 50%, 50%);
+  margin: 1px 3px 5px 5px;
+  padding: 11px 12px;
+  border-radius: 5px 4px;
+  box-shadow: 1px 1px 2px rgba(26, 52, 78, 0.3);
+  transform: rotate(281deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box282 {
+  --cssShared-v-282: 233158;
+  color: hsl(354, 66%, 54%);
+  background-color: hsl(174, 66%, 46%);
+  border: 3px solid hsl(84, 50%, 50%);
+  margin: 2px 6px 10px 12px;
+  padding: 12px 14px;
+  border-radius: 6px 6px;
+  box-shadow: 2px 2px 3px rgba(27, 54, 81, 0.4);
+  transform: rotate(282deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box283 {
+  --cssShared-v-283: 241077;
+  color: hsl(31, 79%, 61%);
+  background-color: hsl(211, 79%, 39%);
+  border: 4px solid hsl(121, 50%, 50%);
+  margin: 3px 9px 15px 1px;
+  padding: 13px 16px;
+  border-radius: 7px 8px;
+  box-shadow: 3px 3px 4px rgba(28, 56, 84, 0.5);
+  transform: rotate(283deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box284 {
+  --cssShared-v-284: 248996;
+  color: hsl(68, 92%, 68%);
+  background-color: hsl(248, 92%, 32%);
+  border: 5px solid hsl(158, 50%, 50%);
+  margin: 4px 12px 20px 8px;
+  padding: 14px 18px;
+  border-radius: 8px 1px;
+  box-shadow: 4px 4px 5px rgba(29, 58, 87, 0.6);
+  transform: rotate(284deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box285 {
+  --cssShared-v-285: 256915;
+  color: hsl(105, 5%, 75%);
+  background-color: hsl(285, 5%, 25%);
+  border: 1px solid hsl(195, 50%, 50%);
+  margin: 5px 15px 0px 15px;
+  padding: 0px 20px;
+  border-radius: 9px 3px;
+  box-shadow: 0px 5px 6px rgba(30, 60, 90, 0.7);
+  transform: rotate(285deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box286 {
+  --cssShared-v-286: 264834;
+  color: hsl(142, 18%, 32%);
+  background-color: hsl(322, 18%, 68%);
+  border: 2px solid hsl(232, 50%, 50%);
+  margin: 6px 18px 5px 4px;
+  padding: 1px 0px;
+  border-radius: 10px 5px;
+  box-shadow: 1px 6px 7px rgba(31, 62, 93, 0.8);
+  transform: rotate(286deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box287 {
+  --cssShared-v-287: 272753;
+  color: hsl(179, 31%, 39%);
+  background-color: hsl(359, 31%, 61%);
+  border: 3px solid hsl(269, 50%, 50%);
+  margin: 7px 21px 10px 11px;
+  padding: 2px 2px;
+  border-radius: 11px 7px;
+  box-shadow: 2px 0px 8px rgba(32, 64, 96, 0.9);
+  transform: rotate(287deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box288 {
+  --cssShared-v-288: 280672;
+  color: hsl(216, 44%, 46%);
+  background-color: hsl(36, 44%, 54%);
+  border: 4px solid hsl(306, 50%, 50%);
+  margin: 8px 24px 15px 0px;
+  padding: 3px 4px;
+  border-radius: 0px 0px;
+  box-shadow: 3px 1px 0px rgba(33, 66, 99, 0.1);
+  transform: rotate(288deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box289 {
+  --cssShared-v-289: 288591;
+  color: hsl(253, 57%, 53%);
+  background-color: hsl(73, 57%, 47%);
+  border: 5px solid hsl(343, 50%, 50%);
+  margin: 9px 27px 20px 7px;
+  padding: 4px 6px;
+  border-radius: 1px 2px;
+  box-shadow: 4px 2px 1px rgba(34, 68, 102, 0.2);
+  transform: rotate(289deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box290 {
+  --cssShared-v-290: 296510;
+  color: hsl(290, 70%, 60%);
+  background-color: hsl(110, 70%, 40%);
+  border: 1px solid hsl(20, 50%, 50%);
+  margin: 10px 0px 0px 14px;
+  padding: 5px 8px;
+  border-radius: 2px 4px;
+  box-shadow: 0px 3px 2px rgba(35, 70, 105, 0.3);
+  transform: rotate(290deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box291 {
+  --cssShared-v-291: 304429;
+  color: hsl(327, 83%, 67%);
+  background-color: hsl(147, 83%, 33%);
+  border: 2px solid hsl(57, 50%, 50%);
+  margin: 11px 3px 5px 3px;
+  padding: 6px 10px;
+  border-radius: 3px 6px;
+  box-shadow: 1px 4px 3px rgba(36, 72, 108, 0.4);
+  transform: rotate(291deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box292 {
+  --cssShared-v-292: 312348;
+  color: hsl(4, 96%, 74%);
+  background-color: hsl(184, 96%, 26%);
+  border: 3px solid hsl(94, 50%, 50%);
+  margin: 12px 6px 10px 10px;
+  padding: 7px 12px;
+  border-radius: 4px 8px;
+  box-shadow: 2px 5px 4px rgba(37, 74, 111, 0.5);
+  transform: rotate(292deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box293 {
+  --cssShared-v-293: 320267;
+  color: hsl(41, 9%, 31%);
+  background-color: hsl(221, 9%, 69%);
+  border: 4px solid hsl(131, 50%, 50%);
+  margin: 13px 9px 15px 17px;
+  padding: 8px 14px;
+  border-radius: 5px 1px;
+  box-shadow: 3px 6px 5px rgba(38, 76, 114, 0.6);
+  transform: rotate(293deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box294 {
+  --cssShared-v-294: 328186;
+  color: hsl(78, 22%, 38%);
+  background-color: hsl(258, 22%, 62%);
+  border: 5px solid hsl(168, 50%, 50%);
+  margin: 14px 12px 20px 6px;
+  padding: 9px 16px;
+  border-radius: 6px 3px;
+  box-shadow: 4px 0px 6px rgba(39, 78, 117, 0.7);
+  transform: rotate(294deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box295 {
+  --cssShared-v-295: 336105;
+  color: hsl(115, 35%, 45%);
+  background-color: hsl(295, 35%, 55%);
+  border: 1px solid hsl(205, 50%, 50%);
+  margin: 15px 15px 0px 13px;
+  padding: 10px 18px;
+  border-radius: 7px 5px;
+  box-shadow: 0px 1px 7px rgba(40, 80, 120, 0.8);
+  transform: rotate(295deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box296 {
+  --cssShared-v-296: 344024;
+  color: hsl(152, 48%, 52%);
+  background-color: hsl(332, 48%, 48%);
+  border: 2px solid hsl(242, 50%, 50%);
+  margin: 16px 18px 5px 2px;
+  padding: 11px 20px;
+  border-radius: 8px 7px;
+  box-shadow: 1px 2px 8px rgba(41, 82, 123, 0.9);
+  transform: rotate(296deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box297 {
+  --cssShared-v-297: 351943;
+  color: hsl(189, 61%, 59%);
+  background-color: hsl(9, 61%, 41%);
+  border: 3px solid hsl(279, 50%, 50%);
+  margin: 17px 21px 10px 9px;
+  padding: 12px 0px;
+  border-radius: 9px 0px;
+  box-shadow: 2px 3px 0px rgba(42, 84, 126, 0.1);
+  transform: rotate(297deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box298 {
+  --cssShared-v-298: 359862;
+  color: hsl(226, 74%, 66%);
+  background-color: hsl(46, 74%, 34%);
+  border: 4px solid hsl(316, 50%, 50%);
+  margin: 18px 24px 15px 16px;
+  padding: 13px 2px;
+  border-radius: 10px 2px;
+  box-shadow: 3px 4px 1px rgba(43, 86, 129, 0.2);
+  transform: rotate(298deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box299 {
+  --cssShared-v-299: 367781;
+  color: hsl(263, 87%, 73%);
+  background-color: hsl(83, 87%, 27%);
+  border: 5px solid hsl(353, 50%, 50%);
+  margin: 19px 27px 20px 5px;
+  padding: 14px 4px;
+  border-radius: 11px 4px;
+  box-shadow: 4px 5px 2px rgba(44, 88, 132, 0.3);
+  transform: rotate(299deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box300 {
+  --cssShared-v-300: 375700;
+  color: hsl(300, 0%, 30%);
+  background-color: hsl(120, 0%, 70%);
+  border: 1px solid hsl(30, 50%, 50%);
+  margin: 0px 0px 0px 12px;
+  padding: 0px 6px;
+  border-radius: 0px 6px;
+  box-shadow: 0px 6px 3px rgba(45, 90, 135, 0.4);
+  transform: rotate(300deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box301 {
+  --cssShared-v-301: 383619;
+  color: hsl(337, 13%, 37%);
+  background-color: hsl(157, 13%, 63%);
+  border: 2px solid hsl(67, 50%, 50%);
+  margin: 1px 3px 5px 1px;
+  padding: 1px 8px;
+  border-radius: 1px 8px;
+  box-shadow: 1px 0px 4px rgba(46, 92, 138, 0.5);
+  transform: rotate(301deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box302 {
+  --cssShared-v-302: 391538;
+  color: hsl(14, 26%, 44%);
+  background-color: hsl(194, 26%, 56%);
+  border: 3px solid hsl(104, 50%, 50%);
+  margin: 2px 6px 10px 8px;
+  padding: 2px 10px;
+  border-radius: 2px 1px;
+  box-shadow: 2px 1px 5px rgba(47, 94, 141, 0.6);
+  transform: rotate(302deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box303 {
+  --cssShared-v-303: 399457;
+  color: hsl(51, 39%, 51%);
+  background-color: hsl(231, 39%, 49%);
+  border: 4px solid hsl(141, 50%, 50%);
+  margin: 3px 9px 15px 15px;
+  padding: 3px 12px;
+  border-radius: 3px 3px;
+  box-shadow: 3px 2px 6px rgba(48, 96, 144, 0.7);
+  transform: rotate(303deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box304 {
+  --cssShared-v-304: 407376;
+  color: hsl(88, 52%, 58%);
+  background-color: hsl(268, 52%, 42%);
+  border: 5px solid hsl(178, 50%, 50%);
+  margin: 4px 12px 20px 4px;
+  padding: 4px 14px;
+  border-radius: 4px 5px;
+  box-shadow: 4px 3px 7px rgba(49, 98, 147, 0.8);
+  transform: rotate(304deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box305 {
+  --cssShared-v-305: 415295;
+  color: hsl(125, 65%, 65%);
+  background-color: hsl(305, 65%, 35%);
+  border: 1px solid hsl(215, 50%, 50%);
+  margin: 5px 15px 0px 11px;
+  padding: 5px 16px;
+  border-radius: 5px 7px;
+  box-shadow: 0px 4px 8px rgba(50, 100, 150, 0.9);
+  transform: rotate(305deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box306 {
+  --cssShared-v-306: 423214;
+  color: hsl(162, 78%, 72%);
+  background-color: hsl(342, 78%, 28%);
+  border: 2px solid hsl(252, 50%, 50%);
+  margin: 6px 18px 5px 0px;
+  padding: 6px 18px;
+  border-radius: 6px 0px;
+  box-shadow: 1px 5px 0px rgba(51, 102, 153, 0.1);
+  transform: rotate(306deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box307 {
+  --cssShared-v-307: 431133;
+  color: hsl(199, 91%, 79%);
+  background-color: hsl(19, 91%, 21%);
+  border: 3px solid hsl(289, 50%, 50%);
+  margin: 7px 21px 10px 7px;
+  padding: 7px 20px;
+  border-radius: 7px 2px;
+  box-shadow: 2px 6px 1px rgba(52, 104, 156, 0.2);
+  transform: rotate(307deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box308 {
+  --cssShared-v-308: 439052;
+  color: hsl(236, 4%, 36%);
+  background-color: hsl(56, 4%, 64%);
+  border: 4px solid hsl(326, 50%, 50%);
+  margin: 8px 24px 15px 14px;
+  padding: 8px 0px;
+  border-radius: 8px 4px;
+  box-shadow: 3px 0px 2px rgba(53, 106, 159, 0.3);
+  transform: rotate(308deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box309 {
+  --cssShared-v-309: 446971;
+  color: hsl(273, 17%, 43%);
+  background-color: hsl(93, 17%, 57%);
+  border: 5px solid hsl(3, 50%, 50%);
+  margin: 9px 27px 20px 3px;
+  padding: 9px 2px;
+  border-radius: 9px 6px;
+  box-shadow: 4px 1px 3px rgba(54, 108, 162, 0.4);
+  transform: rotate(309deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box310 {
+  --cssShared-v-310: 454890;
+  color: hsl(310, 30%, 50%);
+  background-color: hsl(130, 30%, 50%);
+  border: 1px solid hsl(40, 50%, 50%);
+  margin: 10px 0px 0px 10px;
+  padding: 10px 4px;
+  border-radius: 10px 8px;
+  box-shadow: 0px 2px 4px rgba(55, 110, 165, 0.5);
+  transform: rotate(310deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box311 {
+  --cssShared-v-311: 462809;
+  color: hsl(347, 43%, 57%);
+  background-color: hsl(167, 43%, 43%);
+  border: 2px solid hsl(77, 50%, 50%);
+  margin: 11px 3px 5px 17px;
+  padding: 11px 6px;
+  border-radius: 11px 1px;
+  box-shadow: 1px 3px 5px rgba(56, 112, 168, 0.6);
+  transform: rotate(311deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box312 {
+  --cssShared-v-312: 470728;
+  color: hsl(24, 56%, 64%);
+  background-color: hsl(204, 56%, 36%);
+  border: 3px solid hsl(114, 50%, 50%);
+  margin: 12px 6px 10px 6px;
+  padding: 12px 8px;
+  border-radius: 0px 3px;
+  box-shadow: 2px 4px 6px rgba(57, 114, 171, 0.7);
+  transform: rotate(312deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box313 {
+  --cssShared-v-313: 478647;
+  color: hsl(61, 69%, 71%);
+  background-color: hsl(241, 69%, 29%);
+  border: 4px solid hsl(151, 50%, 50%);
+  margin: 13px 9px 15px 13px;
+  padding: 13px 10px;
+  border-radius: 1px 5px;
+  box-shadow: 3px 5px 7px rgba(58, 116, 174, 0.8);
+  transform: rotate(313deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box314 {
+  --cssShared-v-314: 486566;
+  color: hsl(98, 82%, 78%);
+  background-color: hsl(278, 82%, 22%);
+  border: 5px solid hsl(188, 50%, 50%);
+  margin: 14px 12px 20px 2px;
+  padding: 14px 12px;
+  border-radius: 2px 7px;
+  box-shadow: 4px 6px 8px rgba(59, 118, 177, 0.9);
+  transform: rotate(314deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box315 {
+  --cssShared-v-315: 494485;
+  color: hsl(135, 95%, 35%);
+  background-color: hsl(315, 95%, 65%);
+  border: 1px solid hsl(225, 50%, 50%);
+  margin: 15px 15px 0px 9px;
+  padding: 0px 14px;
+  border-radius: 3px 0px;
+  box-shadow: 0px 0px 0px rgba(60, 120, 180, 0.1);
+  transform: rotate(315deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box316 {
+  --cssShared-v-316: 502404;
+  color: hsl(172, 8%, 42%);
+  background-color: hsl(352, 8%, 58%);
+  border: 2px solid hsl(262, 50%, 50%);
+  margin: 16px 18px 5px 16px;
+  padding: 1px 16px;
+  border-radius: 4px 2px;
+  box-shadow: 1px 1px 1px rgba(61, 122, 183, 0.2);
+  transform: rotate(316deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box317 {
+  --cssShared-v-317: 510323;
+  color: hsl(209, 21%, 49%);
+  background-color: hsl(29, 21%, 51%);
+  border: 3px solid hsl(299, 50%, 50%);
+  margin: 17px 21px 10px 5px;
+  padding: 2px 18px;
+  border-radius: 5px 4px;
+  box-shadow: 2px 2px 2px rgba(62, 124, 186, 0.3);
+  transform: rotate(317deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box318 {
+  --cssShared-v-318: 518242;
+  color: hsl(246, 34%, 56%);
+  background-color: hsl(66, 34%, 44%);
+  border: 4px solid hsl(336, 50%, 50%);
+  margin: 18px 24px 15px 12px;
+  padding: 3px 20px;
+  border-radius: 6px 6px;
+  box-shadow: 3px 3px 3px rgba(63, 126, 189, 0.4);
+  transform: rotate(318deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box319 {
+  --cssShared-v-319: 526161;
+  color: hsl(283, 47%, 63%);
+  background-color: hsl(103, 47%, 37%);
+  border: 5px solid hsl(13, 50%, 50%);
+  margin: 19px 27px 20px 1px;
+  padding: 4px 0px;
+  border-radius: 7px 8px;
+  box-shadow: 4px 4px 4px rgba(64, 128, 192, 0.5);
+  transform: rotate(319deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box320 {
+  --cssShared-v-320: 534080;
+  color: hsl(320, 60%, 70%);
+  background-color: hsl(140, 60%, 30%);
+  border: 1px solid hsl(50, 50%, 50%);
+  margin: 0px 0px 0px 8px;
+  padding: 5px 2px;
+  border-radius: 8px 1px;
+  box-shadow: 0px 5px 5px rgba(65, 130, 195, 0.6);
+  transform: rotate(320deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box321 {
+  --cssShared-v-321: 541999;
+  color: hsl(357, 73%, 77%);
+  background-color: hsl(177, 73%, 23%);
+  border: 2px solid hsl(87, 50%, 50%);
+  margin: 1px 3px 5px 15px;
+  padding: 6px 4px;
+  border-radius: 9px 3px;
+  box-shadow: 1px 6px 6px rgba(66, 132, 198, 0.7);
+  transform: rotate(321deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box322 {
+  --cssShared-v-322: 549918;
+  color: hsl(34, 86%, 34%);
+  background-color: hsl(214, 86%, 66%);
+  border: 3px solid hsl(124, 50%, 50%);
+  margin: 2px 6px 10px 4px;
+  padding: 7px 6px;
+  border-radius: 10px 5px;
+  box-shadow: 2px 0px 7px rgba(67, 134, 201, 0.8);
+  transform: rotate(322deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box323 {
+  --cssShared-v-323: 557837;
+  color: hsl(71, 99%, 41%);
+  background-color: hsl(251, 99%, 59%);
+  border: 4px solid hsl(161, 50%, 50%);
+  margin: 3px 9px 15px 11px;
+  padding: 8px 8px;
+  border-radius: 11px 7px;
+  box-shadow: 3px 1px 8px rgba(68, 136, 204, 0.9);
+  transform: rotate(323deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box324 {
+  --cssShared-v-324: 565756;
+  color: hsl(108, 12%, 48%);
+  background-color: hsl(288, 12%, 52%);
+  border: 5px solid hsl(198, 50%, 50%);
+  margin: 4px 12px 20px 0px;
+  padding: 9px 10px;
+  border-radius: 0px 0px;
+  box-shadow: 4px 2px 0px rgba(69, 138, 207, 0.1);
+  transform: rotate(324deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box325 {
+  --cssShared-v-325: 573675;
+  color: hsl(145, 25%, 55%);
+  background-color: hsl(325, 25%, 45%);
+  border: 1px solid hsl(235, 50%, 50%);
+  margin: 5px 15px 0px 7px;
+  padding: 10px 12px;
+  border-radius: 1px 2px;
+  box-shadow: 0px 3px 1px rgba(70, 140, 210, 0.2);
+  transform: rotate(325deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box326 {
+  --cssShared-v-326: 581594;
+  color: hsl(182, 38%, 62%);
+  background-color: hsl(2, 38%, 38%);
+  border: 2px solid hsl(272, 50%, 50%);
+  margin: 6px 18px 5px 14px;
+  padding: 11px 14px;
+  border-radius: 2px 4px;
+  box-shadow: 1px 4px 2px rgba(71, 142, 213, 0.3);
+  transform: rotate(326deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box327 {
+  --cssShared-v-327: 589513;
+  color: hsl(219, 51%, 69%);
+  background-color: hsl(39, 51%, 31%);
+  border: 3px solid hsl(309, 50%, 50%);
+  margin: 7px 21px 10px 3px;
+  padding: 12px 16px;
+  border-radius: 3px 6px;
+  box-shadow: 2px 5px 3px rgba(72, 144, 216, 0.4);
+  transform: rotate(327deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box328 {
+  --cssShared-v-328: 597432;
+  color: hsl(256, 64%, 76%);
+  background-color: hsl(76, 64%, 24%);
+  border: 4px solid hsl(346, 50%, 50%);
+  margin: 8px 24px 15px 10px;
+  padding: 13px 18px;
+  border-radius: 4px 8px;
+  box-shadow: 3px 6px 4px rgba(73, 146, 219, 0.5);
+  transform: rotate(328deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box329 {
+  --cssShared-v-329: 605351;
+  color: hsl(293, 77%, 33%);
+  background-color: hsl(113, 77%, 67%);
+  border: 5px solid hsl(23, 50%, 50%);
+  margin: 9px 27px 20px 17px;
+  padding: 14px 20px;
+  border-radius: 5px 1px;
+  box-shadow: 4px 0px 5px rgba(74, 148, 222, 0.6);
+  transform: rotate(329deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box330 {
+  --cssShared-v-330: 613270;
+  color: hsl(330, 90%, 40%);
+  background-color: hsl(150, 90%, 60%);
+  border: 1px solid hsl(60, 50%, 50%);
+  margin: 10px 0px 0px 6px;
+  padding: 0px 0px;
+  border-radius: 6px 3px;
+  box-shadow: 0px 1px 6px rgba(75, 150, 225, 0.7);
+  transform: rotate(330deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box331 {
+  --cssShared-v-331: 621189;
+  color: hsl(7, 3%, 47%);
+  background-color: hsl(187, 3%, 53%);
+  border: 2px solid hsl(97, 50%, 50%);
+  margin: 11px 3px 5px 13px;
+  padding: 1px 2px;
+  border-radius: 7px 5px;
+  box-shadow: 1px 2px 7px rgba(76, 152, 228, 0.8);
+  transform: rotate(331deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box332 {
+  --cssShared-v-332: 629108;
+  color: hsl(44, 16%, 54%);
+  background-color: hsl(224, 16%, 46%);
+  border: 3px solid hsl(134, 50%, 50%);
+  margin: 12px 6px 10px 2px;
+  padding: 2px 4px;
+  border-radius: 8px 7px;
+  box-shadow: 2px 3px 8px rgba(77, 154, 231, 0.9);
+  transform: rotate(332deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box333 {
+  --cssShared-v-333: 637027;
+  color: hsl(81, 29%, 61%);
+  background-color: hsl(261, 29%, 39%);
+  border: 4px solid hsl(171, 50%, 50%);
+  margin: 13px 9px 15px 9px;
+  padding: 3px 6px;
+  border-radius: 9px 0px;
+  box-shadow: 3px 4px 0px rgba(78, 156, 234, 0.1);
+  transform: rotate(333deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box334 {
+  --cssShared-v-334: 644946;
+  color: hsl(118, 42%, 68%);
+  background-color: hsl(298, 42%, 32%);
+  border: 5px solid hsl(208, 50%, 50%);
+  margin: 14px 12px 20px 16px;
+  padding: 4px 8px;
+  border-radius: 10px 2px;
+  box-shadow: 4px 5px 1px rgba(79, 158, 237, 0.2);
+  transform: rotate(334deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box335 {
+  --cssShared-v-335: 652865;
+  color: hsl(155, 55%, 75%);
+  background-color: hsl(335, 55%, 25%);
+  border: 1px solid hsl(245, 50%, 50%);
+  margin: 15px 15px 0px 5px;
+  padding: 5px 10px;
+  border-radius: 11px 4px;
+  box-shadow: 0px 6px 2px rgba(80, 160, 240, 0.3);
+  transform: rotate(335deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box336 {
+  --cssShared-v-336: 660784;
+  color: hsl(192, 68%, 32%);
+  background-color: hsl(12, 68%, 68%);
+  border: 2px solid hsl(282, 50%, 50%);
+  margin: 16px 18px 5px 12px;
+  padding: 6px 12px;
+  border-radius: 0px 6px;
+  box-shadow: 1px 0px 3px rgba(81, 162, 243, 0.4);
+  transform: rotate(336deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box337 {
+  --cssShared-v-337: 668703;
+  color: hsl(229, 81%, 39%);
+  background-color: hsl(49, 81%, 61%);
+  border: 3px solid hsl(319, 50%, 50%);
+  margin: 17px 21px 10px 1px;
+  padding: 7px 14px;
+  border-radius: 1px 8px;
+  box-shadow: 2px 1px 4px rgba(82, 164, 246, 0.5);
+  transform: rotate(337deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box338 {
+  --cssShared-v-338: 676622;
+  color: hsl(266, 94%, 46%);
+  background-color: hsl(86, 94%, 54%);
+  border: 4px solid hsl(356, 50%, 50%);
+  margin: 18px 24px 15px 8px;
+  padding: 8px 16px;
+  border-radius: 2px 1px;
+  box-shadow: 3px 2px 5px rgba(83, 166, 249, 0.6);
+  transform: rotate(338deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box339 {
+  --cssShared-v-339: 684541;
+  color: hsl(303, 7%, 53%);
+  background-color: hsl(123, 7%, 47%);
+  border: 5px solid hsl(33, 50%, 50%);
+  margin: 19px 27px 20px 15px;
+  padding: 9px 18px;
+  border-radius: 3px 3px;
+  box-shadow: 4px 3px 6px rgba(84, 168, 252, 0.7);
+  transform: rotate(339deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box340 {
+  --cssShared-v-340: 692460;
+  color: hsl(340, 20%, 60%);
+  background-color: hsl(160, 20%, 40%);
+  border: 1px solid hsl(70, 50%, 50%);
+  margin: 0px 0px 0px 4px;
+  padding: 10px 20px;
+  border-radius: 4px 5px;
+  box-shadow: 0px 4px 7px rgba(85, 170, 0, 0.8);
+  transform: rotate(340deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box341 {
+  --cssShared-v-341: 700379;
+  color: hsl(17, 33%, 67%);
+  background-color: hsl(197, 33%, 33%);
+  border: 2px solid hsl(107, 50%, 50%);
+  margin: 1px 3px 5px 11px;
+  padding: 11px 0px;
+  border-radius: 5px 7px;
+  box-shadow: 1px 5px 8px rgba(86, 172, 3, 0.9);
+  transform: rotate(341deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box342 {
+  --cssShared-v-342: 708298;
+  color: hsl(54, 46%, 74%);
+  background-color: hsl(234, 46%, 26%);
+  border: 3px solid hsl(144, 50%, 50%);
+  margin: 2px 6px 10px 0px;
+  padding: 12px 2px;
+  border-radius: 6px 0px;
+  box-shadow: 2px 6px 0px rgba(87, 174, 6, 0.1);
+  transform: rotate(342deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box343 {
+  --cssShared-v-343: 716217;
+  color: hsl(91, 59%, 31%);
+  background-color: hsl(271, 59%, 69%);
+  border: 4px solid hsl(181, 50%, 50%);
+  margin: 3px 9px 15px 7px;
+  padding: 13px 4px;
+  border-radius: 7px 2px;
+  box-shadow: 3px 0px 1px rgba(88, 176, 9, 0.2);
+  transform: rotate(343deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box344 {
+  --cssShared-v-344: 724136;
+  color: hsl(128, 72%, 38%);
+  background-color: hsl(308, 72%, 62%);
+  border: 5px solid hsl(218, 50%, 50%);
+  margin: 4px 12px 20px 14px;
+  padding: 14px 6px;
+  border-radius: 8px 4px;
+  box-shadow: 4px 1px 2px rgba(89, 178, 12, 0.3);
+  transform: rotate(344deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box345 {
+  --cssShared-v-345: 732055;
+  color: hsl(165, 85%, 45%);
+  background-color: hsl(345, 85%, 55%);
+  border: 1px solid hsl(255, 50%, 50%);
+  margin: 5px 15px 0px 3px;
+  padding: 0px 8px;
+  border-radius: 9px 6px;
+  box-shadow: 0px 2px 3px rgba(90, 180, 15, 0.4);
+  transform: rotate(345deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box346 {
+  --cssShared-v-346: 739974;
+  color: hsl(202, 98%, 52%);
+  background-color: hsl(22, 98%, 48%);
+  border: 2px solid hsl(292, 50%, 50%);
+  margin: 6px 18px 5px 10px;
+  padding: 1px 10px;
+  border-radius: 10px 8px;
+  box-shadow: 1px 3px 4px rgba(91, 182, 18, 0.5);
+  transform: rotate(346deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box347 {
+  --cssShared-v-347: 747893;
+  color: hsl(239, 11%, 59%);
+  background-color: hsl(59, 11%, 41%);
+  border: 3px solid hsl(329, 50%, 50%);
+  margin: 7px 21px 10px 17px;
+  padding: 2px 12px;
+  border-radius: 11px 1px;
+  box-shadow: 2px 4px 5px rgba(92, 184, 21, 0.6);
+  transform: rotate(347deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box348 {
+  --cssShared-v-348: 755812;
+  color: hsl(276, 24%, 66%);
+  background-color: hsl(96, 24%, 34%);
+  border: 4px solid hsl(6, 50%, 50%);
+  margin: 8px 24px 15px 6px;
+  padding: 3px 14px;
+  border-radius: 0px 3px;
+  box-shadow: 3px 5px 6px rgba(93, 186, 24, 0.7);
+  transform: rotate(348deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box349 {
+  --cssShared-v-349: 763731;
+  color: hsl(313, 37%, 73%);
+  background-color: hsl(133, 37%, 27%);
+  border: 5px solid hsl(43, 50%, 50%);
+  margin: 9px 27px 20px 13px;
+  padding: 4px 16px;
+  border-radius: 1px 5px;
+  box-shadow: 4px 6px 7px rgba(94, 188, 27, 0.8);
+  transform: rotate(349deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box350 {
+  --cssShared-v-350: 771650;
+  color: hsl(350, 50%, 30%);
+  background-color: hsl(170, 50%, 70%);
+  border: 1px solid hsl(80, 50%, 50%);
+  margin: 10px 0px 0px 2px;
+  padding: 5px 18px;
+  border-radius: 2px 7px;
+  box-shadow: 0px 0px 8px rgba(95, 190, 30, 0.9);
+  transform: rotate(350deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box351 {
+  --cssShared-v-351: 779569;
+  color: hsl(27, 63%, 37%);
+  background-color: hsl(207, 63%, 63%);
+  border: 2px solid hsl(117, 50%, 50%);
+  margin: 11px 3px 5px 9px;
+  padding: 6px 20px;
+  border-radius: 3px 0px;
+  box-shadow: 1px 1px 0px rgba(96, 192, 33, 0.1);
+  transform: rotate(351deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box352 {
+  --cssShared-v-352: 787488;
+  color: hsl(64, 76%, 44%);
+  background-color: hsl(244, 76%, 56%);
+  border: 3px solid hsl(154, 50%, 50%);
+  margin: 12px 6px 10px 16px;
+  padding: 7px 0px;
+  border-radius: 4px 2px;
+  box-shadow: 2px 2px 1px rgba(97, 194, 36, 0.2);
+  transform: rotate(352deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box353 {
+  --cssShared-v-353: 795407;
+  color: hsl(101, 89%, 51%);
+  background-color: hsl(281, 89%, 49%);
+  border: 4px solid hsl(191, 50%, 50%);
+  margin: 13px 9px 15px 5px;
+  padding: 8px 2px;
+  border-radius: 5px 4px;
+  box-shadow: 3px 3px 2px rgba(98, 196, 39, 0.3);
+  transform: rotate(353deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box354 {
+  --cssShared-v-354: 803326;
+  color: hsl(138, 2%, 58%);
+  background-color: hsl(318, 2%, 42%);
+  border: 5px solid hsl(228, 50%, 50%);
+  margin: 14px 12px 20px 12px;
+  padding: 9px 4px;
+  border-radius: 6px 6px;
+  box-shadow: 4px 4px 3px rgba(99, 198, 42, 0.4);
+  transform: rotate(354deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box355 {
+  --cssShared-v-355: 811245;
+  color: hsl(175, 15%, 65%);
+  background-color: hsl(355, 15%, 35%);
+  border: 1px solid hsl(265, 50%, 50%);
+  margin: 15px 15px 0px 1px;
+  padding: 10px 6px;
+  border-radius: 7px 8px;
+  box-shadow: 0px 5px 4px rgba(100, 200, 45, 0.5);
+  transform: rotate(355deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box356 {
+  --cssShared-v-356: 819164;
+  color: hsl(212, 28%, 72%);
+  background-color: hsl(32, 28%, 28%);
+  border: 2px solid hsl(302, 50%, 50%);
+  margin: 16px 18px 5px 8px;
+  padding: 11px 8px;
+  border-radius: 8px 1px;
+  box-shadow: 1px 6px 5px rgba(101, 202, 48, 0.6);
+  transform: rotate(356deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box357 {
+  --cssShared-v-357: 827083;
+  color: hsl(249, 41%, 79%);
+  background-color: hsl(69, 41%, 21%);
+  border: 3px solid hsl(339, 50%, 50%);
+  margin: 17px 21px 10px 15px;
+  padding: 12px 10px;
+  border-radius: 9px 3px;
+  box-shadow: 2px 0px 6px rgba(102, 204, 51, 0.7);
+  transform: rotate(357deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box358 {
+  --cssShared-v-358: 835002;
+  color: hsl(286, 54%, 36%);
+  background-color: hsl(106, 54%, 64%);
+  border: 4px solid hsl(16, 50%, 50%);
+  margin: 18px 24px 15px 4px;
+  padding: 13px 12px;
+  border-radius: 10px 5px;
+  box-shadow: 3px 1px 7px rgba(103, 206, 54, 0.8);
+  transform: rotate(358deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box359 {
+  --cssShared-v-359: 842921;
+  color: hsl(323, 67%, 43%);
+  background-color: hsl(143, 67%, 57%);
+  border: 5px solid hsl(53, 50%, 50%);
+  margin: 19px 27px 20px 11px;
+  padding: 14px 14px;
+  border-radius: 11px 7px;
+  box-shadow: 4px 2px 8px rgba(104, 208, 57, 0.9);
+  transform: rotate(359deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box360 {
+  --cssShared-v-360: 850840;
+  color: hsl(0, 80%, 50%);
+  background-color: hsl(180, 80%, 50%);
+  border: 1px solid hsl(90, 50%, 50%);
+  margin: 0px 0px 0px 0px;
+  padding: 0px 16px;
+  border-radius: 0px 0px;
+  box-shadow: 0px 3px 0px rgba(105, 210, 60, 0.1);
+  transform: rotate(0deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box361 {
+  --cssShared-v-361: 858759;
+  color: hsl(37, 93%, 57%);
+  background-color: hsl(217, 93%, 43%);
+  border: 2px solid hsl(127, 50%, 50%);
+  margin: 1px 3px 5px 7px;
+  padding: 1px 18px;
+  border-radius: 1px 2px;
+  box-shadow: 1px 4px 1px rgba(106, 212, 63, 0.2);
+  transform: rotate(1deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box362 {
+  --cssShared-v-362: 866678;
+  color: hsl(74, 6%, 64%);
+  background-color: hsl(254, 6%, 36%);
+  border: 3px solid hsl(164, 50%, 50%);
+  margin: 2px 6px 10px 14px;
+  padding: 2px 20px;
+  border-radius: 2px 4px;
+  box-shadow: 2px 5px 2px rgba(107, 214, 66, 0.3);
+  transform: rotate(2deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box363 {
+  --cssShared-v-363: 874597;
+  color: hsl(111, 19%, 71%);
+  background-color: hsl(291, 19%, 29%);
+  border: 4px solid hsl(201, 50%, 50%);
+  margin: 3px 9px 15px 3px;
+  padding: 3px 0px;
+  border-radius: 3px 6px;
+  box-shadow: 3px 6px 3px rgba(108, 216, 69, 0.4);
+  transform: rotate(3deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box364 {
+  --cssShared-v-364: 882516;
+  color: hsl(148, 32%, 78%);
+  background-color: hsl(328, 32%, 22%);
+  border: 5px solid hsl(238, 50%, 50%);
+  margin: 4px 12px 20px 10px;
+  padding: 4px 2px;
+  border-radius: 4px 8px;
+  box-shadow: 4px 0px 4px rgba(109, 218, 72, 0.5);
+  transform: rotate(4deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box365 {
+  --cssShared-v-365: 890435;
+  color: hsl(185, 45%, 35%);
+  background-color: hsl(5, 45%, 65%);
+  border: 1px solid hsl(275, 50%, 50%);
+  margin: 5px 15px 0px 17px;
+  padding: 5px 4px;
+  border-radius: 5px 1px;
+  box-shadow: 0px 1px 5px rgba(110, 220, 75, 0.6);
+  transform: rotate(5deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box366 {
+  --cssShared-v-366: 898354;
+  color: hsl(222, 58%, 42%);
+  background-color: hsl(42, 58%, 58%);
+  border: 2px solid hsl(312, 50%, 50%);
+  margin: 6px 18px 5px 6px;
+  padding: 6px 6px;
+  border-radius: 6px 3px;
+  box-shadow: 1px 2px 6px rgba(111, 222, 78, 0.7);
+  transform: rotate(6deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box367 {
+  --cssShared-v-367: 906273;
+  color: hsl(259, 71%, 49%);
+  background-color: hsl(79, 71%, 51%);
+  border: 3px solid hsl(349, 50%, 50%);
+  margin: 7px 21px 10px 13px;
+  padding: 7px 8px;
+  border-radius: 7px 5px;
+  box-shadow: 2px 3px 7px rgba(112, 224, 81, 0.8);
+  transform: rotate(7deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box368 {
+  --cssShared-v-368: 914192;
+  color: hsl(296, 84%, 56%);
+  background-color: hsl(116, 84%, 44%);
+  border: 4px solid hsl(26, 50%, 50%);
+  margin: 8px 24px 15px 2px;
+  padding: 8px 10px;
+  border-radius: 8px 7px;
+  box-shadow: 3px 4px 8px rgba(113, 226, 84, 0.9);
+  transform: rotate(8deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box369 {
+  --cssShared-v-369: 922111;
+  color: hsl(333, 97%, 63%);
+  background-color: hsl(153, 97%, 37%);
+  border: 5px solid hsl(63, 50%, 50%);
+  margin: 9px 27px 20px 9px;
+  padding: 9px 12px;
+  border-radius: 9px 0px;
+  box-shadow: 4px 5px 0px rgba(114, 228, 87, 0.1);
+  transform: rotate(9deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box370 {
+  --cssShared-v-370: 930030;
+  color: hsl(10, 10%, 70%);
+  background-color: hsl(190, 10%, 30%);
+  border: 1px solid hsl(100, 50%, 50%);
+  margin: 10px 0px 0px 16px;
+  padding: 10px 14px;
+  border-radius: 10px 2px;
+  box-shadow: 0px 6px 1px rgba(115, 230, 90, 0.2);
+  transform: rotate(10deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box371 {
+  --cssShared-v-371: 937949;
+  color: hsl(47, 23%, 77%);
+  background-color: hsl(227, 23%, 23%);
+  border: 2px solid hsl(137, 50%, 50%);
+  margin: 11px 3px 5px 5px;
+  padding: 11px 16px;
+  border-radius: 11px 4px;
+  box-shadow: 1px 0px 2px rgba(116, 232, 93, 0.3);
+  transform: rotate(11deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box372 {
+  --cssShared-v-372: 945868;
+  color: hsl(84, 36%, 34%);
+  background-color: hsl(264, 36%, 66%);
+  border: 3px solid hsl(174, 50%, 50%);
+  margin: 12px 6px 10px 12px;
+  padding: 12px 18px;
+  border-radius: 0px 6px;
+  box-shadow: 2px 1px 3px rgba(117, 234, 96, 0.4);
+  transform: rotate(12deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box373 {
+  --cssShared-v-373: 953787;
+  color: hsl(121, 49%, 41%);
+  background-color: hsl(301, 49%, 59%);
+  border: 4px solid hsl(211, 50%, 50%);
+  margin: 13px 9px 15px 1px;
+  padding: 13px 20px;
+  border-radius: 1px 8px;
+  box-shadow: 3px 2px 4px rgba(118, 236, 99, 0.5);
+  transform: rotate(13deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box374 {
+  --cssShared-v-374: 961706;
+  color: hsl(158, 62%, 48%);
+  background-color: hsl(338, 62%, 52%);
+  border: 5px solid hsl(248, 50%, 50%);
+  margin: 14px 12px 20px 8px;
+  padding: 14px 0px;
+  border-radius: 2px 1px;
+  box-shadow: 4px 3px 5px rgba(119, 238, 102, 0.6);
+  transform: rotate(14deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box375 {
+  --cssShared-v-375: 969625;
+  color: hsl(195, 75%, 55%);
+  background-color: hsl(15, 75%, 45%);
+  border: 1px solid hsl(285, 50%, 50%);
+  margin: 15px 15px 0px 15px;
+  padding: 0px 2px;
+  border-radius: 3px 3px;
+  box-shadow: 0px 4px 6px rgba(120, 240, 105, 0.7);
+  transform: rotate(15deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box376 {
+  --cssShared-v-376: 977544;
+  color: hsl(232, 88%, 62%);
+  background-color: hsl(52, 88%, 38%);
+  border: 2px solid hsl(322, 50%, 50%);
+  margin: 16px 18px 5px 4px;
+  padding: 1px 4px;
+  border-radius: 4px 5px;
+  box-shadow: 1px 5px 7px rgba(121, 242, 108, 0.8);
+  transform: rotate(16deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box377 {
+  --cssShared-v-377: 985463;
+  color: hsl(269, 1%, 69%);
+  background-color: hsl(89, 1%, 31%);
+  border: 3px solid hsl(359, 50%, 50%);
+  margin: 17px 21px 10px 11px;
+  padding: 2px 6px;
+  border-radius: 5px 7px;
+  box-shadow: 2px 6px 8px rgba(122, 244, 111, 0.9);
+  transform: rotate(17deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box378 {
+  --cssShared-v-378: 993382;
+  color: hsl(306, 14%, 76%);
+  background-color: hsl(126, 14%, 24%);
+  border: 4px solid hsl(36, 50%, 50%);
+  margin: 18px 24px 15px 0px;
+  padding: 3px 8px;
+  border-radius: 6px 0px;
+  box-shadow: 3px 0px 0px rgba(123, 246, 114, 0.1);
+  transform: rotate(18deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box379 {
+  --cssShared-v-379: 1301;
+  color: hsl(343, 27%, 33%);
+  background-color: hsl(163, 27%, 67%);
+  border: 5px solid hsl(73, 50%, 50%);
+  margin: 19px 27px 20px 7px;
+  padding: 4px 10px;
+  border-radius: 7px 2px;
+  box-shadow: 4px 1px 1px rgba(124, 248, 117, 0.2);
+  transform: rotate(19deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box380 {
+  --cssShared-v-380: 9220;
+  color: hsl(20, 40%, 40%);
+  background-color: hsl(200, 40%, 60%);
+  border: 1px solid hsl(110, 50%, 50%);
+  margin: 0px 0px 0px 14px;
+  padding: 5px 12px;
+  border-radius: 8px 4px;
+  box-shadow: 0px 2px 2px rgba(125, 250, 120, 0.3);
+  transform: rotate(20deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box381 {
+  --cssShared-v-381: 17139;
+  color: hsl(57, 53%, 47%);
+  background-color: hsl(237, 53%, 53%);
+  border: 2px solid hsl(147, 50%, 50%);
+  margin: 1px 3px 5px 3px;
+  padding: 6px 14px;
+  border-radius: 9px 6px;
+  box-shadow: 1px 3px 3px rgba(126, 252, 123, 0.4);
+  transform: rotate(21deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box382 {
+  --cssShared-v-382: 25058;
+  color: hsl(94, 66%, 54%);
+  background-color: hsl(274, 66%, 46%);
+  border: 3px solid hsl(184, 50%, 50%);
+  margin: 2px 6px 10px 10px;
+  padding: 7px 16px;
+  border-radius: 10px 8px;
+  box-shadow: 2px 4px 4px rgba(127, 254, 126, 0.5);
+  transform: rotate(22deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box383 {
+  --cssShared-v-383: 32977;
+  color: hsl(131, 79%, 61%);
+  background-color: hsl(311, 79%, 39%);
+  border: 4px solid hsl(221, 50%, 50%);
+  margin: 3px 9px 15px 17px;
+  padding: 8px 18px;
+  border-radius: 11px 1px;
+  box-shadow: 3px 5px 5px rgba(128, 1, 129, 0.6);
+  transform: rotate(23deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box384 {
+  --cssShared-v-384: 40896;
+  color: hsl(168, 92%, 68%);
+  background-color: hsl(348, 92%, 32%);
+  border: 5px solid hsl(258, 50%, 50%);
+  margin: 4px 12px 20px 6px;
+  padding: 9px 20px;
+  border-radius: 0px 3px;
+  box-shadow: 4px 6px 6px rgba(129, 3, 132, 0.7);
+  transform: rotate(24deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box385 {
+  --cssShared-v-385: 48815;
+  color: hsl(205, 5%, 75%);
+  background-color: hsl(25, 5%, 25%);
+  border: 1px solid hsl(295, 50%, 50%);
+  margin: 5px 15px 0px 13px;
+  padding: 10px 0px;
+  border-radius: 1px 5px;
+  box-shadow: 0px 0px 7px rgba(130, 5, 135, 0.8);
+  transform: rotate(25deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box386 {
+  --cssShared-v-386: 56734;
+  color: hsl(242, 18%, 32%);
+  background-color: hsl(62, 18%, 68%);
+  border: 2px solid hsl(332, 50%, 50%);
+  margin: 6px 18px 5px 2px;
+  padding: 11px 2px;
+  border-radius: 2px 7px;
+  box-shadow: 1px 1px 8px rgba(131, 7, 138, 0.9);
+  transform: rotate(26deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box387 {
+  --cssShared-v-387: 64653;
+  color: hsl(279, 31%, 39%);
+  background-color: hsl(99, 31%, 61%);
+  border: 3px solid hsl(9, 50%, 50%);
+  margin: 7px 21px 10px 9px;
+  padding: 12px 4px;
+  border-radius: 3px 0px;
+  box-shadow: 2px 2px 0px rgba(132, 9, 141, 0.1);
+  transform: rotate(27deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box388 {
+  --cssShared-v-388: 72572;
+  color: hsl(316, 44%, 46%);
+  background-color: hsl(136, 44%, 54%);
+  border: 4px solid hsl(46, 50%, 50%);
+  margin: 8px 24px 15px 16px;
+  padding: 13px 6px;
+  border-radius: 4px 2px;
+  box-shadow: 3px 3px 1px rgba(133, 11, 144, 0.2);
+  transform: rotate(28deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box389 {
+  --cssShared-v-389: 80491;
+  color: hsl(353, 57%, 53%);
+  background-color: hsl(173, 57%, 47%);
+  border: 5px solid hsl(83, 50%, 50%);
+  margin: 9px 27px 20px 5px;
+  padding: 14px 8px;
+  border-radius: 5px 4px;
+  box-shadow: 4px 4px 2px rgba(134, 13, 147, 0.3);
+  transform: rotate(29deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box390 {
+  --cssShared-v-390: 88410;
+  color: hsl(30, 70%, 60%);
+  background-color: hsl(210, 70%, 40%);
+  border: 1px solid hsl(120, 50%, 50%);
+  margin: 10px 0px 0px 12px;
+  padding: 0px 10px;
+  border-radius: 6px 6px;
+  box-shadow: 0px 5px 3px rgba(135, 15, 150, 0.4);
+  transform: rotate(30deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box391 {
+  --cssShared-v-391: 96329;
+  color: hsl(67, 83%, 67%);
+  background-color: hsl(247, 83%, 33%);
+  border: 2px solid hsl(157, 50%, 50%);
+  margin: 11px 3px 5px 1px;
+  padding: 1px 12px;
+  border-radius: 7px 8px;
+  box-shadow: 1px 6px 4px rgba(136, 17, 153, 0.5);
+  transform: rotate(31deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box392 {
+  --cssShared-v-392: 104248;
+  color: hsl(104, 96%, 74%);
+  background-color: hsl(284, 96%, 26%);
+  border: 3px solid hsl(194, 50%, 50%);
+  margin: 12px 6px 10px 8px;
+  padding: 2px 14px;
+  border-radius: 8px 1px;
+  box-shadow: 2px 0px 5px rgba(137, 19, 156, 0.6);
+  transform: rotate(32deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box393 {
+  --cssShared-v-393: 112167;
+  color: hsl(141, 9%, 31%);
+  background-color: hsl(321, 9%, 69%);
+  border: 4px solid hsl(231, 50%, 50%);
+  margin: 13px 9px 15px 15px;
+  padding: 3px 16px;
+  border-radius: 9px 3px;
+  box-shadow: 3px 1px 6px rgba(138, 21, 159, 0.7);
+  transform: rotate(33deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box394 {
+  --cssShared-v-394: 120086;
+  color: hsl(178, 22%, 38%);
+  background-color: hsl(358, 22%, 62%);
+  border: 5px solid hsl(268, 50%, 50%);
+  margin: 14px 12px 20px 4px;
+  padding: 4px 18px;
+  border-radius: 10px 5px;
+  box-shadow: 4px 2px 7px rgba(139, 23, 162, 0.8);
+  transform: rotate(34deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box395 {
+  --cssShared-v-395: 128005;
+  color: hsl(215, 35%, 45%);
+  background-color: hsl(35, 35%, 55%);
+  border: 1px solid hsl(305, 50%, 50%);
+  margin: 15px 15px 0px 11px;
+  padding: 5px 20px;
+  border-radius: 11px 7px;
+  box-shadow: 0px 3px 8px rgba(140, 25, 165, 0.9);
+  transform: rotate(35deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box396 {
+  --cssShared-v-396: 135924;
+  color: hsl(252, 48%, 52%);
+  background-color: hsl(72, 48%, 48%);
+  border: 2px solid hsl(342, 50%, 50%);
+  margin: 16px 18px 5px 0px;
+  padding: 6px 0px;
+  border-radius: 0px 0px;
+  box-shadow: 1px 4px 0px rgba(141, 27, 168, 0.1);
+  transform: rotate(36deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box397 {
+  --cssShared-v-397: 143843;
+  color: hsl(289, 61%, 59%);
+  background-color: hsl(109, 61%, 41%);
+  border: 3px solid hsl(19, 50%, 50%);
+  margin: 17px 21px 10px 7px;
+  padding: 7px 2px;
+  border-radius: 1px 2px;
+  box-shadow: 2px 5px 1px rgba(142, 29, 171, 0.2);
+  transform: rotate(37deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box398 {
+  --cssShared-v-398: 151762;
+  color: hsl(326, 74%, 66%);
+  background-color: hsl(146, 74%, 34%);
+  border: 4px solid hsl(56, 50%, 50%);
+  margin: 18px 24px 15px 14px;
+  padding: 8px 4px;
+  border-radius: 2px 4px;
+  box-shadow: 3px 6px 2px rgba(143, 31, 174, 0.3);
+  transform: rotate(38deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box399 {
+  --cssShared-v-399: 159681;
+  color: hsl(3, 87%, 73%);
+  background-color: hsl(183, 87%, 27%);
+  border: 5px solid hsl(93, 50%, 50%);
+  margin: 19px 27px 20px 3px;
+  padding: 9px 6px;
+  border-radius: 3px 6px;
+  box-shadow: 4px 0px 3px rgba(144, 33, 177, 0.4);
+  transform: rotate(39deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box400 {
+  --cssShared-v-400: 167600;
+  color: hsl(40, 0%, 30%);
+  background-color: hsl(220, 0%, 70%);
+  border: 1px solid hsl(130, 50%, 50%);
+  margin: 0px 0px 0px 10px;
+  padding: 10px 8px;
+  border-radius: 4px 8px;
+  box-shadow: 0px 1px 4px rgba(145, 35, 180, 0.5);
+  transform: rotate(40deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box401 {
+  --cssShared-v-401: 175519;
+  color: hsl(77, 13%, 37%);
+  background-color: hsl(257, 13%, 63%);
+  border: 2px solid hsl(167, 50%, 50%);
+  margin: 1px 3px 5px 17px;
+  padding: 11px 10px;
+  border-radius: 5px 1px;
+  box-shadow: 1px 2px 5px rgba(146, 37, 183, 0.6);
+  transform: rotate(41deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box402 {
+  --cssShared-v-402: 183438;
+  color: hsl(114, 26%, 44%);
+  background-color: hsl(294, 26%, 56%);
+  border: 3px solid hsl(204, 50%, 50%);
+  margin: 2px 6px 10px 6px;
+  padding: 12px 12px;
+  border-radius: 6px 3px;
+  box-shadow: 2px 3px 6px rgba(147, 39, 186, 0.7);
+  transform: rotate(42deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box403 {
+  --cssShared-v-403: 191357;
+  color: hsl(151, 39%, 51%);
+  background-color: hsl(331, 39%, 49%);
+  border: 4px solid hsl(241, 50%, 50%);
+  margin: 3px 9px 15px 13px;
+  padding: 13px 14px;
+  border-radius: 7px 5px;
+  box-shadow: 3px 4px 7px rgba(148, 41, 189, 0.8);
+  transform: rotate(43deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box404 {
+  --cssShared-v-404: 199276;
+  color: hsl(188, 52%, 58%);
+  background-color: hsl(8, 52%, 42%);
+  border: 5px solid hsl(278, 50%, 50%);
+  margin: 4px 12px 20px 2px;
+  padding: 14px 16px;
+  border-radius: 8px 7px;
+  box-shadow: 4px 5px 8px rgba(149, 43, 192, 0.9);
+  transform: rotate(44deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box405 {
+  --cssShared-v-405: 207195;
+  color: hsl(225, 65%, 65%);
+  background-color: hsl(45, 65%, 35%);
+  border: 1px solid hsl(315, 50%, 50%);
+  margin: 5px 15px 0px 9px;
+  padding: 0px 18px;
+  border-radius: 9px 0px;
+  box-shadow: 0px 6px 0px rgba(150, 45, 195, 0.1);
+  transform: rotate(45deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box406 {
+  --cssShared-v-406: 215114;
+  color: hsl(262, 78%, 72%);
+  background-color: hsl(82, 78%, 28%);
+  border: 2px solid hsl(352, 50%, 50%);
+  margin: 6px 18px 5px 16px;
+  padding: 1px 20px;
+  border-radius: 10px 2px;
+  box-shadow: 1px 0px 1px rgba(151, 47, 198, 0.2);
+  transform: rotate(46deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box407 {
+  --cssShared-v-407: 223033;
+  color: hsl(299, 91%, 79%);
+  background-color: hsl(119, 91%, 21%);
+  border: 3px solid hsl(29, 50%, 50%);
+  margin: 7px 21px 10px 5px;
+  padding: 2px 0px;
+  border-radius: 11px 4px;
+  box-shadow: 2px 1px 2px rgba(152, 49, 201, 0.3);
+  transform: rotate(47deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box408 {
+  --cssShared-v-408: 230952;
+  color: hsl(336, 4%, 36%);
+  background-color: hsl(156, 4%, 64%);
+  border: 4px solid hsl(66, 50%, 50%);
+  margin: 8px 24px 15px 12px;
+  padding: 3px 2px;
+  border-radius: 0px 6px;
+  box-shadow: 3px 2px 3px rgba(153, 51, 204, 0.4);
+  transform: rotate(48deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box409 {
+  --cssShared-v-409: 238871;
+  color: hsl(13, 17%, 43%);
+  background-color: hsl(193, 17%, 57%);
+  border: 5px solid hsl(103, 50%, 50%);
+  margin: 9px 27px 20px 1px;
+  padding: 4px 4px;
+  border-radius: 1px 8px;
+  box-shadow: 4px 3px 4px rgba(154, 53, 207, 0.5);
+  transform: rotate(49deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box410 {
+  --cssShared-v-410: 246790;
+  color: hsl(50, 30%, 50%);
+  background-color: hsl(230, 30%, 50%);
+  border: 1px solid hsl(140, 50%, 50%);
+  margin: 10px 0px 0px 8px;
+  padding: 5px 6px;
+  border-radius: 2px 1px;
+  box-shadow: 0px 4px 5px rgba(155, 55, 210, 0.6);
+  transform: rotate(50deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box411 {
+  --cssShared-v-411: 254709;
+  color: hsl(87, 43%, 57%);
+  background-color: hsl(267, 43%, 43%);
+  border: 2px solid hsl(177, 50%, 50%);
+  margin: 11px 3px 5px 15px;
+  padding: 6px 8px;
+  border-radius: 3px 3px;
+  box-shadow: 1px 5px 6px rgba(156, 57, 213, 0.7);
+  transform: rotate(51deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box412 {
+  --cssShared-v-412: 262628;
+  color: hsl(124, 56%, 64%);
+  background-color: hsl(304, 56%, 36%);
+  border: 3px solid hsl(214, 50%, 50%);
+  margin: 12px 6px 10px 4px;
+  padding: 7px 10px;
+  border-radius: 4px 5px;
+  box-shadow: 2px 6px 7px rgba(157, 59, 216, 0.8);
+  transform: rotate(52deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box413 {
+  --cssShared-v-413: 270547;
+  color: hsl(161, 69%, 71%);
+  background-color: hsl(341, 69%, 29%);
+  border: 4px solid hsl(251, 50%, 50%);
+  margin: 13px 9px 15px 11px;
+  padding: 8px 12px;
+  border-radius: 5px 7px;
+  box-shadow: 3px 0px 8px rgba(158, 61, 219, 0.9);
+  transform: rotate(53deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box414 {
+  --cssShared-v-414: 278466;
+  color: hsl(198, 82%, 78%);
+  background-color: hsl(18, 82%, 22%);
+  border: 5px solid hsl(288, 50%, 50%);
+  margin: 14px 12px 20px 0px;
+  padding: 9px 14px;
+  border-radius: 6px 0px;
+  box-shadow: 4px 1px 0px rgba(159, 63, 222, 0.1);
+  transform: rotate(54deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box415 {
+  --cssShared-v-415: 286385;
+  color: hsl(235, 95%, 35%);
+  background-color: hsl(55, 95%, 65%);
+  border: 1px solid hsl(325, 50%, 50%);
+  margin: 15px 15px 0px 7px;
+  padding: 10px 16px;
+  border-radius: 7px 2px;
+  box-shadow: 0px 2px 1px rgba(160, 65, 225, 0.2);
+  transform: rotate(55deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box416 {
+  --cssShared-v-416: 294304;
+  color: hsl(272, 8%, 42%);
+  background-color: hsl(92, 8%, 58%);
+  border: 2px solid hsl(2, 50%, 50%);
+  margin: 16px 18px 5px 14px;
+  padding: 11px 18px;
+  border-radius: 8px 4px;
+  box-shadow: 1px 3px 2px rgba(161, 67, 228, 0.3);
+  transform: rotate(56deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box417 {
+  --cssShared-v-417: 302223;
+  color: hsl(309, 21%, 49%);
+  background-color: hsl(129, 21%, 51%);
+  border: 3px solid hsl(39, 50%, 50%);
+  margin: 17px 21px 10px 3px;
+  padding: 12px 20px;
+  border-radius: 9px 6px;
+  box-shadow: 2px 4px 3px rgba(162, 69, 231, 0.4);
+  transform: rotate(57deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box418 {
+  --cssShared-v-418: 310142;
+  color: hsl(346, 34%, 56%);
+  background-color: hsl(166, 34%, 44%);
+  border: 4px solid hsl(76, 50%, 50%);
+  margin: 18px 24px 15px 10px;
+  padding: 13px 0px;
+  border-radius: 10px 8px;
+  box-shadow: 3px 5px 4px rgba(163, 71, 234, 0.5);
+  transform: rotate(58deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box419 {
+  --cssShared-v-419: 318061;
+  color: hsl(23, 47%, 63%);
+  background-color: hsl(203, 47%, 37%);
+  border: 5px solid hsl(113, 50%, 50%);
+  margin: 19px 27px 20px 17px;
+  padding: 14px 2px;
+  border-radius: 11px 1px;
+  box-shadow: 4px 6px 5px rgba(164, 73, 237, 0.6);
+  transform: rotate(59deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box420 {
+  --cssShared-v-420: 325980;
+  color: hsl(60, 60%, 70%);
+  background-color: hsl(240, 60%, 30%);
+  border: 1px solid hsl(150, 50%, 50%);
+  margin: 0px 0px 0px 6px;
+  padding: 0px 4px;
+  border-radius: 0px 3px;
+  box-shadow: 0px 0px 6px rgba(165, 75, 240, 0.7);
+  transform: rotate(60deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box421 {
+  --cssShared-v-421: 333899;
+  color: hsl(97, 73%, 77%);
+  background-color: hsl(277, 73%, 23%);
+  border: 2px solid hsl(187, 50%, 50%);
+  margin: 1px 3px 5px 13px;
+  padding: 1px 6px;
+  border-radius: 1px 5px;
+  box-shadow: 1px 1px 7px rgba(166, 77, 243, 0.8);
+  transform: rotate(61deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box422 {
+  --cssShared-v-422: 341818;
+  color: hsl(134, 86%, 34%);
+  background-color: hsl(314, 86%, 66%);
+  border: 3px solid hsl(224, 50%, 50%);
+  margin: 2px 6px 10px 2px;
+  padding: 2px 8px;
+  border-radius: 2px 7px;
+  box-shadow: 2px 2px 8px rgba(167, 79, 246, 0.9);
+  transform: rotate(62deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box423 {
+  --cssShared-v-423: 349737;
+  color: hsl(171, 99%, 41%);
+  background-color: hsl(351, 99%, 59%);
+  border: 4px solid hsl(261, 50%, 50%);
+  margin: 3px 9px 15px 9px;
+  padding: 3px 10px;
+  border-radius: 3px 0px;
+  box-shadow: 3px 3px 0px rgba(168, 81, 249, 0.1);
+  transform: rotate(63deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box424 {
+  --cssShared-v-424: 357656;
+  color: hsl(208, 12%, 48%);
+  background-color: hsl(28, 12%, 52%);
+  border: 5px solid hsl(298, 50%, 50%);
+  margin: 4px 12px 20px 16px;
+  padding: 4px 12px;
+  border-radius: 4px 2px;
+  box-shadow: 4px 4px 1px rgba(169, 83, 252, 0.2);
+  transform: rotate(64deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box425 {
+  --cssShared-v-425: 365575;
+  color: hsl(245, 25%, 55%);
+  background-color: hsl(65, 25%, 45%);
+  border: 1px solid hsl(335, 50%, 50%);
+  margin: 5px 15px 0px 5px;
+  padding: 5px 14px;
+  border-radius: 5px 4px;
+  box-shadow: 0px 5px 2px rgba(170, 85, 0, 0.3);
+  transform: rotate(65deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box426 {
+  --cssShared-v-426: 373494;
+  color: hsl(282, 38%, 62%);
+  background-color: hsl(102, 38%, 38%);
+  border: 2px solid hsl(12, 50%, 50%);
+  margin: 6px 18px 5px 12px;
+  padding: 6px 16px;
+  border-radius: 6px 6px;
+  box-shadow: 1px 6px 3px rgba(171, 87, 3, 0.4);
+  transform: rotate(66deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box427 {
+  --cssShared-v-427: 381413;
+  color: hsl(319, 51%, 69%);
+  background-color: hsl(139, 51%, 31%);
+  border: 3px solid hsl(49, 50%, 50%);
+  margin: 7px 21px 10px 1px;
+  padding: 7px 18px;
+  border-radius: 7px 8px;
+  box-shadow: 2px 0px 4px rgba(172, 89, 6, 0.5);
+  transform: rotate(67deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box428 {
+  --cssShared-v-428: 389332;
+  color: hsl(356, 64%, 76%);
+  background-color: hsl(176, 64%, 24%);
+  border: 4px solid hsl(86, 50%, 50%);
+  margin: 8px 24px 15px 8px;
+  padding: 8px 20px;
+  border-radius: 8px 1px;
+  box-shadow: 3px 1px 5px rgba(173, 91, 9, 0.6);
+  transform: rotate(68deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box429 {
+  --cssShared-v-429: 397251;
+  color: hsl(33, 77%, 33%);
+  background-color: hsl(213, 77%, 67%);
+  border: 5px solid hsl(123, 50%, 50%);
+  margin: 9px 27px 20px 15px;
+  padding: 9px 0px;
+  border-radius: 9px 3px;
+  box-shadow: 4px 2px 6px rgba(174, 93, 12, 0.7);
+  transform: rotate(69deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box430 {
+  --cssShared-v-430: 405170;
+  color: hsl(70, 90%, 40%);
+  background-color: hsl(250, 90%, 60%);
+  border: 1px solid hsl(160, 50%, 50%);
+  margin: 10px 0px 0px 4px;
+  padding: 10px 2px;
+  border-radius: 10px 5px;
+  box-shadow: 0px 3px 7px rgba(175, 95, 15, 0.8);
+  transform: rotate(70deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box431 {
+  --cssShared-v-431: 413089;
+  color: hsl(107, 3%, 47%);
+  background-color: hsl(287, 3%, 53%);
+  border: 2px solid hsl(197, 50%, 50%);
+  margin: 11px 3px 5px 11px;
+  padding: 11px 4px;
+  border-radius: 11px 7px;
+  box-shadow: 1px 4px 8px rgba(176, 97, 18, 0.9);
+  transform: rotate(71deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box432 {
+  --cssShared-v-432: 421008;
+  color: hsl(144, 16%, 54%);
+  background-color: hsl(324, 16%, 46%);
+  border: 3px solid hsl(234, 50%, 50%);
+  margin: 12px 6px 10px 0px;
+  padding: 12px 6px;
+  border-radius: 0px 0px;
+  box-shadow: 2px 5px 0px rgba(177, 99, 21, 0.1);
+  transform: rotate(72deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box433 {
+  --cssShared-v-433: 428927;
+  color: hsl(181, 29%, 61%);
+  background-color: hsl(1, 29%, 39%);
+  border: 4px solid hsl(271, 50%, 50%);
+  margin: 13px 9px 15px 7px;
+  padding: 13px 8px;
+  border-radius: 1px 2px;
+  box-shadow: 3px 6px 1px rgba(178, 101, 24, 0.2);
+  transform: rotate(73deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box434 {
+  --cssShared-v-434: 436846;
+  color: hsl(218, 42%, 68%);
+  background-color: hsl(38, 42%, 32%);
+  border: 5px solid hsl(308, 50%, 50%);
+  margin: 14px 12px 20px 14px;
+  padding: 14px 10px;
+  border-radius: 2px 4px;
+  box-shadow: 4px 0px 2px rgba(179, 103, 27, 0.3);
+  transform: rotate(74deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box435 {
+  --cssShared-v-435: 444765;
+  color: hsl(255, 55%, 75%);
+  background-color: hsl(75, 55%, 25%);
+  border: 1px solid hsl(345, 50%, 50%);
+  margin: 15px 15px 0px 3px;
+  padding: 0px 12px;
+  border-radius: 3px 6px;
+  box-shadow: 0px 1px 3px rgba(180, 105, 30, 0.4);
+  transform: rotate(75deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box436 {
+  --cssShared-v-436: 452684;
+  color: hsl(292, 68%, 32%);
+  background-color: hsl(112, 68%, 68%);
+  border: 2px solid hsl(22, 50%, 50%);
+  margin: 16px 18px 5px 10px;
+  padding: 1px 14px;
+  border-radius: 4px 8px;
+  box-shadow: 1px 2px 4px rgba(181, 107, 33, 0.5);
+  transform: rotate(76deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box437 {
+  --cssShared-v-437: 460603;
+  color: hsl(329, 81%, 39%);
+  background-color: hsl(149, 81%, 61%);
+  border: 3px solid hsl(59, 50%, 50%);
+  margin: 17px 21px 10px 17px;
+  padding: 2px 16px;
+  border-radius: 5px 1px;
+  box-shadow: 2px 3px 5px rgba(182, 109, 36, 0.6);
+  transform: rotate(77deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box438 {
+  --cssShared-v-438: 468522;
+  color: hsl(6, 94%, 46%);
+  background-color: hsl(186, 94%, 54%);
+  border: 4px solid hsl(96, 50%, 50%);
+  margin: 18px 24px 15px 6px;
+  padding: 3px 18px;
+  border-radius: 6px 3px;
+  box-shadow: 3px 4px 6px rgba(183, 111, 39, 0.7);
+  transform: rotate(78deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box439 {
+  --cssShared-v-439: 476441;
+  color: hsl(43, 7%, 53%);
+  background-color: hsl(223, 7%, 47%);
+  border: 5px solid hsl(133, 50%, 50%);
+  margin: 19px 27px 20px 13px;
+  padding: 4px 20px;
+  border-radius: 7px 5px;
+  box-shadow: 4px 5px 7px rgba(184, 113, 42, 0.8);
+  transform: rotate(79deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box440 {
+  --cssShared-v-440: 484360;
+  color: hsl(80, 20%, 60%);
+  background-color: hsl(260, 20%, 40%);
+  border: 1px solid hsl(170, 50%, 50%);
+  margin: 0px 0px 0px 2px;
+  padding: 5px 0px;
+  border-radius: 8px 7px;
+  box-shadow: 0px 6px 8px rgba(185, 115, 45, 0.9);
+  transform: rotate(80deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box441 {
+  --cssShared-v-441: 492279;
+  color: hsl(117, 33%, 67%);
+  background-color: hsl(297, 33%, 33%);
+  border: 2px solid hsl(207, 50%, 50%);
+  margin: 1px 3px 5px 9px;
+  padding: 6px 2px;
+  border-radius: 9px 0px;
+  box-shadow: 1px 0px 0px rgba(186, 117, 48, 0.1);
+  transform: rotate(81deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box442 {
+  --cssShared-v-442: 500198;
+  color: hsl(154, 46%, 74%);
+  background-color: hsl(334, 46%, 26%);
+  border: 3px solid hsl(244, 50%, 50%);
+  margin: 2px 6px 10px 16px;
+  padding: 7px 4px;
+  border-radius: 10px 2px;
+  box-shadow: 2px 1px 1px rgba(187, 119, 51, 0.2);
+  transform: rotate(82deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box443 {
+  --cssShared-v-443: 508117;
+  color: hsl(191, 59%, 31%);
+  background-color: hsl(11, 59%, 69%);
+  border: 4px solid hsl(281, 50%, 50%);
+  margin: 3px 9px 15px 5px;
+  padding: 8px 6px;
+  border-radius: 11px 4px;
+  box-shadow: 3px 2px 2px rgba(188, 121, 54, 0.3);
+  transform: rotate(83deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box444 {
+  --cssShared-v-444: 516036;
+  color: hsl(228, 72%, 38%);
+  background-color: hsl(48, 72%, 62%);
+  border: 5px solid hsl(318, 50%, 50%);
+  margin: 4px 12px 20px 12px;
+  padding: 9px 8px;
+  border-radius: 0px 6px;
+  box-shadow: 4px 3px 3px rgba(189, 123, 57, 0.4);
+  transform: rotate(84deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box445 {
+  --cssShared-v-445: 523955;
+  color: hsl(265, 85%, 45%);
+  background-color: hsl(85, 85%, 55%);
+  border: 1px solid hsl(355, 50%, 50%);
+  margin: 5px 15px 0px 1px;
+  padding: 10px 10px;
+  border-radius: 1px 8px;
+  box-shadow: 0px 4px 4px rgba(190, 125, 60, 0.5);
+  transform: rotate(85deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box446 {
+  --cssShared-v-446: 531874;
+  color: hsl(302, 98%, 52%);
+  background-color: hsl(122, 98%, 48%);
+  border: 2px solid hsl(32, 50%, 50%);
+  margin: 6px 18px 5px 8px;
+  padding: 11px 12px;
+  border-radius: 2px 1px;
+  box-shadow: 1px 5px 5px rgba(191, 127, 63, 0.6);
+  transform: rotate(86deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box447 {
+  --cssShared-v-447: 539793;
+  color: hsl(339, 11%, 59%);
+  background-color: hsl(159, 11%, 41%);
+  border: 3px solid hsl(69, 50%, 50%);
+  margin: 7px 21px 10px 15px;
+  padding: 12px 14px;
+  border-radius: 3px 3px;
+  box-shadow: 2px 6px 6px rgba(192, 129, 66, 0.7);
+  transform: rotate(87deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box448 {
+  --cssShared-v-448: 547712;
+  color: hsl(16, 24%, 66%);
+  background-color: hsl(196, 24%, 34%);
+  border: 4px solid hsl(106, 50%, 50%);
+  margin: 8px 24px 15px 4px;
+  padding: 13px 16px;
+  border-radius: 4px 5px;
+  box-shadow: 3px 0px 7px rgba(193, 131, 69, 0.8);
+  transform: rotate(88deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box449 {
+  --cssShared-v-449: 555631;
+  color: hsl(53, 37%, 73%);
+  background-color: hsl(233, 37%, 27%);
+  border: 5px solid hsl(143, 50%, 50%);
+  margin: 9px 27px 20px 11px;
+  padding: 14px 18px;
+  border-radius: 5px 7px;
+  box-shadow: 4px 1px 8px rgba(194, 133, 72, 0.9);
+  transform: rotate(89deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box450 {
+  --cssShared-v-450: 563550;
+  color: hsl(90, 50%, 30%);
+  background-color: hsl(270, 50%, 70%);
+  border: 1px solid hsl(180, 50%, 50%);
+  margin: 10px 0px 0px 0px;
+  padding: 0px 20px;
+  border-radius: 6px 0px;
+  box-shadow: 0px 2px 0px rgba(195, 135, 75, 0.1);
+  transform: rotate(90deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box451 {
+  --cssShared-v-451: 571469;
+  color: hsl(127, 63%, 37%);
+  background-color: hsl(307, 63%, 63%);
+  border: 2px solid hsl(217, 50%, 50%);
+  margin: 11px 3px 5px 7px;
+  padding: 1px 0px;
+  border-radius: 7px 2px;
+  box-shadow: 1px 3px 1px rgba(196, 137, 78, 0.2);
+  transform: rotate(91deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box452 {
+  --cssShared-v-452: 579388;
+  color: hsl(164, 76%, 44%);
+  background-color: hsl(344, 76%, 56%);
+  border: 3px solid hsl(254, 50%, 50%);
+  margin: 12px 6px 10px 14px;
+  padding: 2px 2px;
+  border-radius: 8px 4px;
+  box-shadow: 2px 4px 2px rgba(197, 139, 81, 0.3);
+  transform: rotate(92deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box453 {
+  --cssShared-v-453: 587307;
+  color: hsl(201, 89%, 51%);
+  background-color: hsl(21, 89%, 49%);
+  border: 4px solid hsl(291, 50%, 50%);
+  margin: 13px 9px 15px 3px;
+  padding: 3px 4px;
+  border-radius: 9px 6px;
+  box-shadow: 3px 5px 3px rgba(198, 141, 84, 0.4);
+  transform: rotate(93deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box454 {
+  --cssShared-v-454: 595226;
+  color: hsl(238, 2%, 58%);
+  background-color: hsl(58, 2%, 42%);
+  border: 5px solid hsl(328, 50%, 50%);
+  margin: 14px 12px 20px 10px;
+  padding: 4px 6px;
+  border-radius: 10px 8px;
+  box-shadow: 4px 6px 4px rgba(199, 143, 87, 0.5);
+  transform: rotate(94deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box455 {
+  --cssShared-v-455: 603145;
+  color: hsl(275, 15%, 65%);
+  background-color: hsl(95, 15%, 35%);
+  border: 1px solid hsl(5, 50%, 50%);
+  margin: 15px 15px 0px 17px;
+  padding: 5px 8px;
+  border-radius: 11px 1px;
+  box-shadow: 0px 0px 5px rgba(200, 145, 90, 0.6);
+  transform: rotate(95deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box456 {
+  --cssShared-v-456: 611064;
+  color: hsl(312, 28%, 72%);
+  background-color: hsl(132, 28%, 28%);
+  border: 2px solid hsl(42, 50%, 50%);
+  margin: 16px 18px 5px 6px;
+  padding: 6px 10px;
+  border-radius: 0px 3px;
+  box-shadow: 1px 1px 6px rgba(201, 147, 93, 0.7);
+  transform: rotate(96deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box457 {
+  --cssShared-v-457: 618983;
+  color: hsl(349, 41%, 79%);
+  background-color: hsl(169, 41%, 21%);
+  border: 3px solid hsl(79, 50%, 50%);
+  margin: 17px 21px 10px 13px;
+  padding: 7px 12px;
+  border-radius: 1px 5px;
+  box-shadow: 2px 2px 7px rgba(202, 149, 96, 0.8);
+  transform: rotate(97deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box458 {
+  --cssShared-v-458: 626902;
+  color: hsl(26, 54%, 36%);
+  background-color: hsl(206, 54%, 64%);
+  border: 4px solid hsl(116, 50%, 50%);
+  margin: 18px 24px 15px 2px;
+  padding: 8px 14px;
+  border-radius: 2px 7px;
+  box-shadow: 3px 3px 8px rgba(203, 151, 99, 0.9);
+  transform: rotate(98deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box459 {
+  --cssShared-v-459: 634821;
+  color: hsl(63, 67%, 43%);
+  background-color: hsl(243, 67%, 57%);
+  border: 5px solid hsl(153, 50%, 50%);
+  margin: 19px 27px 20px 9px;
+  padding: 9px 16px;
+  border-radius: 3px 0px;
+  box-shadow: 4px 4px 0px rgba(204, 153, 102, 0.1);
+  transform: rotate(99deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box460 {
+  --cssShared-v-460: 642740;
+  color: hsl(100, 80%, 50%);
+  background-color: hsl(280, 80%, 50%);
+  border: 1px solid hsl(190, 50%, 50%);
+  margin: 0px 0px 0px 16px;
+  padding: 10px 18px;
+  border-radius: 4px 2px;
+  box-shadow: 0px 5px 1px rgba(205, 155, 105, 0.2);
+  transform: rotate(100deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box461 {
+  --cssShared-v-461: 650659;
+  color: hsl(137, 93%, 57%);
+  background-color: hsl(317, 93%, 43%);
+  border: 2px solid hsl(227, 50%, 50%);
+  margin: 1px 3px 5px 5px;
+  padding: 11px 20px;
+  border-radius: 5px 4px;
+  box-shadow: 1px 6px 2px rgba(206, 157, 108, 0.3);
+  transform: rotate(101deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box462 {
+  --cssShared-v-462: 658578;
+  color: hsl(174, 6%, 64%);
+  background-color: hsl(354, 6%, 36%);
+  border: 3px solid hsl(264, 50%, 50%);
+  margin: 2px 6px 10px 12px;
+  padding: 12px 0px;
+  border-radius: 6px 6px;
+  box-shadow: 2px 0px 3px rgba(207, 159, 111, 0.4);
+  transform: rotate(102deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box463 {
+  --cssShared-v-463: 666497;
+  color: hsl(211, 19%, 71%);
+  background-color: hsl(31, 19%, 29%);
+  border: 4px solid hsl(301, 50%, 50%);
+  margin: 3px 9px 15px 1px;
+  padding: 13px 2px;
+  border-radius: 7px 8px;
+  box-shadow: 3px 1px 4px rgba(208, 161, 114, 0.5);
+  transform: rotate(103deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box464 {
+  --cssShared-v-464: 674416;
+  color: hsl(248, 32%, 78%);
+  background-color: hsl(68, 32%, 22%);
+  border: 5px solid hsl(338, 50%, 50%);
+  margin: 4px 12px 20px 8px;
+  padding: 14px 4px;
+  border-radius: 8px 1px;
+  box-shadow: 4px 2px 5px rgba(209, 163, 117, 0.6);
+  transform: rotate(104deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box465 {
+  --cssShared-v-465: 682335;
+  color: hsl(285, 45%, 35%);
+  background-color: hsl(105, 45%, 65%);
+  border: 1px solid hsl(15, 50%, 50%);
+  margin: 5px 15px 0px 15px;
+  padding: 0px 6px;
+  border-radius: 9px 3px;
+  box-shadow: 0px 3px 6px rgba(210, 165, 120, 0.7);
+  transform: rotate(105deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box466 {
+  --cssShared-v-466: 690254;
+  color: hsl(322, 58%, 42%);
+  background-color: hsl(142, 58%, 58%);
+  border: 2px solid hsl(52, 50%, 50%);
+  margin: 6px 18px 5px 4px;
+  padding: 1px 8px;
+  border-radius: 10px 5px;
+  box-shadow: 1px 4px 7px rgba(211, 167, 123, 0.8);
+  transform: rotate(106deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box467 {
+  --cssShared-v-467: 698173;
+  color: hsl(359, 71%, 49%);
+  background-color: hsl(179, 71%, 51%);
+  border: 3px solid hsl(89, 50%, 50%);
+  margin: 7px 21px 10px 11px;
+  padding: 2px 10px;
+  border-radius: 11px 7px;
+  box-shadow: 2px 5px 8px rgba(212, 169, 126, 0.9);
+  transform: rotate(107deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box468 {
+  --cssShared-v-468: 706092;
+  color: hsl(36, 84%, 56%);
+  background-color: hsl(216, 84%, 44%);
+  border: 4px solid hsl(126, 50%, 50%);
+  margin: 8px 24px 15px 0px;
+  padding: 3px 12px;
+  border-radius: 0px 0px;
+  box-shadow: 3px 6px 0px rgba(213, 171, 129, 0.1);
+  transform: rotate(108deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box469 {
+  --cssShared-v-469: 714011;
+  color: hsl(73, 97%, 63%);
+  background-color: hsl(253, 97%, 37%);
+  border: 5px solid hsl(163, 50%, 50%);
+  margin: 9px 27px 20px 7px;
+  padding: 4px 14px;
+  border-radius: 1px 2px;
+  box-shadow: 4px 0px 1px rgba(214, 173, 132, 0.2);
+  transform: rotate(109deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box470 {
+  --cssShared-v-470: 721930;
+  color: hsl(110, 10%, 70%);
+  background-color: hsl(290, 10%, 30%);
+  border: 1px solid hsl(200, 50%, 50%);
+  margin: 10px 0px 0px 14px;
+  padding: 5px 16px;
+  border-radius: 2px 4px;
+  box-shadow: 0px 1px 2px rgba(215, 175, 135, 0.3);
+  transform: rotate(110deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box471 {
+  --cssShared-v-471: 729849;
+  color: hsl(147, 23%, 77%);
+  background-color: hsl(327, 23%, 23%);
+  border: 2px solid hsl(237, 50%, 50%);
+  margin: 11px 3px 5px 3px;
+  padding: 6px 18px;
+  border-radius: 3px 6px;
+  box-shadow: 1px 2px 3px rgba(216, 177, 138, 0.4);
+  transform: rotate(111deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box472 {
+  --cssShared-v-472: 737768;
+  color: hsl(184, 36%, 34%);
+  background-color: hsl(4, 36%, 66%);
+  border: 3px solid hsl(274, 50%, 50%);
+  margin: 12px 6px 10px 10px;
+  padding: 7px 20px;
+  border-radius: 4px 8px;
+  box-shadow: 2px 3px 4px rgba(217, 179, 141, 0.5);
+  transform: rotate(112deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box473 {
+  --cssShared-v-473: 745687;
+  color: hsl(221, 49%, 41%);
+  background-color: hsl(41, 49%, 59%);
+  border: 4px solid hsl(311, 50%, 50%);
+  margin: 13px 9px 15px 17px;
+  padding: 8px 0px;
+  border-radius: 5px 1px;
+  box-shadow: 3px 4px 5px rgba(218, 181, 144, 0.6);
+  transform: rotate(113deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box474 {
+  --cssShared-v-474: 753606;
+  color: hsl(258, 62%, 48%);
+  background-color: hsl(78, 62%, 52%);
+  border: 5px solid hsl(348, 50%, 50%);
+  margin: 14px 12px 20px 6px;
+  padding: 9px 2px;
+  border-radius: 6px 3px;
+  box-shadow: 4px 5px 6px rgba(219, 183, 147, 0.7);
+  transform: rotate(114deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box475 {
+  --cssShared-v-475: 761525;
+  color: hsl(295, 75%, 55%);
+  background-color: hsl(115, 75%, 45%);
+  border: 1px solid hsl(25, 50%, 50%);
+  margin: 15px 15px 0px 13px;
+  padding: 10px 4px;
+  border-radius: 7px 5px;
+  box-shadow: 0px 6px 7px rgba(220, 185, 150, 0.8);
+  transform: rotate(115deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box476 {
+  --cssShared-v-476: 769444;
+  color: hsl(332, 88%, 62%);
+  background-color: hsl(152, 88%, 38%);
+  border: 2px solid hsl(62, 50%, 50%);
+  margin: 16px 18px 5px 2px;
+  padding: 11px 6px;
+  border-radius: 8px 7px;
+  box-shadow: 1px 0px 8px rgba(221, 187, 153, 0.9);
+  transform: rotate(116deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box477 {
+  --cssShared-v-477: 777363;
+  color: hsl(9, 1%, 69%);
+  background-color: hsl(189, 1%, 31%);
+  border: 3px solid hsl(99, 50%, 50%);
+  margin: 17px 21px 10px 9px;
+  padding: 12px 8px;
+  border-radius: 9px 0px;
+  box-shadow: 2px 1px 0px rgba(222, 189, 156, 0.1);
+  transform: rotate(117deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box478 {
+  --cssShared-v-478: 785282;
+  color: hsl(46, 14%, 76%);
+  background-color: hsl(226, 14%, 24%);
+  border: 4px solid hsl(136, 50%, 50%);
+  margin: 18px 24px 15px 16px;
+  padding: 13px 10px;
+  border-radius: 10px 2px;
+  box-shadow: 3px 2px 1px rgba(223, 191, 159, 0.2);
+  transform: rotate(118deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box479 {
+  --cssShared-v-479: 793201;
+  color: hsl(83, 27%, 33%);
+  background-color: hsl(263, 27%, 67%);
+  border: 5px solid hsl(173, 50%, 50%);
+  margin: 19px 27px 20px 5px;
+  padding: 14px 12px;
+  border-radius: 11px 4px;
+  box-shadow: 4px 3px 2px rgba(224, 193, 162, 0.3);
+  transform: rotate(119deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box480 {
+  --cssShared-v-480: 801120;
+  color: hsl(120, 40%, 40%);
+  background-color: hsl(300, 40%, 60%);
+  border: 1px solid hsl(210, 50%, 50%);
+  margin: 0px 0px 0px 12px;
+  padding: 0px 14px;
+  border-radius: 0px 6px;
+  box-shadow: 0px 4px 3px rgba(225, 195, 165, 0.4);
+  transform: rotate(120deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box481 {
+  --cssShared-v-481: 809039;
+  color: hsl(157, 53%, 47%);
+  background-color: hsl(337, 53%, 53%);
+  border: 2px solid hsl(247, 50%, 50%);
+  margin: 1px 3px 5px 1px;
+  padding: 1px 16px;
+  border-radius: 1px 8px;
+  box-shadow: 1px 5px 4px rgba(226, 197, 168, 0.5);
+  transform: rotate(121deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box482 {
+  --cssShared-v-482: 816958;
+  color: hsl(194, 66%, 54%);
+  background-color: hsl(14, 66%, 46%);
+  border: 3px solid hsl(284, 50%, 50%);
+  margin: 2px 6px 10px 8px;
+  padding: 2px 18px;
+  border-radius: 2px 1px;
+  box-shadow: 2px 6px 5px rgba(227, 199, 171, 0.6);
+  transform: rotate(122deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box483 {
+  --cssShared-v-483: 824877;
+  color: hsl(231, 79%, 61%);
+  background-color: hsl(51, 79%, 39%);
+  border: 4px solid hsl(321, 50%, 50%);
+  margin: 3px 9px 15px 15px;
+  padding: 3px 20px;
+  border-radius: 3px 3px;
+  box-shadow: 3px 0px 6px rgba(228, 201, 174, 0.7);
+  transform: rotate(123deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box484 {
+  --cssShared-v-484: 832796;
+  color: hsl(268, 92%, 68%);
+  background-color: hsl(88, 92%, 32%);
+  border: 5px solid hsl(358, 50%, 50%);
+  margin: 4px 12px 20px 4px;
+  padding: 4px 0px;
+  border-radius: 4px 5px;
+  box-shadow: 4px 1px 7px rgba(229, 203, 177, 0.8);
+  transform: rotate(124deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box485 {
+  --cssShared-v-485: 840715;
+  color: hsl(305, 5%, 75%);
+  background-color: hsl(125, 5%, 25%);
+  border: 1px solid hsl(35, 50%, 50%);
+  margin: 5px 15px 0px 11px;
+  padding: 5px 2px;
+  border-radius: 5px 7px;
+  box-shadow: 0px 2px 8px rgba(230, 205, 180, 0.9);
+  transform: rotate(125deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box486 {
+  --cssShared-v-486: 848634;
+  color: hsl(342, 18%, 32%);
+  background-color: hsl(162, 18%, 68%);
+  border: 2px solid hsl(72, 50%, 50%);
+  margin: 6px 18px 5px 0px;
+  padding: 6px 4px;
+  border-radius: 6px 0px;
+  box-shadow: 1px 3px 0px rgba(231, 207, 183, 0.1);
+  transform: rotate(126deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box487 {
+  --cssShared-v-487: 856553;
+  color: hsl(19, 31%, 39%);
+  background-color: hsl(199, 31%, 61%);
+  border: 3px solid hsl(109, 50%, 50%);
+  margin: 7px 21px 10px 7px;
+  padding: 7px 6px;
+  border-radius: 7px 2px;
+  box-shadow: 2px 4px 1px rgba(232, 209, 186, 0.2);
+  transform: rotate(127deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box488 {
+  --cssShared-v-488: 864472;
+  color: hsl(56, 44%, 46%);
+  background-color: hsl(236, 44%, 54%);
+  border: 4px solid hsl(146, 50%, 50%);
+  margin: 8px 24px 15px 14px;
+  padding: 8px 8px;
+  border-radius: 8px 4px;
+  box-shadow: 3px 5px 2px rgba(233, 211, 189, 0.3);
+  transform: rotate(128deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box489 {
+  --cssShared-v-489: 872391;
+  color: hsl(93, 57%, 53%);
+  background-color: hsl(273, 57%, 47%);
+  border: 5px solid hsl(183, 50%, 50%);
+  margin: 9px 27px 20px 3px;
+  padding: 9px 10px;
+  border-radius: 9px 6px;
+  box-shadow: 4px 6px 3px rgba(234, 213, 192, 0.4);
+  transform: rotate(129deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box490 {
+  --cssShared-v-490: 880310;
+  color: hsl(130, 70%, 60%);
+  background-color: hsl(310, 70%, 40%);
+  border: 1px solid hsl(220, 50%, 50%);
+  margin: 10px 0px 0px 10px;
+  padding: 10px 12px;
+  border-radius: 10px 8px;
+  box-shadow: 0px 0px 4px rgba(235, 215, 195, 0.5);
+  transform: rotate(130deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box491 {
+  --cssShared-v-491: 888229;
+  color: hsl(167, 83%, 67%);
+  background-color: hsl(347, 83%, 33%);
+  border: 2px solid hsl(257, 50%, 50%);
+  margin: 11px 3px 5px 17px;
+  padding: 11px 14px;
+  border-radius: 11px 1px;
+  box-shadow: 1px 1px 5px rgba(236, 217, 198, 0.6);
+  transform: rotate(131deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box492 {
+  --cssShared-v-492: 896148;
+  color: hsl(204, 96%, 74%);
+  background-color: hsl(24, 96%, 26%);
+  border: 3px solid hsl(294, 50%, 50%);
+  margin: 12px 6px 10px 6px;
+  padding: 12px 16px;
+  border-radius: 0px 3px;
+  box-shadow: 2px 2px 6px rgba(237, 219, 201, 0.7);
+  transform: rotate(132deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box493 {
+  --cssShared-v-493: 904067;
+  color: hsl(241, 9%, 31%);
+  background-color: hsl(61, 9%, 69%);
+  border: 4px solid hsl(331, 50%, 50%);
+  margin: 13px 9px 15px 13px;
+  padding: 13px 18px;
+  border-radius: 1px 5px;
+  box-shadow: 3px 3px 7px rgba(238, 221, 204, 0.8);
+  transform: rotate(133deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box494 {
+  --cssShared-v-494: 911986;
+  color: hsl(278, 22%, 38%);
+  background-color: hsl(98, 22%, 62%);
+  border: 5px solid hsl(8, 50%, 50%);
+  margin: 14px 12px 20px 2px;
+  padding: 14px 20px;
+  border-radius: 2px 7px;
+  box-shadow: 4px 4px 8px rgba(239, 223, 207, 0.9);
+  transform: rotate(134deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box495 {
+  --cssShared-v-495: 919905;
+  color: hsl(315, 35%, 45%);
+  background-color: hsl(135, 35%, 55%);
+  border: 1px solid hsl(45, 50%, 50%);
+  margin: 15px 15px 0px 9px;
+  padding: 0px 0px;
+  border-radius: 3px 0px;
+  box-shadow: 0px 5px 0px rgba(240, 225, 210, 0.1);
+  transform: rotate(135deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box496 {
+  --cssShared-v-496: 927824;
+  color: hsl(352, 48%, 52%);
+  background-color: hsl(172, 48%, 48%);
+  border: 2px solid hsl(82, 50%, 50%);
+  margin: 16px 18px 5px 16px;
+  padding: 1px 2px;
+  border-radius: 4px 2px;
+  box-shadow: 1px 6px 1px rgba(241, 227, 213, 0.2);
+  transform: rotate(136deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box497 {
+  --cssShared-v-497: 935743;
+  color: hsl(29, 61%, 59%);
+  background-color: hsl(209, 61%, 41%);
+  border: 3px solid hsl(119, 50%, 50%);
+  margin: 17px 21px 10px 5px;
+  padding: 2px 4px;
+  border-radius: 5px 4px;
+  box-shadow: 2px 0px 2px rgba(242, 229, 216, 0.3);
+  transform: rotate(137deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box498 {
+  --cssShared-v-498: 943662;
+  color: hsl(66, 74%, 66%);
+  background-color: hsl(246, 74%, 34%);
+  border: 4px solid hsl(156, 50%, 50%);
+  margin: 18px 24px 15px 12px;
+  padding: 3px 6px;
+  border-radius: 6px 6px;
+  box-shadow: 3px 1px 3px rgba(243, 231, 219, 0.4);
+  transform: rotate(138deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box499 {
+  --cssShared-v-499: 951581;
+  color: hsl(103, 87%, 73%);
+  background-color: hsl(283, 87%, 27%);
+  border: 5px solid hsl(193, 50%, 50%);
+  margin: 19px 27px 20px 1px;
+  padding: 4px 8px;
+  border-radius: 7px 8px;
+  box-shadow: 4px 2px 4px rgba(244, 233, 222, 0.5);
+  transform: rotate(139deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box500 {
+  --cssShared-v-500: 959500;
+  color: hsl(140, 0%, 30%);
+  background-color: hsl(320, 0%, 70%);
+  border: 1px solid hsl(230, 50%, 50%);
+  margin: 0px 0px 0px 8px;
+  padding: 5px 10px;
+  border-radius: 8px 1px;
+  box-shadow: 0px 3px 5px rgba(245, 235, 225, 0.6);
+  transform: rotate(140deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box501 {
+  --cssShared-v-501: 967419;
+  color: hsl(177, 13%, 37%);
+  background-color: hsl(357, 13%, 63%);
+  border: 2px solid hsl(267, 50%, 50%);
+  margin: 1px 3px 5px 15px;
+  padding: 6px 12px;
+  border-radius: 9px 3px;
+  box-shadow: 1px 4px 6px rgba(246, 237, 228, 0.7);
+  transform: rotate(141deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box502 {
+  --cssShared-v-502: 975338;
+  color: hsl(214, 26%, 44%);
+  background-color: hsl(34, 26%, 56%);
+  border: 3px solid hsl(304, 50%, 50%);
+  margin: 2px 6px 10px 4px;
+  padding: 7px 14px;
+  border-radius: 10px 5px;
+  box-shadow: 2px 5px 7px rgba(247, 239, 231, 0.8);
+  transform: rotate(142deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box503 {
+  --cssShared-v-503: 983257;
+  color: hsl(251, 39%, 51%);
+  background-color: hsl(71, 39%, 49%);
+  border: 4px solid hsl(341, 50%, 50%);
+  margin: 3px 9px 15px 11px;
+  padding: 8px 16px;
+  border-radius: 11px 7px;
+  box-shadow: 3px 6px 8px rgba(248, 241, 234, 0.9);
+  transform: rotate(143deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box504 {
+  --cssShared-v-504: 991176;
+  color: hsl(288, 52%, 58%);
+  background-color: hsl(108, 52%, 42%);
+  border: 5px solid hsl(18, 50%, 50%);
+  margin: 4px 12px 20px 0px;
+  padding: 9px 18px;
+  border-radius: 0px 0px;
+  box-shadow: 4px 0px 0px rgba(249, 243, 237, 0.1);
+  transform: rotate(144deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box505 {
+  --cssShared-v-505: 999095;
+  color: hsl(325, 65%, 65%);
+  background-color: hsl(145, 65%, 35%);
+  border: 1px solid hsl(55, 50%, 50%);
+  margin: 5px 15px 0px 7px;
+  padding: 10px 20px;
+  border-radius: 1px 2px;
+  box-shadow: 0px 1px 1px rgba(250, 245, 240, 0.2);
+  transform: rotate(145deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box506 {
+  --cssShared-v-506: 7014;
+  color: hsl(2, 78%, 72%);
+  background-color: hsl(182, 78%, 28%);
+  border: 2px solid hsl(92, 50%, 50%);
+  margin: 6px 18px 5px 14px;
+  padding: 11px 0px;
+  border-radius: 2px 4px;
+  box-shadow: 1px 2px 2px rgba(251, 247, 243, 0.3);
+  transform: rotate(146deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box507 {
+  --cssShared-v-507: 14933;
+  color: hsl(39, 91%, 79%);
+  background-color: hsl(219, 91%, 21%);
+  border: 3px solid hsl(129, 50%, 50%);
+  margin: 7px 21px 10px 3px;
+  padding: 12px 2px;
+  border-radius: 3px 6px;
+  box-shadow: 2px 3px 3px rgba(252, 249, 246, 0.4);
+  transform: rotate(147deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box508 {
+  --cssShared-v-508: 22852;
+  color: hsl(76, 4%, 36%);
+  background-color: hsl(256, 4%, 64%);
+  border: 4px solid hsl(166, 50%, 50%);
+  margin: 8px 24px 15px 10px;
+  padding: 13px 4px;
+  border-radius: 4px 8px;
+  box-shadow: 3px 4px 4px rgba(253, 251, 249, 0.5);
+  transform: rotate(148deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box509 {
+  --cssShared-v-509: 30771;
+  color: hsl(113, 17%, 43%);
+  background-color: hsl(293, 17%, 57%);
+  border: 5px solid hsl(203, 50%, 50%);
+  margin: 9px 27px 20px 17px;
+  padding: 14px 6px;
+  border-radius: 5px 1px;
+  box-shadow: 4px 5px 5px rgba(254, 253, 252, 0.6);
+  transform: rotate(149deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box510 {
+  --cssShared-v-510: 38690;
+  color: hsl(150, 30%, 50%);
+  background-color: hsl(330, 30%, 50%);
+  border: 1px solid hsl(240, 50%, 50%);
+  margin: 10px 0px 0px 6px;
+  padding: 0px 8px;
+  border-radius: 6px 3px;
+  box-shadow: 0px 6px 6px rgba(0, 0, 0, 0.7);
+  transform: rotate(150deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box511 {
+  --cssShared-v-511: 46609;
+  color: hsl(187, 43%, 57%);
+  background-color: hsl(7, 43%, 43%);
+  border: 2px solid hsl(277, 50%, 50%);
+  margin: 11px 3px 5px 13px;
+  padding: 1px 10px;
+  border-radius: 7px 5px;
+  box-shadow: 1px 0px 7px rgba(1, 2, 3, 0.8);
+  transform: rotate(151deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box512 {
+  --cssShared-v-512: 54528;
+  color: hsl(224, 56%, 64%);
+  background-color: hsl(44, 56%, 36%);
+  border: 3px solid hsl(314, 50%, 50%);
+  margin: 12px 6px 10px 2px;
+  padding: 2px 12px;
+  border-radius: 8px 7px;
+  box-shadow: 2px 1px 8px rgba(2, 4, 6, 0.9);
+  transform: rotate(152deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box513 {
+  --cssShared-v-513: 62447;
+  color: hsl(261, 69%, 71%);
+  background-color: hsl(81, 69%, 29%);
+  border: 4px solid hsl(351, 50%, 50%);
+  margin: 13px 9px 15px 9px;
+  padding: 3px 14px;
+  border-radius: 9px 0px;
+  box-shadow: 3px 2px 0px rgba(3, 6, 9, 0.1);
+  transform: rotate(153deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box514 {
+  --cssShared-v-514: 70366;
+  color: hsl(298, 82%, 78%);
+  background-color: hsl(118, 82%, 22%);
+  border: 5px solid hsl(28, 50%, 50%);
+  margin: 14px 12px 20px 16px;
+  padding: 4px 16px;
+  border-radius: 10px 2px;
+  box-shadow: 4px 3px 1px rgba(4, 8, 12, 0.2);
+  transform: rotate(154deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box515 {
+  --cssShared-v-515: 78285;
+  color: hsl(335, 95%, 35%);
+  background-color: hsl(155, 95%, 65%);
+  border: 1px solid hsl(65, 50%, 50%);
+  margin: 15px 15px 0px 5px;
+  padding: 5px 18px;
+  border-radius: 11px 4px;
+  box-shadow: 0px 4px 2px rgba(5, 10, 15, 0.3);
+  transform: rotate(155deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box516 {
+  --cssShared-v-516: 86204;
+  color: hsl(12, 8%, 42%);
+  background-color: hsl(192, 8%, 58%);
+  border: 2px solid hsl(102, 50%, 50%);
+  margin: 16px 18px 5px 12px;
+  padding: 6px 20px;
+  border-radius: 0px 6px;
+  box-shadow: 1px 5px 3px rgba(6, 12, 18, 0.4);
+  transform: rotate(156deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box517 {
+  --cssShared-v-517: 94123;
+  color: hsl(49, 21%, 49%);
+  background-color: hsl(229, 21%, 51%);
+  border: 3px solid hsl(139, 50%, 50%);
+  margin: 17px 21px 10px 1px;
+  padding: 7px 0px;
+  border-radius: 1px 8px;
+  box-shadow: 2px 6px 4px rgba(7, 14, 21, 0.5);
+  transform: rotate(157deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box518 {
+  --cssShared-v-518: 102042;
+  color: hsl(86, 34%, 56%);
+  background-color: hsl(266, 34%, 44%);
+  border: 4px solid hsl(176, 50%, 50%);
+  margin: 18px 24px 15px 8px;
+  padding: 8px 2px;
+  border-radius: 2px 1px;
+  box-shadow: 3px 0px 5px rgba(8, 16, 24, 0.6);
+  transform: rotate(158deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box519 {
+  --cssShared-v-519: 109961;
+  color: hsl(123, 47%, 63%);
+  background-color: hsl(303, 47%, 37%);
+  border: 5px solid hsl(213, 50%, 50%);
+  margin: 19px 27px 20px 15px;
+  padding: 9px 4px;
+  border-radius: 3px 3px;
+  box-shadow: 4px 1px 6px rgba(9, 18, 27, 0.7);
+  transform: rotate(159deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box520 {
+  --cssShared-v-520: 117880;
+  color: hsl(160, 60%, 70%);
+  background-color: hsl(340, 60%, 30%);
+  border: 1px solid hsl(250, 50%, 50%);
+  margin: 0px 0px 0px 4px;
+  padding: 10px 6px;
+  border-radius: 4px 5px;
+  box-shadow: 0px 2px 7px rgba(10, 20, 30, 0.8);
+  transform: rotate(160deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box521 {
+  --cssShared-v-521: 125799;
+  color: hsl(197, 73%, 77%);
+  background-color: hsl(17, 73%, 23%);
+  border: 2px solid hsl(287, 50%, 50%);
+  margin: 1px 3px 5px 11px;
+  padding: 11px 8px;
+  border-radius: 5px 7px;
+  box-shadow: 1px 3px 8px rgba(11, 22, 33, 0.9);
+  transform: rotate(161deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box522 {
+  --cssShared-v-522: 133718;
+  color: hsl(234, 86%, 34%);
+  background-color: hsl(54, 86%, 66%);
+  border: 3px solid hsl(324, 50%, 50%);
+  margin: 2px 6px 10px 0px;
+  padding: 12px 10px;
+  border-radius: 6px 0px;
+  box-shadow: 2px 4px 0px rgba(12, 24, 36, 0.1);
+  transform: rotate(162deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box523 {
+  --cssShared-v-523: 141637;
+  color: hsl(271, 99%, 41%);
+  background-color: hsl(91, 99%, 59%);
+  border: 4px solid hsl(1, 50%, 50%);
+  margin: 3px 9px 15px 7px;
+  padding: 13px 12px;
+  border-radius: 7px 2px;
+  box-shadow: 3px 5px 1px rgba(13, 26, 39, 0.2);
+  transform: rotate(163deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box524 {
+  --cssShared-v-524: 149556;
+  color: hsl(308, 12%, 48%);
+  background-color: hsl(128, 12%, 52%);
+  border: 5px solid hsl(38, 50%, 50%);
+  margin: 4px 12px 20px 14px;
+  padding: 14px 14px;
+  border-radius: 8px 4px;
+  box-shadow: 4px 6px 2px rgba(14, 28, 42, 0.3);
+  transform: rotate(164deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box525 {
+  --cssShared-v-525: 157475;
+  color: hsl(345, 25%, 55%);
+  background-color: hsl(165, 25%, 45%);
+  border: 1px solid hsl(75, 50%, 50%);
+  margin: 5px 15px 0px 3px;
+  padding: 0px 16px;
+  border-radius: 9px 6px;
+  box-shadow: 0px 0px 3px rgba(15, 30, 45, 0.4);
+  transform: rotate(165deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box526 {
+  --cssShared-v-526: 165394;
+  color: hsl(22, 38%, 62%);
+  background-color: hsl(202, 38%, 38%);
+  border: 2px solid hsl(112, 50%, 50%);
+  margin: 6px 18px 5px 10px;
+  padding: 1px 18px;
+  border-radius: 10px 8px;
+  box-shadow: 1px 1px 4px rgba(16, 32, 48, 0.5);
+  transform: rotate(166deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box527 {
+  --cssShared-v-527: 173313;
+  color: hsl(59, 51%, 69%);
+  background-color: hsl(239, 51%, 31%);
+  border: 3px solid hsl(149, 50%, 50%);
+  margin: 7px 21px 10px 17px;
+  padding: 2px 20px;
+  border-radius: 11px 1px;
+  box-shadow: 2px 2px 5px rgba(17, 34, 51, 0.6);
+  transform: rotate(167deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box528 {
+  --cssShared-v-528: 181232;
+  color: hsl(96, 64%, 76%);
+  background-color: hsl(276, 64%, 24%);
+  border: 4px solid hsl(186, 50%, 50%);
+  margin: 8px 24px 15px 6px;
+  padding: 3px 0px;
+  border-radius: 0px 3px;
+  box-shadow: 3px 3px 6px rgba(18, 36, 54, 0.7);
+  transform: rotate(168deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box529 {
+  --cssShared-v-529: 189151;
+  color: hsl(133, 77%, 33%);
+  background-color: hsl(313, 77%, 67%);
+  border: 5px solid hsl(223, 50%, 50%);
+  margin: 9px 27px 20px 13px;
+  padding: 4px 2px;
+  border-radius: 1px 5px;
+  box-shadow: 4px 4px 7px rgba(19, 38, 57, 0.8);
+  transform: rotate(169deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box530 {
+  --cssShared-v-530: 197070;
+  color: hsl(170, 90%, 40%);
+  background-color: hsl(350, 90%, 60%);
+  border: 1px solid hsl(260, 50%, 50%);
+  margin: 10px 0px 0px 2px;
+  padding: 5px 4px;
+  border-radius: 2px 7px;
+  box-shadow: 0px 5px 8px rgba(20, 40, 60, 0.9);
+  transform: rotate(170deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box531 {
+  --cssShared-v-531: 204989;
+  color: hsl(207, 3%, 47%);
+  background-color: hsl(27, 3%, 53%);
+  border: 2px solid hsl(297, 50%, 50%);
+  margin: 11px 3px 5px 9px;
+  padding: 6px 6px;
+  border-radius: 3px 0px;
+  box-shadow: 1px 6px 0px rgba(21, 42, 63, 0.1);
+  transform: rotate(171deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box532 {
+  --cssShared-v-532: 212908;
+  color: hsl(244, 16%, 54%);
+  background-color: hsl(64, 16%, 46%);
+  border: 3px solid hsl(334, 50%, 50%);
+  margin: 12px 6px 10px 16px;
+  padding: 7px 8px;
+  border-radius: 4px 2px;
+  box-shadow: 2px 0px 1px rgba(22, 44, 66, 0.2);
+  transform: rotate(172deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box533 {
+  --cssShared-v-533: 220827;
+  color: hsl(281, 29%, 61%);
+  background-color: hsl(101, 29%, 39%);
+  border: 4px solid hsl(11, 50%, 50%);
+  margin: 13px 9px 15px 5px;
+  padding: 8px 10px;
+  border-radius: 5px 4px;
+  box-shadow: 3px 1px 2px rgba(23, 46, 69, 0.3);
+  transform: rotate(173deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box534 {
+  --cssShared-v-534: 228746;
+  color: hsl(318, 42%, 68%);
+  background-color: hsl(138, 42%, 32%);
+  border: 5px solid hsl(48, 50%, 50%);
+  margin: 14px 12px 20px 12px;
+  padding: 9px 12px;
+  border-radius: 6px 6px;
+  box-shadow: 4px 2px 3px rgba(24, 48, 72, 0.4);
+  transform: rotate(174deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box535 {
+  --cssShared-v-535: 236665;
+  color: hsl(355, 55%, 75%);
+  background-color: hsl(175, 55%, 25%);
+  border: 1px solid hsl(85, 50%, 50%);
+  margin: 15px 15px 0px 1px;
+  padding: 10px 14px;
+  border-radius: 7px 8px;
+  box-shadow: 0px 3px 4px rgba(25, 50, 75, 0.5);
+  transform: rotate(175deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box536 {
+  --cssShared-v-536: 244584;
+  color: hsl(32, 68%, 32%);
+  background-color: hsl(212, 68%, 68%);
+  border: 2px solid hsl(122, 50%, 50%);
+  margin: 16px 18px 5px 8px;
+  padding: 11px 16px;
+  border-radius: 8px 1px;
+  box-shadow: 1px 4px 5px rgba(26, 52, 78, 0.6);
+  transform: rotate(176deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box537 {
+  --cssShared-v-537: 252503;
+  color: hsl(69, 81%, 39%);
+  background-color: hsl(249, 81%, 61%);
+  border: 3px solid hsl(159, 50%, 50%);
+  margin: 17px 21px 10px 15px;
+  padding: 12px 18px;
+  border-radius: 9px 3px;
+  box-shadow: 2px 5px 6px rgba(27, 54, 81, 0.7);
+  transform: rotate(177deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box538 {
+  --cssShared-v-538: 260422;
+  color: hsl(106, 94%, 46%);
+  background-color: hsl(286, 94%, 54%);
+  border: 4px solid hsl(196, 50%, 50%);
+  margin: 18px 24px 15px 4px;
+  padding: 13px 20px;
+  border-radius: 10px 5px;
+  box-shadow: 3px 6px 7px rgba(28, 56, 84, 0.8);
+  transform: rotate(178deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box539 {
+  --cssShared-v-539: 268341;
+  color: hsl(143, 7%, 53%);
+  background-color: hsl(323, 7%, 47%);
+  border: 5px solid hsl(233, 50%, 50%);
+  margin: 19px 27px 20px 11px;
+  padding: 14px 0px;
+  border-radius: 11px 7px;
+  box-shadow: 4px 0px 8px rgba(29, 58, 87, 0.9);
+  transform: rotate(179deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box540 {
+  --cssShared-v-540: 276260;
+  color: hsl(180, 20%, 60%);
+  background-color: hsl(0, 20%, 40%);
+  border: 1px solid hsl(270, 50%, 50%);
+  margin: 0px 0px 0px 0px;
+  padding: 0px 2px;
+  border-radius: 0px 0px;
+  box-shadow: 0px 1px 0px rgba(30, 60, 90, 0.1);
+  transform: rotate(180deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box541 {
+  --cssShared-v-541: 284179;
+  color: hsl(217, 33%, 67%);
+  background-color: hsl(37, 33%, 33%);
+  border: 2px solid hsl(307, 50%, 50%);
+  margin: 1px 3px 5px 7px;
+  padding: 1px 4px;
+  border-radius: 1px 2px;
+  box-shadow: 1px 2px 1px rgba(31, 62, 93, 0.2);
+  transform: rotate(181deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box542 {
+  --cssShared-v-542: 292098;
+  color: hsl(254, 46%, 74%);
+  background-color: hsl(74, 46%, 26%);
+  border: 3px solid hsl(344, 50%, 50%);
+  margin: 2px 6px 10px 14px;
+  padding: 2px 6px;
+  border-radius: 2px 4px;
+  box-shadow: 2px 3px 2px rgba(32, 64, 96, 0.3);
+  transform: rotate(182deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box543 {
+  --cssShared-v-543: 300017;
+  color: hsl(291, 59%, 31%);
+  background-color: hsl(111, 59%, 69%);
+  border: 4px solid hsl(21, 50%, 50%);
+  margin: 3px 9px 15px 3px;
+  padding: 3px 8px;
+  border-radius: 3px 6px;
+  box-shadow: 3px 4px 3px rgba(33, 66, 99, 0.4);
+  transform: rotate(183deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box544 {
+  --cssShared-v-544: 307936;
+  color: hsl(328, 72%, 38%);
+  background-color: hsl(148, 72%, 62%);
+  border: 5px solid hsl(58, 50%, 50%);
+  margin: 4px 12px 20px 10px;
+  padding: 4px 10px;
+  border-radius: 4px 8px;
+  box-shadow: 4px 5px 4px rgba(34, 68, 102, 0.5);
+  transform: rotate(184deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box545 {
+  --cssShared-v-545: 315855;
+  color: hsl(5, 85%, 45%);
+  background-color: hsl(185, 85%, 55%);
+  border: 1px solid hsl(95, 50%, 50%);
+  margin: 5px 15px 0px 17px;
+  padding: 5px 12px;
+  border-radius: 5px 1px;
+  box-shadow: 0px 6px 5px rgba(35, 70, 105, 0.6);
+  transform: rotate(185deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box546 {
+  --cssShared-v-546: 323774;
+  color: hsl(42, 98%, 52%);
+  background-color: hsl(222, 98%, 48%);
+  border: 2px solid hsl(132, 50%, 50%);
+  margin: 6px 18px 5px 6px;
+  padding: 6px 14px;
+  border-radius: 6px 3px;
+  box-shadow: 1px 0px 6px rgba(36, 72, 108, 0.7);
+  transform: rotate(186deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box547 {
+  --cssShared-v-547: 331693;
+  color: hsl(79, 11%, 59%);
+  background-color: hsl(259, 11%, 41%);
+  border: 3px solid hsl(169, 50%, 50%);
+  margin: 7px 21px 10px 13px;
+  padding: 7px 16px;
+  border-radius: 7px 5px;
+  box-shadow: 2px 1px 7px rgba(37, 74, 111, 0.8);
+  transform: rotate(187deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box548 {
+  --cssShared-v-548: 339612;
+  color: hsl(116, 24%, 66%);
+  background-color: hsl(296, 24%, 34%);
+  border: 4px solid hsl(206, 50%, 50%);
+  margin: 8px 24px 15px 2px;
+  padding: 8px 18px;
+  border-radius: 8px 7px;
+  box-shadow: 3px 2px 8px rgba(38, 76, 114, 0.9);
+  transform: rotate(188deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box549 {
+  --cssShared-v-549: 347531;
+  color: hsl(153, 37%, 73%);
+  background-color: hsl(333, 37%, 27%);
+  border: 5px solid hsl(243, 50%, 50%);
+  margin: 9px 27px 20px 9px;
+  padding: 9px 20px;
+  border-radius: 9px 0px;
+  box-shadow: 4px 3px 0px rgba(39, 78, 117, 0.1);
+  transform: rotate(189deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box550 {
+  --cssShared-v-550: 355450;
+  color: hsl(190, 50%, 30%);
+  background-color: hsl(10, 50%, 70%);
+  border: 1px solid hsl(280, 50%, 50%);
+  margin: 10px 0px 0px 16px;
+  padding: 10px 0px;
+  border-radius: 10px 2px;
+  box-shadow: 0px 4px 1px rgba(40, 80, 120, 0.2);
+  transform: rotate(190deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box551 {
+  --cssShared-v-551: 363369;
+  color: hsl(227, 63%, 37%);
+  background-color: hsl(47, 63%, 63%);
+  border: 2px solid hsl(317, 50%, 50%);
+  margin: 11px 3px 5px 5px;
+  padding: 11px 2px;
+  border-radius: 11px 4px;
+  box-shadow: 1px 5px 2px rgba(41, 82, 123, 0.3);
+  transform: rotate(191deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box552 {
+  --cssShared-v-552: 371288;
+  color: hsl(264, 76%, 44%);
+  background-color: hsl(84, 76%, 56%);
+  border: 3px solid hsl(354, 50%, 50%);
+  margin: 12px 6px 10px 12px;
+  padding: 12px 4px;
+  border-radius: 0px 6px;
+  box-shadow: 2px 6px 3px rgba(42, 84, 126, 0.4);
+  transform: rotate(192deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box553 {
+  --cssShared-v-553: 379207;
+  color: hsl(301, 89%, 51%);
+  background-color: hsl(121, 89%, 49%);
+  border: 4px solid hsl(31, 50%, 50%);
+  margin: 13px 9px 15px 1px;
+  padding: 13px 6px;
+  border-radius: 1px 8px;
+  box-shadow: 3px 0px 4px rgba(43, 86, 129, 0.5);
+  transform: rotate(193deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box554 {
+  --cssShared-v-554: 387126;
+  color: hsl(338, 2%, 58%);
+  background-color: hsl(158, 2%, 42%);
+  border: 5px solid hsl(68, 50%, 50%);
+  margin: 14px 12px 20px 8px;
+  padding: 14px 8px;
+  border-radius: 2px 1px;
+  box-shadow: 4px 1px 5px rgba(44, 88, 132, 0.6);
+  transform: rotate(194deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box555 {
+  --cssShared-v-555: 395045;
+  color: hsl(15, 15%, 65%);
+  background-color: hsl(195, 15%, 35%);
+  border: 1px solid hsl(105, 50%, 50%);
+  margin: 15px 15px 0px 15px;
+  padding: 0px 10px;
+  border-radius: 3px 3px;
+  box-shadow: 0px 2px 6px rgba(45, 90, 135, 0.7);
+  transform: rotate(195deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box556 {
+  --cssShared-v-556: 402964;
+  color: hsl(52, 28%, 72%);
+  background-color: hsl(232, 28%, 28%);
+  border: 2px solid hsl(142, 50%, 50%);
+  margin: 16px 18px 5px 4px;
+  padding: 1px 12px;
+  border-radius: 4px 5px;
+  box-shadow: 1px 3px 7px rgba(46, 92, 138, 0.8);
+  transform: rotate(196deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box557 {
+  --cssShared-v-557: 410883;
+  color: hsl(89, 41%, 79%);
+  background-color: hsl(269, 41%, 21%);
+  border: 3px solid hsl(179, 50%, 50%);
+  margin: 17px 21px 10px 11px;
+  padding: 2px 14px;
+  border-radius: 5px 7px;
+  box-shadow: 2px 4px 8px rgba(47, 94, 141, 0.9);
+  transform: rotate(197deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box558 {
+  --cssShared-v-558: 418802;
+  color: hsl(126, 54%, 36%);
+  background-color: hsl(306, 54%, 64%);
+  border: 4px solid hsl(216, 50%, 50%);
+  margin: 18px 24px 15px 0px;
+  padding: 3px 16px;
+  border-radius: 6px 0px;
+  box-shadow: 3px 5px 0px rgba(48, 96, 144, 0.1);
+  transform: rotate(198deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box559 {
+  --cssShared-v-559: 426721;
+  color: hsl(163, 67%, 43%);
+  background-color: hsl(343, 67%, 57%);
+  border: 5px solid hsl(253, 50%, 50%);
+  margin: 19px 27px 20px 7px;
+  padding: 4px 18px;
+  border-radius: 7px 2px;
+  box-shadow: 4px 6px 1px rgba(49, 98, 147, 0.2);
+  transform: rotate(199deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box560 {
+  --cssShared-v-560: 434640;
+  color: hsl(200, 80%, 50%);
+  background-color: hsl(20, 80%, 50%);
+  border: 1px solid hsl(290, 50%, 50%);
+  margin: 0px 0px 0px 14px;
+  padding: 5px 20px;
+  border-radius: 8px 4px;
+  box-shadow: 0px 0px 2px rgba(50, 100, 150, 0.3);
+  transform: rotate(200deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box561 {
+  --cssShared-v-561: 442559;
+  color: hsl(237, 93%, 57%);
+  background-color: hsl(57, 93%, 43%);
+  border: 2px solid hsl(327, 50%, 50%);
+  margin: 1px 3px 5px 3px;
+  padding: 6px 0px;
+  border-radius: 9px 6px;
+  box-shadow: 1px 1px 3px rgba(51, 102, 153, 0.4);
+  transform: rotate(201deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box562 {
+  --cssShared-v-562: 450478;
+  color: hsl(274, 6%, 64%);
+  background-color: hsl(94, 6%, 36%);
+  border: 3px solid hsl(4, 50%, 50%);
+  margin: 2px 6px 10px 10px;
+  padding: 7px 2px;
+  border-radius: 10px 8px;
+  box-shadow: 2px 2px 4px rgba(52, 104, 156, 0.5);
+  transform: rotate(202deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box563 {
+  --cssShared-v-563: 458397;
+  color: hsl(311, 19%, 71%);
+  background-color: hsl(131, 19%, 29%);
+  border: 4px solid hsl(41, 50%, 50%);
+  margin: 3px 9px 15px 17px;
+  padding: 8px 4px;
+  border-radius: 11px 1px;
+  box-shadow: 3px 3px 5px rgba(53, 106, 159, 0.6);
+  transform: rotate(203deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box564 {
+  --cssShared-v-564: 466316;
+  color: hsl(348, 32%, 78%);
+  background-color: hsl(168, 32%, 22%);
+  border: 5px solid hsl(78, 50%, 50%);
+  margin: 4px 12px 20px 6px;
+  padding: 9px 6px;
+  border-radius: 0px 3px;
+  box-shadow: 4px 4px 6px rgba(54, 108, 162, 0.7);
+  transform: rotate(204deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box565 {
+  --cssShared-v-565: 474235;
+  color: hsl(25, 45%, 35%);
+  background-color: hsl(205, 45%, 65%);
+  border: 1px solid hsl(115, 50%, 50%);
+  margin: 5px 15px 0px 13px;
+  padding: 10px 8px;
+  border-radius: 1px 5px;
+  box-shadow: 0px 5px 7px rgba(55, 110, 165, 0.8);
+  transform: rotate(205deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box566 {
+  --cssShared-v-566: 482154;
+  color: hsl(62, 58%, 42%);
+  background-color: hsl(242, 58%, 58%);
+  border: 2px solid hsl(152, 50%, 50%);
+  margin: 6px 18px 5px 2px;
+  padding: 11px 10px;
+  border-radius: 2px 7px;
+  box-shadow: 1px 6px 8px rgba(56, 112, 168, 0.9);
+  transform: rotate(206deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box567 {
+  --cssShared-v-567: 490073;
+  color: hsl(99, 71%, 49%);
+  background-color: hsl(279, 71%, 51%);
+  border: 3px solid hsl(189, 50%, 50%);
+  margin: 7px 21px 10px 9px;
+  padding: 12px 12px;
+  border-radius: 3px 0px;
+  box-shadow: 2px 0px 0px rgba(57, 114, 171, 0.1);
+  transform: rotate(207deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box568 {
+  --cssShared-v-568: 497992;
+  color: hsl(136, 84%, 56%);
+  background-color: hsl(316, 84%, 44%);
+  border: 4px solid hsl(226, 50%, 50%);
+  margin: 8px 24px 15px 16px;
+  padding: 13px 14px;
+  border-radius: 4px 2px;
+  box-shadow: 3px 1px 1px rgba(58, 116, 174, 0.2);
+  transform: rotate(208deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box569 {
+  --cssShared-v-569: 505911;
+  color: hsl(173, 97%, 63%);
+  background-color: hsl(353, 97%, 37%);
+  border: 5px solid hsl(263, 50%, 50%);
+  margin: 9px 27px 20px 5px;
+  padding: 14px 16px;
+  border-radius: 5px 4px;
+  box-shadow: 4px 2px 2px rgba(59, 118, 177, 0.3);
+  transform: rotate(209deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box570 {
+  --cssShared-v-570: 513830;
+  color: hsl(210, 10%, 70%);
+  background-color: hsl(30, 10%, 30%);
+  border: 1px solid hsl(300, 50%, 50%);
+  margin: 10px 0px 0px 12px;
+  padding: 0px 18px;
+  border-radius: 6px 6px;
+  box-shadow: 0px 3px 3px rgba(60, 120, 180, 0.4);
+  transform: rotate(210deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box571 {
+  --cssShared-v-571: 521749;
+  color: hsl(247, 23%, 77%);
+  background-color: hsl(67, 23%, 23%);
+  border: 2px solid hsl(337, 50%, 50%);
+  margin: 11px 3px 5px 1px;
+  padding: 1px 20px;
+  border-radius: 7px 8px;
+  box-shadow: 1px 4px 4px rgba(61, 122, 183, 0.5);
+  transform: rotate(211deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box572 {
+  --cssShared-v-572: 529668;
+  color: hsl(284, 36%, 34%);
+  background-color: hsl(104, 36%, 66%);
+  border: 3px solid hsl(14, 50%, 50%);
+  margin: 12px 6px 10px 8px;
+  padding: 2px 0px;
+  border-radius: 8px 1px;
+  box-shadow: 2px 5px 5px rgba(62, 124, 186, 0.6);
+  transform: rotate(212deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box573 {
+  --cssShared-v-573: 537587;
+  color: hsl(321, 49%, 41%);
+  background-color: hsl(141, 49%, 59%);
+  border: 4px solid hsl(51, 50%, 50%);
+  margin: 13px 9px 15px 15px;
+  padding: 3px 2px;
+  border-radius: 9px 3px;
+  box-shadow: 3px 6px 6px rgba(63, 126, 189, 0.7);
+  transform: rotate(213deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box574 {
+  --cssShared-v-574: 545506;
+  color: hsl(358, 62%, 48%);
+  background-color: hsl(178, 62%, 52%);
+  border: 5px solid hsl(88, 50%, 50%);
+  margin: 14px 12px 20px 4px;
+  padding: 4px 4px;
+  border-radius: 10px 5px;
+  box-shadow: 4px 0px 7px rgba(64, 128, 192, 0.8);
+  transform: rotate(214deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box575 {
+  --cssShared-v-575: 553425;
+  color: hsl(35, 75%, 55%);
+  background-color: hsl(215, 75%, 45%);
+  border: 1px solid hsl(125, 50%, 50%);
+  margin: 15px 15px 0px 11px;
+  padding: 5px 6px;
+  border-radius: 11px 7px;
+  box-shadow: 0px 1px 8px rgba(65, 130, 195, 0.9);
+  transform: rotate(215deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box576 {
+  --cssShared-v-576: 561344;
+  color: hsl(72, 88%, 62%);
+  background-color: hsl(252, 88%, 38%);
+  border: 2px solid hsl(162, 50%, 50%);
+  margin: 16px 18px 5px 0px;
+  padding: 6px 8px;
+  border-radius: 0px 0px;
+  box-shadow: 1px 2px 0px rgba(66, 132, 198, 0.1);
+  transform: rotate(216deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box577 {
+  --cssShared-v-577: 569263;
+  color: hsl(109, 1%, 69%);
+  background-color: hsl(289, 1%, 31%);
+  border: 3px solid hsl(199, 50%, 50%);
+  margin: 17px 21px 10px 7px;
+  padding: 7px 10px;
+  border-radius: 1px 2px;
+  box-shadow: 2px 3px 1px rgba(67, 134, 201, 0.2);
+  transform: rotate(217deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box578 {
+  --cssShared-v-578: 577182;
+  color: hsl(146, 14%, 76%);
+  background-color: hsl(326, 14%, 24%);
+  border: 4px solid hsl(236, 50%, 50%);
+  margin: 18px 24px 15px 14px;
+  padding: 8px 12px;
+  border-radius: 2px 4px;
+  box-shadow: 3px 4px 2px rgba(68, 136, 204, 0.3);
+  transform: rotate(218deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box579 {
+  --cssShared-v-579: 585101;
+  color: hsl(183, 27%, 33%);
+  background-color: hsl(3, 27%, 67%);
+  border: 5px solid hsl(273, 50%, 50%);
+  margin: 19px 27px 20px 3px;
+  padding: 9px 14px;
+  border-radius: 3px 6px;
+  box-shadow: 4px 5px 3px rgba(69, 138, 207, 0.4);
+  transform: rotate(219deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box580 {
+  --cssShared-v-580: 593020;
+  color: hsl(220, 40%, 40%);
+  background-color: hsl(40, 40%, 60%);
+  border: 1px solid hsl(310, 50%, 50%);
+  margin: 0px 0px 0px 10px;
+  padding: 10px 16px;
+  border-radius: 4px 8px;
+  box-shadow: 0px 6px 4px rgba(70, 140, 210, 0.5);
+  transform: rotate(220deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box581 {
+  --cssShared-v-581: 600939;
+  color: hsl(257, 53%, 47%);
+  background-color: hsl(77, 53%, 53%);
+  border: 2px solid hsl(347, 50%, 50%);
+  margin: 1px 3px 5px 17px;
+  padding: 11px 18px;
+  border-radius: 5px 1px;
+  box-shadow: 1px 0px 5px rgba(71, 142, 213, 0.6);
+  transform: rotate(221deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box582 {
+  --cssShared-v-582: 608858;
+  color: hsl(294, 66%, 54%);
+  background-color: hsl(114, 66%, 46%);
+  border: 3px solid hsl(24, 50%, 50%);
+  margin: 2px 6px 10px 6px;
+  padding: 12px 20px;
+  border-radius: 6px 3px;
+  box-shadow: 2px 1px 6px rgba(72, 144, 216, 0.7);
+  transform: rotate(222deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box583 {
+  --cssShared-v-583: 616777;
+  color: hsl(331, 79%, 61%);
+  background-color: hsl(151, 79%, 39%);
+  border: 4px solid hsl(61, 50%, 50%);
+  margin: 3px 9px 15px 13px;
+  padding: 13px 0px;
+  border-radius: 7px 5px;
+  box-shadow: 3px 2px 7px rgba(73, 146, 219, 0.8);
+  transform: rotate(223deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box584 {
+  --cssShared-v-584: 624696;
+  color: hsl(8, 92%, 68%);
+  background-color: hsl(188, 92%, 32%);
+  border: 5px solid hsl(98, 50%, 50%);
+  margin: 4px 12px 20px 2px;
+  padding: 14px 2px;
+  border-radius: 8px 7px;
+  box-shadow: 4px 3px 8px rgba(74, 148, 222, 0.9);
+  transform: rotate(224deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box585 {
+  --cssShared-v-585: 632615;
+  color: hsl(45, 5%, 75%);
+  background-color: hsl(225, 5%, 25%);
+  border: 1px solid hsl(135, 50%, 50%);
+  margin: 5px 15px 0px 9px;
+  padding: 0px 4px;
+  border-radius: 9px 0px;
+  box-shadow: 0px 4px 0px rgba(75, 150, 225, 0.1);
+  transform: rotate(225deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box586 {
+  --cssShared-v-586: 640534;
+  color: hsl(82, 18%, 32%);
+  background-color: hsl(262, 18%, 68%);
+  border: 2px solid hsl(172, 50%, 50%);
+  margin: 6px 18px 5px 16px;
+  padding: 1px 6px;
+  border-radius: 10px 2px;
+  box-shadow: 1px 5px 1px rgba(76, 152, 228, 0.2);
+  transform: rotate(226deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box587 {
+  --cssShared-v-587: 648453;
+  color: hsl(119, 31%, 39%);
+  background-color: hsl(299, 31%, 61%);
+  border: 3px solid hsl(209, 50%, 50%);
+  margin: 7px 21px 10px 5px;
+  padding: 2px 8px;
+  border-radius: 11px 4px;
+  box-shadow: 2px 6px 2px rgba(77, 154, 231, 0.3);
+  transform: rotate(227deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box588 {
+  --cssShared-v-588: 656372;
+  color: hsl(156, 44%, 46%);
+  background-color: hsl(336, 44%, 54%);
+  border: 4px solid hsl(246, 50%, 50%);
+  margin: 8px 24px 15px 12px;
+  padding: 3px 10px;
+  border-radius: 0px 6px;
+  box-shadow: 3px 0px 3px rgba(78, 156, 234, 0.4);
+  transform: rotate(228deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box589 {
+  --cssShared-v-589: 664291;
+  color: hsl(193, 57%, 53%);
+  background-color: hsl(13, 57%, 47%);
+  border: 5px solid hsl(283, 50%, 50%);
+  margin: 9px 27px 20px 1px;
+  padding: 4px 12px;
+  border-radius: 1px 8px;
+  box-shadow: 4px 1px 4px rgba(79, 158, 237, 0.5);
+  transform: rotate(229deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box590 {
+  --cssShared-v-590: 672210;
+  color: hsl(230, 70%, 60%);
+  background-color: hsl(50, 70%, 40%);
+  border: 1px solid hsl(320, 50%, 50%);
+  margin: 10px 0px 0px 8px;
+  padding: 5px 14px;
+  border-radius: 2px 1px;
+  box-shadow: 0px 2px 5px rgba(80, 160, 240, 0.6);
+  transform: rotate(230deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box591 {
+  --cssShared-v-591: 680129;
+  color: hsl(267, 83%, 67%);
+  background-color: hsl(87, 83%, 33%);
+  border: 2px solid hsl(357, 50%, 50%);
+  margin: 11px 3px 5px 15px;
+  padding: 6px 16px;
+  border-radius: 3px 3px;
+  box-shadow: 1px 3px 6px rgba(81, 162, 243, 0.7);
+  transform: rotate(231deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box592 {
+  --cssShared-v-592: 688048;
+  color: hsl(304, 96%, 74%);
+  background-color: hsl(124, 96%, 26%);
+  border: 3px solid hsl(34, 50%, 50%);
+  margin: 12px 6px 10px 4px;
+  padding: 7px 18px;
+  border-radius: 4px 5px;
+  box-shadow: 2px 4px 7px rgba(82, 164, 246, 0.8);
+  transform: rotate(232deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box593 {
+  --cssShared-v-593: 695967;
+  color: hsl(341, 9%, 31%);
+  background-color: hsl(161, 9%, 69%);
+  border: 4px solid hsl(71, 50%, 50%);
+  margin: 13px 9px 15px 11px;
+  padding: 8px 20px;
+  border-radius: 5px 7px;
+  box-shadow: 3px 5px 8px rgba(83, 166, 249, 0.9);
+  transform: rotate(233deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box594 {
+  --cssShared-v-594: 703886;
+  color: hsl(18, 22%, 38%);
+  background-color: hsl(198, 22%, 62%);
+  border: 5px solid hsl(108, 50%, 50%);
+  margin: 14px 12px 20px 0px;
+  padding: 9px 0px;
+  border-radius: 6px 0px;
+  box-shadow: 4px 6px 0px rgba(84, 168, 252, 0.1);
+  transform: rotate(234deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box595 {
+  --cssShared-v-595: 711805;
+  color: hsl(55, 35%, 45%);
+  background-color: hsl(235, 35%, 55%);
+  border: 1px solid hsl(145, 50%, 50%);
+  margin: 15px 15px 0px 7px;
+  padding: 10px 2px;
+  border-radius: 7px 2px;
+  box-shadow: 0px 0px 1px rgba(85, 170, 0, 0.2);
+  transform: rotate(235deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box596 {
+  --cssShared-v-596: 719724;
+  color: hsl(92, 48%, 52%);
+  background-color: hsl(272, 48%, 48%);
+  border: 2px solid hsl(182, 50%, 50%);
+  margin: 16px 18px 5px 14px;
+  padding: 11px 4px;
+  border-radius: 8px 4px;
+  box-shadow: 1px 1px 2px rgba(86, 172, 3, 0.3);
+  transform: rotate(236deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box597 {
+  --cssShared-v-597: 727643;
+  color: hsl(129, 61%, 59%);
+  background-color: hsl(309, 61%, 41%);
+  border: 3px solid hsl(219, 50%, 50%);
+  margin: 17px 21px 10px 3px;
+  padding: 12px 6px;
+  border-radius: 9px 6px;
+  box-shadow: 2px 2px 3px rgba(87, 174, 6, 0.4);
+  transform: rotate(237deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box598 {
+  --cssShared-v-598: 735562;
+  color: hsl(166, 74%, 66%);
+  background-color: hsl(346, 74%, 34%);
+  border: 4px solid hsl(256, 50%, 50%);
+  margin: 18px 24px 15px 10px;
+  padding: 13px 8px;
+  border-radius: 10px 8px;
+  box-shadow: 3px 3px 4px rgba(88, 176, 9, 0.5);
+  transform: rotate(238deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box599 {
+  --cssShared-v-599: 743481;
+  color: hsl(203, 87%, 73%);
+  background-color: hsl(23, 87%, 27%);
+  border: 5px solid hsl(293, 50%, 50%);
+  margin: 19px 27px 20px 17px;
+  padding: 14px 10px;
+  border-radius: 11px 1px;
+  box-shadow: 4px 4px 5px rgba(89, 178, 12, 0.6);
+  transform: rotate(239deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box600 {
+  --cssShared-v-600: 751400;
+  color: hsl(240, 0%, 30%);
+  background-color: hsl(60, 0%, 70%);
+  border: 1px solid hsl(330, 50%, 50%);
+  margin: 0px 0px 0px 6px;
+  padding: 0px 12px;
+  border-radius: 0px 3px;
+  box-shadow: 0px 5px 6px rgba(90, 180, 15, 0.7);
+  transform: rotate(240deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box601 {
+  --cssShared-v-601: 759319;
+  color: hsl(277, 13%, 37%);
+  background-color: hsl(97, 13%, 63%);
+  border: 2px solid hsl(7, 50%, 50%);
+  margin: 1px 3px 5px 13px;
+  padding: 1px 14px;
+  border-radius: 1px 5px;
+  box-shadow: 1px 6px 7px rgba(91, 182, 18, 0.8);
+  transform: rotate(241deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box602 {
+  --cssShared-v-602: 767238;
+  color: hsl(314, 26%, 44%);
+  background-color: hsl(134, 26%, 56%);
+  border: 3px solid hsl(44, 50%, 50%);
+  margin: 2px 6px 10px 2px;
+  padding: 2px 16px;
+  border-radius: 2px 7px;
+  box-shadow: 2px 0px 8px rgba(92, 184, 21, 0.9);
+  transform: rotate(242deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box603 {
+  --cssShared-v-603: 775157;
+  color: hsl(351, 39%, 51%);
+  background-color: hsl(171, 39%, 49%);
+  border: 4px solid hsl(81, 50%, 50%);
+  margin: 3px 9px 15px 9px;
+  padding: 3px 18px;
+  border-radius: 3px 0px;
+  box-shadow: 3px 1px 0px rgba(93, 186, 24, 0.1);
+  transform: rotate(243deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box604 {
+  --cssShared-v-604: 783076;
+  color: hsl(28, 52%, 58%);
+  background-color: hsl(208, 52%, 42%);
+  border: 5px solid hsl(118, 50%, 50%);
+  margin: 4px 12px 20px 16px;
+  padding: 4px 20px;
+  border-radius: 4px 2px;
+  box-shadow: 4px 2px 1px rgba(94, 188, 27, 0.2);
+  transform: rotate(244deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box605 {
+  --cssShared-v-605: 790995;
+  color: hsl(65, 65%, 65%);
+  background-color: hsl(245, 65%, 35%);
+  border: 1px solid hsl(155, 50%, 50%);
+  margin: 5px 15px 0px 5px;
+  padding: 5px 0px;
+  border-radius: 5px 4px;
+  box-shadow: 0px 3px 2px rgba(95, 190, 30, 0.3);
+  transform: rotate(245deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box606 {
+  --cssShared-v-606: 798914;
+  color: hsl(102, 78%, 72%);
+  background-color: hsl(282, 78%, 28%);
+  border: 2px solid hsl(192, 50%, 50%);
+  margin: 6px 18px 5px 12px;
+  padding: 6px 2px;
+  border-radius: 6px 6px;
+  box-shadow: 1px 4px 3px rgba(96, 192, 33, 0.4);
+  transform: rotate(246deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box607 {
+  --cssShared-v-607: 806833;
+  color: hsl(139, 91%, 79%);
+  background-color: hsl(319, 91%, 21%);
+  border: 3px solid hsl(229, 50%, 50%);
+  margin: 7px 21px 10px 1px;
+  padding: 7px 4px;
+  border-radius: 7px 8px;
+  box-shadow: 2px 5px 4px rgba(97, 194, 36, 0.5);
+  transform: rotate(247deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box608 {
+  --cssShared-v-608: 814752;
+  color: hsl(176, 4%, 36%);
+  background-color: hsl(356, 4%, 64%);
+  border: 4px solid hsl(266, 50%, 50%);
+  margin: 8px 24px 15px 8px;
+  padding: 8px 6px;
+  border-radius: 8px 1px;
+  box-shadow: 3px 6px 5px rgba(98, 196, 39, 0.6);
+  transform: rotate(248deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box609 {
+  --cssShared-v-609: 822671;
+  color: hsl(213, 17%, 43%);
+  background-color: hsl(33, 17%, 57%);
+  border: 5px solid hsl(303, 50%, 50%);
+  margin: 9px 27px 20px 15px;
+  padding: 9px 8px;
+  border-radius: 9px 3px;
+  box-shadow: 4px 0px 6px rgba(99, 198, 42, 0.7);
+  transform: rotate(249deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box610 {
+  --cssShared-v-610: 830590;
+  color: hsl(250, 30%, 50%);
+  background-color: hsl(70, 30%, 50%);
+  border: 1px solid hsl(340, 50%, 50%);
+  margin: 10px 0px 0px 4px;
+  padding: 10px 10px;
+  border-radius: 10px 5px;
+  box-shadow: 0px 1px 7px rgba(100, 200, 45, 0.8);
+  transform: rotate(250deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box611 {
+  --cssShared-v-611: 838509;
+  color: hsl(287, 43%, 57%);
+  background-color: hsl(107, 43%, 43%);
+  border: 2px solid hsl(17, 50%, 50%);
+  margin: 11px 3px 5px 11px;
+  padding: 11px 12px;
+  border-radius: 11px 7px;
+  box-shadow: 1px 2px 8px rgba(101, 202, 48, 0.9);
+  transform: rotate(251deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box612 {
+  --cssShared-v-612: 846428;
+  color: hsl(324, 56%, 64%);
+  background-color: hsl(144, 56%, 36%);
+  border: 3px solid hsl(54, 50%, 50%);
+  margin: 12px 6px 10px 0px;
+  padding: 12px 14px;
+  border-radius: 0px 0px;
+  box-shadow: 2px 3px 0px rgba(102, 204, 51, 0.1);
+  transform: rotate(252deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box613 {
+  --cssShared-v-613: 854347;
+  color: hsl(1, 69%, 71%);
+  background-color: hsl(181, 69%, 29%);
+  border: 4px solid hsl(91, 50%, 50%);
+  margin: 13px 9px 15px 7px;
+  padding: 13px 16px;
+  border-radius: 1px 2px;
+  box-shadow: 3px 4px 1px rgba(103, 206, 54, 0.2);
+  transform: rotate(253deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box614 {
+  --cssShared-v-614: 862266;
+  color: hsl(38, 82%, 78%);
+  background-color: hsl(218, 82%, 22%);
+  border: 5px solid hsl(128, 50%, 50%);
+  margin: 14px 12px 20px 14px;
+  padding: 14px 18px;
+  border-radius: 2px 4px;
+  box-shadow: 4px 5px 2px rgba(104, 208, 57, 0.3);
+  transform: rotate(254deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box615 {
+  --cssShared-v-615: 870185;
+  color: hsl(75, 95%, 35%);
+  background-color: hsl(255, 95%, 65%);
+  border: 1px solid hsl(165, 50%, 50%);
+  margin: 15px 15px 0px 3px;
+  padding: 0px 20px;
+  border-radius: 3px 6px;
+  box-shadow: 0px 6px 3px rgba(105, 210, 60, 0.4);
+  transform: rotate(255deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box616 {
+  --cssShared-v-616: 878104;
+  color: hsl(112, 8%, 42%);
+  background-color: hsl(292, 8%, 58%);
+  border: 2px solid hsl(202, 50%, 50%);
+  margin: 16px 18px 5px 10px;
+  padding: 1px 0px;
+  border-radius: 4px 8px;
+  box-shadow: 1px 0px 4px rgba(106, 212, 63, 0.5);
+  transform: rotate(256deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box617 {
+  --cssShared-v-617: 886023;
+  color: hsl(149, 21%, 49%);
+  background-color: hsl(329, 21%, 51%);
+  border: 3px solid hsl(239, 50%, 50%);
+  margin: 17px 21px 10px 17px;
+  padding: 2px 2px;
+  border-radius: 5px 1px;
+  box-shadow: 2px 1px 5px rgba(107, 214, 66, 0.6);
+  transform: rotate(257deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box618 {
+  --cssShared-v-618: 893942;
+  color: hsl(186, 34%, 56%);
+  background-color: hsl(6, 34%, 44%);
+  border: 4px solid hsl(276, 50%, 50%);
+  margin: 18px 24px 15px 6px;
+  padding: 3px 4px;
+  border-radius: 6px 3px;
+  box-shadow: 3px 2px 6px rgba(108, 216, 69, 0.7);
+  transform: rotate(258deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box619 {
+  --cssShared-v-619: 901861;
+  color: hsl(223, 47%, 63%);
+  background-color: hsl(43, 47%, 37%);
+  border: 5px solid hsl(313, 50%, 50%);
+  margin: 19px 27px 20px 13px;
+  padding: 4px 6px;
+  border-radius: 7px 5px;
+  box-shadow: 4px 3px 7px rgba(109, 218, 72, 0.8);
+  transform: rotate(259deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box620 {
+  --cssShared-v-620: 909780;
+  color: hsl(260, 60%, 70%);
+  background-color: hsl(80, 60%, 30%);
+  border: 1px solid hsl(350, 50%, 50%);
+  margin: 0px 0px 0px 2px;
+  padding: 5px 8px;
+  border-radius: 8px 7px;
+  box-shadow: 0px 4px 8px rgba(110, 220, 75, 0.9);
+  transform: rotate(260deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box621 {
+  --cssShared-v-621: 917699;
+  color: hsl(297, 73%, 77%);
+  background-color: hsl(117, 73%, 23%);
+  border: 2px solid hsl(27, 50%, 50%);
+  margin: 1px 3px 5px 9px;
+  padding: 6px 10px;
+  border-radius: 9px 0px;
+  box-shadow: 1px 5px 0px rgba(111, 222, 78, 0.1);
+  transform: rotate(261deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box622 {
+  --cssShared-v-622: 925618;
+  color: hsl(334, 86%, 34%);
+  background-color: hsl(154, 86%, 66%);
+  border: 3px solid hsl(64, 50%, 50%);
+  margin: 2px 6px 10px 16px;
+  padding: 7px 12px;
+  border-radius: 10px 2px;
+  box-shadow: 2px 6px 1px rgba(112, 224, 81, 0.2);
+  transform: rotate(262deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box623 {
+  --cssShared-v-623: 933537;
+  color: hsl(11, 99%, 41%);
+  background-color: hsl(191, 99%, 59%);
+  border: 4px solid hsl(101, 50%, 50%);
+  margin: 3px 9px 15px 5px;
+  padding: 8px 14px;
+  border-radius: 11px 4px;
+  box-shadow: 3px 0px 2px rgba(113, 226, 84, 0.3);
+  transform: rotate(263deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box624 {
+  --cssShared-v-624: 941456;
+  color: hsl(48, 12%, 48%);
+  background-color: hsl(228, 12%, 52%);
+  border: 5px solid hsl(138, 50%, 50%);
+  margin: 4px 12px 20px 12px;
+  padding: 9px 16px;
+  border-radius: 0px 6px;
+  box-shadow: 4px 1px 3px rgba(114, 228, 87, 0.4);
+  transform: rotate(264deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box625 {
+  --cssShared-v-625: 949375;
+  color: hsl(85, 25%, 55%);
+  background-color: hsl(265, 25%, 45%);
+  border: 1px solid hsl(175, 50%, 50%);
+  margin: 5px 15px 0px 1px;
+  padding: 10px 18px;
+  border-radius: 1px 8px;
+  box-shadow: 0px 2px 4px rgba(115, 230, 90, 0.5);
+  transform: rotate(265deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box626 {
+  --cssShared-v-626: 957294;
+  color: hsl(122, 38%, 62%);
+  background-color: hsl(302, 38%, 38%);
+  border: 2px solid hsl(212, 50%, 50%);
+  margin: 6px 18px 5px 8px;
+  padding: 11px 20px;
+  border-radius: 2px 1px;
+  box-shadow: 1px 3px 5px rgba(116, 232, 93, 0.6);
+  transform: rotate(266deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box627 {
+  --cssShared-v-627: 965213;
+  color: hsl(159, 51%, 69%);
+  background-color: hsl(339, 51%, 31%);
+  border: 3px solid hsl(249, 50%, 50%);
+  margin: 7px 21px 10px 15px;
+  padding: 12px 0px;
+  border-radius: 3px 3px;
+  box-shadow: 2px 4px 6px rgba(117, 234, 96, 0.7);
+  transform: rotate(267deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box628 {
+  --cssShared-v-628: 973132;
+  color: hsl(196, 64%, 76%);
+  background-color: hsl(16, 64%, 24%);
+  border: 4px solid hsl(286, 50%, 50%);
+  margin: 8px 24px 15px 4px;
+  padding: 13px 2px;
+  border-radius: 4px 5px;
+  box-shadow: 3px 5px 7px rgba(118, 236, 99, 0.8);
+  transform: rotate(268deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box629 {
+  --cssShared-v-629: 981051;
+  color: hsl(233, 77%, 33%);
+  background-color: hsl(53, 77%, 67%);
+  border: 5px solid hsl(323, 50%, 50%);
+  margin: 9px 27px 20px 11px;
+  padding: 14px 4px;
+  border-radius: 5px 7px;
+  box-shadow: 4px 6px 8px rgba(119, 238, 102, 0.9);
+  transform: rotate(269deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box630 {
+  --cssShared-v-630: 988970;
+  color: hsl(270, 90%, 40%);
+  background-color: hsl(90, 90%, 60%);
+  border: 1px solid hsl(0, 50%, 50%);
+  margin: 10px 0px 0px 0px;
+  padding: 0px 6px;
+  border-radius: 6px 0px;
+  box-shadow: 0px 0px 0px rgba(120, 240, 105, 0.1);
+  transform: rotate(270deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box631 {
+  --cssShared-v-631: 996889;
+  color: hsl(307, 3%, 47%);
+  background-color: hsl(127, 3%, 53%);
+  border: 2px solid hsl(37, 50%, 50%);
+  margin: 11px 3px 5px 7px;
+  padding: 1px 8px;
+  border-radius: 7px 2px;
+  box-shadow: 1px 1px 1px rgba(121, 242, 108, 0.2);
+  transform: rotate(271deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box632 {
+  --cssShared-v-632: 4808;
+  color: hsl(344, 16%, 54%);
+  background-color: hsl(164, 16%, 46%);
+  border: 3px solid hsl(74, 50%, 50%);
+  margin: 12px 6px 10px 14px;
+  padding: 2px 10px;
+  border-radius: 8px 4px;
+  box-shadow: 2px 2px 2px rgba(122, 244, 111, 0.3);
+  transform: rotate(272deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box633 {
+  --cssShared-v-633: 12727;
+  color: hsl(21, 29%, 61%);
+  background-color: hsl(201, 29%, 39%);
+  border: 4px solid hsl(111, 50%, 50%);
+  margin: 13px 9px 15px 3px;
+  padding: 3px 12px;
+  border-radius: 9px 6px;
+  box-shadow: 3px 3px 3px rgba(123, 246, 114, 0.4);
+  transform: rotate(273deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box634 {
+  --cssShared-v-634: 20646;
+  color: hsl(58, 42%, 68%);
+  background-color: hsl(238, 42%, 32%);
+  border: 5px solid hsl(148, 50%, 50%);
+  margin: 14px 12px 20px 10px;
+  padding: 4px 14px;
+  border-radius: 10px 8px;
+  box-shadow: 4px 4px 4px rgba(124, 248, 117, 0.5);
+  transform: rotate(274deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box635 {
+  --cssShared-v-635: 28565;
+  color: hsl(95, 55%, 75%);
+  background-color: hsl(275, 55%, 25%);
+  border: 1px solid hsl(185, 50%, 50%);
+  margin: 15px 15px 0px 17px;
+  padding: 5px 16px;
+  border-radius: 11px 1px;
+  box-shadow: 0px 5px 5px rgba(125, 250, 120, 0.6);
+  transform: rotate(275deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box636 {
+  --cssShared-v-636: 36484;
+  color: hsl(132, 68%, 32%);
+  background-color: hsl(312, 68%, 68%);
+  border: 2px solid hsl(222, 50%, 50%);
+  margin: 16px 18px 5px 6px;
+  padding: 6px 18px;
+  border-radius: 0px 3px;
+  box-shadow: 1px 6px 6px rgba(126, 252, 123, 0.7);
+  transform: rotate(276deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box637 {
+  --cssShared-v-637: 44403;
+  color: hsl(169, 81%, 39%);
+  background-color: hsl(349, 81%, 61%);
+  border: 3px solid hsl(259, 50%, 50%);
+  margin: 17px 21px 10px 13px;
+  padding: 7px 20px;
+  border-radius: 1px 5px;
+  box-shadow: 2px 0px 7px rgba(127, 254, 126, 0.8);
+  transform: rotate(277deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box638 {
+  --cssShared-v-638: 52322;
+  color: hsl(206, 94%, 46%);
+  background-color: hsl(26, 94%, 54%);
+  border: 4px solid hsl(296, 50%, 50%);
+  margin: 18px 24px 15px 2px;
+  padding: 8px 0px;
+  border-radius: 2px 7px;
+  box-shadow: 3px 1px 8px rgba(128, 1, 129, 0.9);
+  transform: rotate(278deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box639 {
+  --cssShared-v-639: 60241;
+  color: hsl(243, 7%, 53%);
+  background-color: hsl(63, 7%, 47%);
+  border: 5px solid hsl(333, 50%, 50%);
+  margin: 19px 27px 20px 9px;
+  padding: 9px 2px;
+  border-radius: 3px 0px;
+  box-shadow: 4px 2px 0px rgba(129, 3, 132, 0.1);
+  transform: rotate(279deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box640 {
+  --cssShared-v-640: 68160;
+  color: hsl(280, 20%, 60%);
+  background-color: hsl(100, 20%, 40%);
+  border: 1px solid hsl(10, 50%, 50%);
+  margin: 0px 0px 0px 16px;
+  padding: 10px 4px;
+  border-radius: 4px 2px;
+  box-shadow: 0px 3px 1px rgba(130, 5, 135, 0.2);
+  transform: rotate(280deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box641 {
+  --cssShared-v-641: 76079;
+  color: hsl(317, 33%, 67%);
+  background-color: hsl(137, 33%, 33%);
+  border: 2px solid hsl(47, 50%, 50%);
+  margin: 1px 3px 5px 5px;
+  padding: 11px 6px;
+  border-radius: 5px 4px;
+  box-shadow: 1px 4px 2px rgba(131, 7, 138, 0.3);
+  transform: rotate(281deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box642 {
+  --cssShared-v-642: 83998;
+  color: hsl(354, 46%, 74%);
+  background-color: hsl(174, 46%, 26%);
+  border: 3px solid hsl(84, 50%, 50%);
+  margin: 2px 6px 10px 12px;
+  padding: 12px 8px;
+  border-radius: 6px 6px;
+  box-shadow: 2px 5px 3px rgba(132, 9, 141, 0.4);
+  transform: rotate(282deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box643 {
+  --cssShared-v-643: 91917;
+  color: hsl(31, 59%, 31%);
+  background-color: hsl(211, 59%, 69%);
+  border: 4px solid hsl(121, 50%, 50%);
+  margin: 3px 9px 15px 1px;
+  padding: 13px 10px;
+  border-radius: 7px 8px;
+  box-shadow: 3px 6px 4px rgba(133, 11, 144, 0.5);
+  transform: rotate(283deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box644 {
+  --cssShared-v-644: 99836;
+  color: hsl(68, 72%, 38%);
+  background-color: hsl(248, 72%, 62%);
+  border: 5px solid hsl(158, 50%, 50%);
+  margin: 4px 12px 20px 8px;
+  padding: 14px 12px;
+  border-radius: 8px 1px;
+  box-shadow: 4px 0px 5px rgba(134, 13, 147, 0.6);
+  transform: rotate(284deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box645 {
+  --cssShared-v-645: 107755;
+  color: hsl(105, 85%, 45%);
+  background-color: hsl(285, 85%, 55%);
+  border: 1px solid hsl(195, 50%, 50%);
+  margin: 5px 15px 0px 15px;
+  padding: 0px 14px;
+  border-radius: 9px 3px;
+  box-shadow: 0px 1px 6px rgba(135, 15, 150, 0.7);
+  transform: rotate(285deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box646 {
+  --cssShared-v-646: 115674;
+  color: hsl(142, 98%, 52%);
+  background-color: hsl(322, 98%, 48%);
+  border: 2px solid hsl(232, 50%, 50%);
+  margin: 6px 18px 5px 4px;
+  padding: 1px 16px;
+  border-radius: 10px 5px;
+  box-shadow: 1px 2px 7px rgba(136, 17, 153, 0.8);
+  transform: rotate(286deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box647 {
+  --cssShared-v-647: 123593;
+  color: hsl(179, 11%, 59%);
+  background-color: hsl(359, 11%, 41%);
+  border: 3px solid hsl(269, 50%, 50%);
+  margin: 7px 21px 10px 11px;
+  padding: 2px 18px;
+  border-radius: 11px 7px;
+  box-shadow: 2px 3px 8px rgba(137, 19, 156, 0.9);
+  transform: rotate(287deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box648 {
+  --cssShared-v-648: 131512;
+  color: hsl(216, 24%, 66%);
+  background-color: hsl(36, 24%, 34%);
+  border: 4px solid hsl(306, 50%, 50%);
+  margin: 8px 24px 15px 0px;
+  padding: 3px 20px;
+  border-radius: 0px 0px;
+  box-shadow: 3px 4px 0px rgba(138, 21, 159, 0.1);
+  transform: rotate(288deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box649 {
+  --cssShared-v-649: 139431;
+  color: hsl(253, 37%, 73%);
+  background-color: hsl(73, 37%, 27%);
+  border: 5px solid hsl(343, 50%, 50%);
+  margin: 9px 27px 20px 7px;
+  padding: 4px 0px;
+  border-radius: 1px 2px;
+  box-shadow: 4px 5px 1px rgba(139, 23, 162, 0.2);
+  transform: rotate(289deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box650 {
+  --cssShared-v-650: 147350;
+  color: hsl(290, 50%, 30%);
+  background-color: hsl(110, 50%, 70%);
+  border: 1px solid hsl(20, 50%, 50%);
+  margin: 10px 0px 0px 14px;
+  padding: 5px 2px;
+  border-radius: 2px 4px;
+  box-shadow: 0px 6px 2px rgba(140, 25, 165, 0.3);
+  transform: rotate(290deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box651 {
+  --cssShared-v-651: 155269;
+  color: hsl(327, 63%, 37%);
+  background-color: hsl(147, 63%, 63%);
+  border: 2px solid hsl(57, 50%, 50%);
+  margin: 11px 3px 5px 3px;
+  padding: 6px 4px;
+  border-radius: 3px 6px;
+  box-shadow: 1px 0px 3px rgba(141, 27, 168, 0.4);
+  transform: rotate(291deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box652 {
+  --cssShared-v-652: 163188;
+  color: hsl(4, 76%, 44%);
+  background-color: hsl(184, 76%, 56%);
+  border: 3px solid hsl(94, 50%, 50%);
+  margin: 12px 6px 10px 10px;
+  padding: 7px 6px;
+  border-radius: 4px 8px;
+  box-shadow: 2px 1px 4px rgba(142, 29, 171, 0.5);
+  transform: rotate(292deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box653 {
+  --cssShared-v-653: 171107;
+  color: hsl(41, 89%, 51%);
+  background-color: hsl(221, 89%, 49%);
+  border: 4px solid hsl(131, 50%, 50%);
+  margin: 13px 9px 15px 17px;
+  padding: 8px 8px;
+  border-radius: 5px 1px;
+  box-shadow: 3px 2px 5px rgba(143, 31, 174, 0.6);
+  transform: rotate(293deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box654 {
+  --cssShared-v-654: 179026;
+  color: hsl(78, 2%, 58%);
+  background-color: hsl(258, 2%, 42%);
+  border: 5px solid hsl(168, 50%, 50%);
+  margin: 14px 12px 20px 6px;
+  padding: 9px 10px;
+  border-radius: 6px 3px;
+  box-shadow: 4px 3px 6px rgba(144, 33, 177, 0.7);
+  transform: rotate(294deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box655 {
+  --cssShared-v-655: 186945;
+  color: hsl(115, 15%, 65%);
+  background-color: hsl(295, 15%, 35%);
+  border: 1px solid hsl(205, 50%, 50%);
+  margin: 15px 15px 0px 13px;
+  padding: 10px 12px;
+  border-radius: 7px 5px;
+  box-shadow: 0px 4px 7px rgba(145, 35, 180, 0.8);
+  transform: rotate(295deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box656 {
+  --cssShared-v-656: 194864;
+  color: hsl(152, 28%, 72%);
+  background-color: hsl(332, 28%, 28%);
+  border: 2px solid hsl(242, 50%, 50%);
+  margin: 16px 18px 5px 2px;
+  padding: 11px 14px;
+  border-radius: 8px 7px;
+  box-shadow: 1px 5px 8px rgba(146, 37, 183, 0.9);
+  transform: rotate(296deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box657 {
+  --cssShared-v-657: 202783;
+  color: hsl(189, 41%, 79%);
+  background-color: hsl(9, 41%, 21%);
+  border: 3px solid hsl(279, 50%, 50%);
+  margin: 17px 21px 10px 9px;
+  padding: 12px 16px;
+  border-radius: 9px 0px;
+  box-shadow: 2px 6px 0px rgba(147, 39, 186, 0.1);
+  transform: rotate(297deg) scale(1.07);
+  font-size: 27px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box658 {
+  --cssShared-v-658: 210702;
+  color: hsl(226, 54%, 36%);
+  background-color: hsl(46, 54%, 64%);
+  border: 4px solid hsl(316, 50%, 50%);
+  margin: 18px 24px 15px 16px;
+  padding: 13px 18px;
+  border-radius: 10px 2px;
+  box-shadow: 3px 0px 1px rgba(148, 41, 189, 0.2);
+  transform: rotate(298deg) scale(1.08);
+  font-size: 28px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box659 {
+  --cssShared-v-659: 218621;
+  color: hsl(263, 67%, 43%);
+  background-color: hsl(83, 67%, 57%);
+  border: 5px solid hsl(353, 50%, 50%);
+  margin: 19px 27px 20px 5px;
+  padding: 14px 20px;
+  border-radius: 11px 4px;
+  box-shadow: 4px 1px 2px rgba(149, 43, 192, 0.3);
+  transform: rotate(299deg) scale(1.09);
+  font-size: 29px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box660 {
+  --cssShared-v-660: 226540;
+  color: hsl(300, 80%, 50%);
+  background-color: hsl(120, 80%, 50%);
+  border: 1px solid hsl(30, 50%, 50%);
+  margin: 0px 0px 0px 12px;
+  padding: 0px 0px;
+  border-radius: 0px 6px;
+  box-shadow: 0px 2px 3px rgba(150, 45, 195, 0.4);
+  transform: rotate(300deg) scale(1.10);
+  font-size: 10px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box661 {
+  --cssShared-v-661: 234459;
+  color: hsl(337, 93%, 57%);
+  background-color: hsl(157, 93%, 43%);
+  border: 2px solid hsl(67, 50%, 50%);
+  margin: 1px 3px 5px 1px;
+  padding: 1px 2px;
+  border-radius: 1px 8px;
+  box-shadow: 1px 3px 4px rgba(151, 47, 198, 0.5);
+  transform: rotate(301deg) scale(1.11);
+  font-size: 11px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box662 {
+  --cssShared-v-662: 242378;
+  color: hsl(14, 6%, 64%);
+  background-color: hsl(194, 6%, 36%);
+  border: 3px solid hsl(104, 50%, 50%);
+  margin: 2px 6px 10px 8px;
+  padding: 2px 4px;
+  border-radius: 2px 1px;
+  box-shadow: 2px 4px 5px rgba(152, 49, 201, 0.6);
+  transform: rotate(302deg) scale(1.12);
+  font-size: 12px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box663 {
+  --cssShared-v-663: 250297;
+  color: hsl(51, 19%, 71%);
+  background-color: hsl(231, 19%, 29%);
+  border: 4px solid hsl(141, 50%, 50%);
+  margin: 3px 9px 15px 15px;
+  padding: 3px 6px;
+  border-radius: 3px 3px;
+  box-shadow: 3px 5px 6px rgba(153, 51, 204, 0.7);
+  transform: rotate(303deg) scale(1.13);
+  font-size: 13px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box664 {
+  --cssShared-v-664: 258216;
+  color: hsl(88, 32%, 78%);
+  background-color: hsl(268, 32%, 22%);
+  border: 5px solid hsl(178, 50%, 50%);
+  margin: 4px 12px 20px 4px;
+  padding: 4px 8px;
+  border-radius: 4px 5px;
+  box-shadow: 4px 6px 7px rgba(154, 53, 207, 0.8);
+  transform: rotate(304deg) scale(1.14);
+  font-size: 14px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box665 {
+  --cssShared-v-665: 266135;
+  color: hsl(125, 45%, 35%);
+  background-color: hsl(305, 45%, 65%);
+  border: 1px solid hsl(215, 50%, 50%);
+  margin: 5px 15px 0px 11px;
+  padding: 5px 10px;
+  border-radius: 5px 7px;
+  box-shadow: 0px 0px 8px rgba(155, 55, 210, 0.9);
+  transform: rotate(305deg) scale(1.15);
+  font-size: 15px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box666 {
+  --cssShared-v-666: 274054;
+  color: hsl(162, 58%, 42%);
+  background-color: hsl(342, 58%, 58%);
+  border: 2px solid hsl(252, 50%, 50%);
+  margin: 6px 18px 5px 0px;
+  padding: 6px 12px;
+  border-radius: 6px 0px;
+  box-shadow: 1px 1px 0px rgba(156, 57, 213, 0.1);
+  transform: rotate(306deg) scale(1.16);
+  font-size: 16px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box667 {
+  --cssShared-v-667: 281973;
+  color: hsl(199, 71%, 49%);
+  background-color: hsl(19, 71%, 51%);
+  border: 3px solid hsl(289, 50%, 50%);
+  margin: 7px 21px 10px 7px;
+  padding: 7px 14px;
+  border-radius: 7px 2px;
+  box-shadow: 2px 2px 1px rgba(157, 59, 216, 0.2);
+  transform: rotate(307deg) scale(1.17);
+  font-size: 17px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box668 {
+  --cssShared-v-668: 289892;
+  color: hsl(236, 84%, 56%);
+  background-color: hsl(56, 84%, 44%);
+  border: 4px solid hsl(326, 50%, 50%);
+  margin: 8px 24px 15px 14px;
+  padding: 8px 16px;
+  border-radius: 8px 4px;
+  box-shadow: 3px 3px 2px rgba(158, 61, 219, 0.3);
+  transform: rotate(308deg) scale(1.18);
+  font-size: 18px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box669 {
+  --cssShared-v-669: 297811;
+  color: hsl(273, 97%, 63%);
+  background-color: hsl(93, 97%, 37%);
+  border: 5px solid hsl(3, 50%, 50%);
+  margin: 9px 27px 20px 3px;
+  padding: 9px 18px;
+  border-radius: 9px 6px;
+  box-shadow: 4px 4px 3px rgba(159, 63, 222, 0.4);
+  transform: rotate(309deg) scale(1.19);
+  font-size: 19px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box670 {
+  --cssShared-v-670: 305730;
+  color: hsl(310, 10%, 70%);
+  background-color: hsl(130, 10%, 30%);
+  border: 1px solid hsl(40, 50%, 50%);
+  margin: 10px 0px 0px 10px;
+  padding: 10px 20px;
+  border-radius: 10px 8px;
+  box-shadow: 0px 5px 4px rgba(160, 65, 225, 0.5);
+  transform: rotate(310deg) scale(1.20);
+  font-size: 20px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box671 {
+  --cssShared-v-671: 313649;
+  color: hsl(347, 23%, 77%);
+  background-color: hsl(167, 23%, 23%);
+  border: 2px solid hsl(77, 50%, 50%);
+  margin: 11px 3px 5px 17px;
+  padding: 11px 0px;
+  border-radius: 11px 1px;
+  box-shadow: 1px 6px 5px rgba(161, 67, 228, 0.6);
+  transform: rotate(311deg) scale(1.21);
+  font-size: 21px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box672 {
+  --cssShared-v-672: 321568;
+  color: hsl(24, 36%, 34%);
+  background-color: hsl(204, 36%, 66%);
+  border: 3px solid hsl(114, 50%, 50%);
+  margin: 12px 6px 10px 6px;
+  padding: 12px 2px;
+  border-radius: 0px 3px;
+  box-shadow: 2px 0px 6px rgba(162, 69, 231, 0.7);
+  transform: rotate(312deg) scale(1.22);
+  font-size: 22px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box673 {
+  --cssShared-v-673: 329487;
+  color: hsl(61, 49%, 41%);
+  background-color: hsl(241, 49%, 59%);
+  border: 4px solid hsl(151, 50%, 50%);
+  margin: 13px 9px 15px 13px;
+  padding: 13px 4px;
+  border-radius: 1px 5px;
+  box-shadow: 3px 1px 7px rgba(163, 71, 234, 0.8);
+  transform: rotate(313deg) scale(1.23);
+  font-size: 23px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box674 {
+  --cssShared-v-674: 337406;
+  color: hsl(98, 62%, 48%);
+  background-color: hsl(278, 62%, 52%);
+  border: 5px solid hsl(188, 50%, 50%);
+  margin: 14px 12px 20px 2px;
+  padding: 14px 6px;
+  border-radius: 2px 7px;
+  box-shadow: 4px 2px 8px rgba(164, 73, 237, 0.9);
+  transform: rotate(314deg) scale(1.24);
+  font-size: 24px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box675 {
+  --cssShared-v-675: 345325;
+  color: hsl(135, 75%, 55%);
+  background-color: hsl(315, 75%, 45%);
+  border: 1px solid hsl(225, 50%, 50%);
+  margin: 15px 15px 0px 9px;
+  padding: 0px 8px;
+  border-radius: 3px 0px;
+  box-shadow: 0px 3px 0px rgba(165, 75, 240, 0.1);
+  transform: rotate(315deg) scale(1.25);
+  font-size: 25px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box676 {
+  --cssShared-v-676: 353244;
+  color: hsl(172, 88%, 62%);
+  background-color: hsl(352, 88%, 38%);
+  border: 2px solid hsl(262, 50%, 50%);
+  margin: 16px 18px 5px 16px;
+  padding: 1px 10px;
+  border-radius: 4px 2px;
+  box-shadow: 1px 4px 1px rgba(166, 77, 243, 0.2);
+  transform: rotate(316deg) scale(1.26);
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box677 {
+  --cssShared-v-677: 361163;
+  color: hsl(209, 1%, 69%);
+  background-color: hsl(29, 1%, 31%);
+  border: 3px solid hsl(299, 50%, 50%);
+  margin: 17px 21px 10px 5px;
+  padding: 2px 12px;
+  border-radius: 5px 4px;
+  box-shadow: 2px 5px 2px rgba(167, 79, 246, 0.3);
+  transform: rotate(317deg) scale(1.27);
+  font-size: 27px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box678 {
+  --cssShared-v-678: 369082;
+  color: hsl(246, 14%, 76%);
+  background-color: hsl(66, 14%, 24%);
+  border: 4px solid hsl(336, 50%, 50%);
+  margin: 18px 24px 15px 12px;
+  padding: 3px 14px;
+  border-radius: 6px 6px;
+  box-shadow: 3px 6px 3px rgba(168, 81, 249, 0.4);
+  transform: rotate(318deg) scale(1.28);
+  font-size: 28px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box679 {
+  --cssShared-v-679: 377001;
+  color: hsl(283, 27%, 33%);
+  background-color: hsl(103, 27%, 67%);
+  border: 5px solid hsl(13, 50%, 50%);
+  margin: 19px 27px 20px 1px;
+  padding: 4px 16px;
+  border-radius: 7px 8px;
+  box-shadow: 4px 0px 4px rgba(169, 83, 252, 0.5);
+  transform: rotate(319deg) scale(1.29);
+  font-size: 29px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box680 {
+  --cssShared-v-680: 384920;
+  color: hsl(320, 40%, 40%);
+  background-color: hsl(140, 40%, 60%);
+  border: 1px solid hsl(50, 50%, 50%);
+  margin: 0px 0px 0px 8px;
+  padding: 5px 18px;
+  border-radius: 8px 1px;
+  box-shadow: 0px 1px 5px rgba(170, 85, 0, 0.6);
+  transform: rotate(320deg) scale(1.30);
+  font-size: 10px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box681 {
+  --cssShared-v-681: 392839;
+  color: hsl(357, 53%, 47%);
+  background-color: hsl(177, 53%, 53%);
+  border: 2px solid hsl(87, 50%, 50%);
+  margin: 1px 3px 5px 15px;
+  padding: 6px 20px;
+  border-radius: 9px 3px;
+  box-shadow: 1px 2px 6px rgba(171, 87, 3, 0.7);
+  transform: rotate(321deg) scale(1.31);
+  font-size: 11px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box682 {
+  --cssShared-v-682: 400758;
+  color: hsl(34, 66%, 54%);
+  background-color: hsl(214, 66%, 46%);
+  border: 3px solid hsl(124, 50%, 50%);
+  margin: 2px 6px 10px 4px;
+  padding: 7px 0px;
+  border-radius: 10px 5px;
+  box-shadow: 2px 3px 7px rgba(172, 89, 6, 0.8);
+  transform: rotate(322deg) scale(1.32);
+  font-size: 12px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box683 {
+  --cssShared-v-683: 408677;
+  color: hsl(71, 79%, 61%);
+  background-color: hsl(251, 79%, 39%);
+  border: 4px solid hsl(161, 50%, 50%);
+  margin: 3px 9px 15px 11px;
+  padding: 8px 2px;
+  border-radius: 11px 7px;
+  box-shadow: 3px 4px 8px rgba(173, 91, 9, 0.9);
+  transform: rotate(323deg) scale(1.33);
+  font-size: 13px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box684 {
+  --cssShared-v-684: 416596;
+  color: hsl(108, 92%, 68%);
+  background-color: hsl(288, 92%, 32%);
+  border: 5px solid hsl(198, 50%, 50%);
+  margin: 4px 12px 20px 0px;
+  padding: 9px 4px;
+  border-radius: 0px 0px;
+  box-shadow: 4px 5px 0px rgba(174, 93, 12, 0.1);
+  transform: rotate(324deg) scale(1.34);
+  font-size: 14px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box685 {
+  --cssShared-v-685: 424515;
+  color: hsl(145, 5%, 75%);
+  background-color: hsl(325, 5%, 25%);
+  border: 1px solid hsl(235, 50%, 50%);
+  margin: 5px 15px 0px 7px;
+  padding: 10px 6px;
+  border-radius: 1px 2px;
+  box-shadow: 0px 6px 1px rgba(175, 95, 15, 0.2);
+  transform: rotate(325deg) scale(1.35);
+  font-size: 15px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box686 {
+  --cssShared-v-686: 432434;
+  color: hsl(182, 18%, 32%);
+  background-color: hsl(2, 18%, 68%);
+  border: 2px solid hsl(272, 50%, 50%);
+  margin: 6px 18px 5px 14px;
+  padding: 11px 8px;
+  border-radius: 2px 4px;
+  box-shadow: 1px 0px 2px rgba(176, 97, 18, 0.3);
+  transform: rotate(326deg) scale(1.36);
+  font-size: 16px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box687 {
+  --cssShared-v-687: 440353;
+  color: hsl(219, 31%, 39%);
+  background-color: hsl(39, 31%, 61%);
+  border: 3px solid hsl(309, 50%, 50%);
+  margin: 7px 21px 10px 3px;
+  padding: 12px 10px;
+  border-radius: 3px 6px;
+  box-shadow: 2px 1px 3px rgba(177, 99, 21, 0.4);
+  transform: rotate(327deg) scale(1.37);
+  font-size: 17px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box688 {
+  --cssShared-v-688: 448272;
+  color: hsl(256, 44%, 46%);
+  background-color: hsl(76, 44%, 54%);
+  border: 4px solid hsl(346, 50%, 50%);
+  margin: 8px 24px 15px 10px;
+  padding: 13px 12px;
+  border-radius: 4px 8px;
+  box-shadow: 3px 2px 4px rgba(178, 101, 24, 0.5);
+  transform: rotate(328deg) scale(1.38);
+  font-size: 18px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box689 {
+  --cssShared-v-689: 456191;
+  color: hsl(293, 57%, 53%);
+  background-color: hsl(113, 57%, 47%);
+  border: 5px solid hsl(23, 50%, 50%);
+  margin: 9px 27px 20px 17px;
+  padding: 14px 14px;
+  border-radius: 5px 1px;
+  box-shadow: 4px 3px 5px rgba(179, 103, 27, 0.6);
+  transform: rotate(329deg) scale(1.39);
+  font-size: 19px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box690 {
+  --cssShared-v-690: 464110;
+  color: hsl(330, 70%, 60%);
+  background-color: hsl(150, 70%, 40%);
+  border: 1px solid hsl(60, 50%, 50%);
+  margin: 10px 0px 0px 6px;
+  padding: 0px 16px;
+  border-radius: 6px 3px;
+  box-shadow: 0px 4px 6px rgba(180, 105, 30, 0.7);
+  transform: rotate(330deg) scale(1.40);
+  font-size: 20px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box691 {
+  --cssShared-v-691: 472029;
+  color: hsl(7, 83%, 67%);
+  background-color: hsl(187, 83%, 33%);
+  border: 2px solid hsl(97, 50%, 50%);
+  margin: 11px 3px 5px 13px;
+  padding: 1px 18px;
+  border-radius: 7px 5px;
+  box-shadow: 1px 5px 7px rgba(181, 107, 33, 0.8);
+  transform: rotate(331deg) scale(1.41);
+  font-size: 21px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box692 {
+  --cssShared-v-692: 479948;
+  color: hsl(44, 96%, 74%);
+  background-color: hsl(224, 96%, 26%);
+  border: 3px solid hsl(134, 50%, 50%);
+  margin: 12px 6px 10px 2px;
+  padding: 2px 20px;
+  border-radius: 8px 7px;
+  box-shadow: 2px 6px 8px rgba(182, 109, 36, 0.9);
+  transform: rotate(332deg) scale(1.42);
+  font-size: 22px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box693 {
+  --cssShared-v-693: 487867;
+  color: hsl(81, 9%, 31%);
+  background-color: hsl(261, 9%, 69%);
+  border: 4px solid hsl(171, 50%, 50%);
+  margin: 13px 9px 15px 9px;
+  padding: 3px 0px;
+  border-radius: 9px 0px;
+  box-shadow: 3px 0px 0px rgba(183, 111, 39, 0.1);
+  transform: rotate(333deg) scale(1.43);
+  font-size: 23px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box694 {
+  --cssShared-v-694: 495786;
+  color: hsl(118, 22%, 38%);
+  background-color: hsl(298, 22%, 62%);
+  border: 5px solid hsl(208, 50%, 50%);
+  margin: 14px 12px 20px 16px;
+  padding: 4px 2px;
+  border-radius: 10px 2px;
+  box-shadow: 4px 1px 1px rgba(184, 113, 42, 0.2);
+  transform: rotate(334deg) scale(1.44);
+  font-size: 24px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box695 {
+  --cssShared-v-695: 503705;
+  color: hsl(155, 35%, 45%);
+  background-color: hsl(335, 35%, 55%);
+  border: 1px solid hsl(245, 50%, 50%);
+  margin: 15px 15px 0px 5px;
+  padding: 5px 4px;
+  border-radius: 11px 4px;
+  box-shadow: 0px 2px 2px rgba(185, 115, 45, 0.3);
+  transform: rotate(335deg) scale(1.45);
+  font-size: 25px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box696 {
+  --cssShared-v-696: 511624;
+  color: hsl(192, 48%, 52%);
+  background-color: hsl(12, 48%, 48%);
+  border: 2px solid hsl(282, 50%, 50%);
+  margin: 16px 18px 5px 12px;
+  padding: 6px 6px;
+  border-radius: 0px 6px;
+  box-shadow: 1px 3px 3px rgba(186, 117, 48, 0.4);
+  transform: rotate(336deg) scale(1.46);
+  font-size: 26px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box697 {
+  --cssShared-v-697: 519543;
+  color: hsl(229, 61%, 59%);
+  background-color: hsl(49, 61%, 41%);
+  border: 3px solid hsl(319, 50%, 50%);
+  margin: 17px 21px 10px 1px;
+  padding: 7px 8px;
+  border-radius: 1px 8px;
+  box-shadow: 2px 4px 4px rgba(187, 119, 51, 0.5);
+  transform: rotate(337deg) scale(1.47);
+  font-size: 27px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box698 {
+  --cssShared-v-698: 527462;
+  color: hsl(266, 74%, 66%);
+  background-color: hsl(86, 74%, 34%);
+  border: 4px solid hsl(356, 50%, 50%);
+  margin: 18px 24px 15px 8px;
+  padding: 8px 10px;
+  border-radius: 2px 1px;
+  box-shadow: 3px 5px 5px rgba(188, 121, 54, 0.6);
+  transform: rotate(338deg) scale(1.48);
+  font-size: 28px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box699 {
+  --cssShared-v-699: 535381;
+  color: hsl(303, 87%, 73%);
+  background-color: hsl(123, 87%, 27%);
+  border: 5px solid hsl(33, 50%, 50%);
+  margin: 19px 27px 20px 15px;
+  padding: 9px 12px;
+  border-radius: 3px 3px;
+  box-shadow: 4px 6px 6px rgba(189, 123, 57, 0.7);
+  transform: rotate(339deg) scale(1.49);
+  font-size: 29px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box700 {
+  --cssShared-v-700: 543300;
+  color: hsl(340, 0%, 30%);
+  background-color: hsl(160, 0%, 70%);
+  border: 1px solid hsl(70, 50%, 50%);
+  margin: 0px 0px 0px 4px;
+  padding: 10px 14px;
+  border-radius: 4px 5px;
+  box-shadow: 0px 0px 7px rgba(190, 125, 60, 0.8);
+  transform: rotate(340deg) scale(1.00);
+  font-size: 10px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box701 {
+  --cssShared-v-701: 551219;
+  color: hsl(17, 13%, 37%);
+  background-color: hsl(197, 13%, 63%);
+  border: 2px solid hsl(107, 50%, 50%);
+  margin: 1px 3px 5px 11px;
+  padding: 11px 16px;
+  border-radius: 5px 7px;
+  box-shadow: 1px 1px 8px rgba(191, 127, 63, 0.9);
+  transform: rotate(341deg) scale(1.01);
+  font-size: 11px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box702 {
+  --cssShared-v-702: 559138;
+  color: hsl(54, 26%, 44%);
+  background-color: hsl(234, 26%, 56%);
+  border: 3px solid hsl(144, 50%, 50%);
+  margin: 2px 6px 10px 0px;
+  padding: 12px 18px;
+  border-radius: 6px 0px;
+  box-shadow: 2px 2px 0px rgba(192, 129, 66, 0.1);
+  transform: rotate(342deg) scale(1.02);
+  font-size: 12px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box703 {
+  --cssShared-v-703: 567057;
+  color: hsl(91, 39%, 51%);
+  background-color: hsl(271, 39%, 49%);
+  border: 4px solid hsl(181, 50%, 50%);
+  margin: 3px 9px 15px 7px;
+  padding: 13px 20px;
+  border-radius: 7px 2px;
+  box-shadow: 3px 3px 1px rgba(193, 131, 69, 0.2);
+  transform: rotate(343deg) scale(1.03);
+  font-size: 13px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box704 {
+  --cssShared-v-704: 574976;
+  color: hsl(128, 52%, 58%);
+  background-color: hsl(308, 52%, 42%);
+  border: 5px solid hsl(218, 50%, 50%);
+  margin: 4px 12px 20px 14px;
+  padding: 14px 0px;
+  border-radius: 8px 4px;
+  box-shadow: 4px 4px 2px rgba(194, 133, 72, 0.3);
+  transform: rotate(344deg) scale(1.04);
+  font-size: 14px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box705 {
+  --cssShared-v-705: 582895;
+  color: hsl(165, 65%, 65%);
+  background-color: hsl(345, 65%, 35%);
+  border: 1px solid hsl(255, 50%, 50%);
+  margin: 5px 15px 0px 3px;
+  padding: 0px 2px;
+  border-radius: 9px 6px;
+  box-shadow: 0px 5px 3px rgba(195, 135, 75, 0.4);
+  transform: rotate(345deg) scale(1.05);
+  font-size: 15px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box706 {
+  --cssShared-v-706: 590814;
+  color: hsl(202, 78%, 72%);
+  background-color: hsl(22, 78%, 28%);
+  border: 2px solid hsl(292, 50%, 50%);
+  margin: 6px 18px 5px 10px;
+  padding: 1px 4px;
+  border-radius: 10px 8px;
+  box-shadow: 1px 6px 4px rgba(196, 137, 78, 0.5);
+  transform: rotate(346deg) scale(1.06);
+  font-size: 16px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box707 {
+  --cssShared-v-707: 598733;
+  color: hsl(239, 91%, 79%);
+  background-color: hsl(59, 91%, 21%);
+  border: 3px solid hsl(329, 50%, 50%);
+  margin: 7px 21px 10px 17px;
+  padding: 2px 6px;
+  border-radius: 11px 1px;
+  box-shadow: 2px 0px 5px rgba(197, 139, 81, 0.6);
+  transform: rotate(347deg) scale(1.07);
+  font-size: 17px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box708 {
+  --cssShared-v-708: 606652;
+  color: hsl(276, 4%, 36%);
+  background-color: hsl(96, 4%, 64%);
+  border: 4px solid hsl(6, 50%, 50%);
+  margin: 8px 24px 15px 6px;
+  padding: 3px 8px;
+  border-radius: 0px 3px;
+  box-shadow: 3px 1px 6px rgba(198, 141, 84, 0.7);
+  transform: rotate(348deg) scale(1.08);
+  font-size: 18px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box709 {
+  --cssShared-v-709: 614571;
+  color: hsl(313, 17%, 43%);
+  background-color: hsl(133, 17%, 57%);
+  border: 5px solid hsl(43, 50%, 50%);
+  margin: 9px 27px 20px 13px;
+  padding: 4px 10px;
+  border-radius: 1px 5px;
+  box-shadow: 4px 2px 7px rgba(199, 143, 87, 0.8);
+  transform: rotate(349deg) scale(1.09);
+  font-size: 19px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box710 {
+  --cssShared-v-710: 622490;
+  color: hsl(350, 30%, 50%);
+  background-color: hsl(170, 30%, 50%);
+  border: 1px solid hsl(80, 50%, 50%);
+  margin: 10px 0px 0px 2px;
+  padding: 5px 12px;
+  border-radius: 2px 7px;
+  box-shadow: 0px 3px 8px rgba(200, 145, 90, 0.9);
+  transform: rotate(350deg) scale(1.10);
+  font-size: 20px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box711 {
+  --cssShared-v-711: 630409;
+  color: hsl(27, 43%, 57%);
+  background-color: hsl(207, 43%, 43%);
+  border: 2px solid hsl(117, 50%, 50%);
+  margin: 11px 3px 5px 9px;
+  padding: 6px 14px;
+  border-radius: 3px 0px;
+  box-shadow: 1px 4px 0px rgba(201, 147, 93, 0.1);
+  transform: rotate(351deg) scale(1.11);
+  font-size: 21px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box712 {
+  --cssShared-v-712: 638328;
+  color: hsl(64, 56%, 64%);
+  background-color: hsl(244, 56%, 36%);
+  border: 3px solid hsl(154, 50%, 50%);
+  margin: 12px 6px 10px 16px;
+  padding: 7px 16px;
+  border-radius: 4px 2px;
+  box-shadow: 2px 5px 1px rgba(202, 149, 96, 0.2);
+  transform: rotate(352deg) scale(1.12);
+  font-size: 22px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box713 {
+  --cssShared-v-713: 646247;
+  color: hsl(101, 69%, 71%);
+  background-color: hsl(281, 69%, 29%);
+  border: 4px solid hsl(191, 50%, 50%);
+  margin: 13px 9px 15px 5px;
+  padding: 8px 18px;
+  border-radius: 5px 4px;
+  box-shadow: 3px 6px 2px rgba(203, 151, 99, 0.3);
+  transform: rotate(353deg) scale(1.13);
+  font-size: 23px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box714 {
+  --cssShared-v-714: 654166;
+  color: hsl(138, 82%, 78%);
+  background-color: hsl(318, 82%, 22%);
+  border: 5px solid hsl(228, 50%, 50%);
+  margin: 14px 12px 20px 12px;
+  padding: 9px 20px;
+  border-radius: 6px 6px;
+  box-shadow: 4px 0px 3px rgba(204, 153, 102, 0.4);
+  transform: rotate(354deg) scale(1.14);
+  font-size: 24px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box715 {
+  --cssShared-v-715: 662085;
+  color: hsl(175, 95%, 35%);
+  background-color: hsl(355, 95%, 65%);
+  border: 1px solid hsl(265, 50%, 50%);
+  margin: 15px 15px 0px 1px;
+  padding: 10px 0px;
+  border-radius: 7px 8px;
+  box-shadow: 0px 1px 4px rgba(205, 155, 105, 0.5);
+  transform: rotate(355deg) scale(1.15);
+  font-size: 25px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box716 {
+  --cssShared-v-716: 670004;
+  color: hsl(212, 8%, 42%);
+  background-color: hsl(32, 8%, 58%);
+  border: 2px solid hsl(302, 50%, 50%);
+  margin: 16px 18px 5px 8px;
+  padding: 11px 2px;
+  border-radius: 8px 1px;
+  box-shadow: 1px 2px 5px rgba(206, 157, 108, 0.6);
+  transform: rotate(356deg) scale(1.16);
+  font-size: 26px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box717 {
+  --cssShared-v-717: 677923;
+  color: hsl(249, 21%, 49%);
+  background-color: hsl(69, 21%, 51%);
+  border: 3px solid hsl(339, 50%, 50%);
+  margin: 17px 21px 10px 15px;
+  padding: 12px 4px;
+  border-radius: 9px 3px;
+  box-shadow: 2px 3px 6px rgba(207, 159, 111, 0.7);
+  transform: rotate(357deg) scale(1.17);
+  font-size: 27px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box718 {
+  --cssShared-v-718: 685842;
+  color: hsl(286, 34%, 56%);
+  background-color: hsl(106, 34%, 44%);
+  border: 4px solid hsl(16, 50%, 50%);
+  margin: 18px 24px 15px 4px;
+  padding: 13px 6px;
+  border-radius: 10px 5px;
+  box-shadow: 3px 4px 7px rgba(208, 161, 114, 0.8);
+  transform: rotate(358deg) scale(1.18);
+  font-size: 28px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box719 {
+  --cssShared-v-719: 693761;
+  color: hsl(323, 47%, 63%);
+  background-color: hsl(143, 47%, 37%);
+  border: 5px solid hsl(53, 50%, 50%);
+  margin: 19px 27px 20px 11px;
+  padding: 14px 8px;
+  border-radius: 11px 7px;
+  box-shadow: 4px 5px 8px rgba(209, 163, 117, 0.9);
+  transform: rotate(359deg) scale(1.19);
+  font-size: 29px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box720 {
+  --cssShared-v-720: 701680;
+  color: hsl(0, 60%, 70%);
+  background-color: hsl(180, 60%, 30%);
+  border: 1px solid hsl(90, 50%, 50%);
+  margin: 0px 0px 0px 0px;
+  padding: 0px 10px;
+  border-radius: 0px 0px;
+  box-shadow: 0px 6px 0px rgba(210, 165, 120, 0.1);
+  transform: rotate(0deg) scale(1.20);
+  font-size: 10px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box721 {
+  --cssShared-v-721: 709599;
+  color: hsl(37, 73%, 77%);
+  background-color: hsl(217, 73%, 23%);
+  border: 2px solid hsl(127, 50%, 50%);
+  margin: 1px 3px 5px 7px;
+  padding: 1px 12px;
+  border-radius: 1px 2px;
+  box-shadow: 1px 0px 1px rgba(211, 167, 123, 0.2);
+  transform: rotate(1deg) scale(1.21);
+  font-size: 11px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box722 {
+  --cssShared-v-722: 717518;
+  color: hsl(74, 86%, 34%);
+  background-color: hsl(254, 86%, 66%);
+  border: 3px solid hsl(164, 50%, 50%);
+  margin: 2px 6px 10px 14px;
+  padding: 2px 14px;
+  border-radius: 2px 4px;
+  box-shadow: 2px 1px 2px rgba(212, 169, 126, 0.3);
+  transform: rotate(2deg) scale(1.22);
+  font-size: 12px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box723 {
+  --cssShared-v-723: 725437;
+  color: hsl(111, 99%, 41%);
+  background-color: hsl(291, 99%, 59%);
+  border: 4px solid hsl(201, 50%, 50%);
+  margin: 3px 9px 15px 3px;
+  padding: 3px 16px;
+  border-radius: 3px 6px;
+  box-shadow: 3px 2px 3px rgba(213, 171, 129, 0.4);
+  transform: rotate(3deg) scale(1.23);
+  font-size: 13px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box724 {
+  --cssShared-v-724: 733356;
+  color: hsl(148, 12%, 48%);
+  background-color: hsl(328, 12%, 52%);
+  border: 5px solid hsl(238, 50%, 50%);
+  margin: 4px 12px 20px 10px;
+  padding: 4px 18px;
+  border-radius: 4px 8px;
+  box-shadow: 4px 3px 4px rgba(214, 173, 132, 0.5);
+  transform: rotate(4deg) scale(1.24);
+  font-size: 14px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box725 {
+  --cssShared-v-725: 741275;
+  color: hsl(185, 25%, 55%);
+  background-color: hsl(5, 25%, 45%);
+  border: 1px solid hsl(275, 50%, 50%);
+  margin: 5px 15px 0px 17px;
+  padding: 5px 20px;
+  border-radius: 5px 1px;
+  box-shadow: 0px 4px 5px rgba(215, 175, 135, 0.6);
+  transform: rotate(5deg) scale(1.25);
+  font-size: 15px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box726 {
+  --cssShared-v-726: 749194;
+  color: hsl(222, 38%, 62%);
+  background-color: hsl(42, 38%, 38%);
+  border: 2px solid hsl(312, 50%, 50%);
+  margin: 6px 18px 5px 6px;
+  padding: 6px 0px;
+  border-radius: 6px 3px;
+  box-shadow: 1px 5px 6px rgba(216, 177, 138, 0.7);
+  transform: rotate(6deg) scale(1.26);
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box727 {
+  --cssShared-v-727: 757113;
+  color: hsl(259, 51%, 69%);
+  background-color: hsl(79, 51%, 31%);
+  border: 3px solid hsl(349, 50%, 50%);
+  margin: 7px 21px 10px 13px;
+  padding: 7px 2px;
+  border-radius: 7px 5px;
+  box-shadow: 2px 6px 7px rgba(217, 179, 141, 0.8);
+  transform: rotate(7deg) scale(1.27);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box728 {
+  --cssShared-v-728: 765032;
+  color: hsl(296, 64%, 76%);
+  background-color: hsl(116, 64%, 24%);
+  border: 4px solid hsl(26, 50%, 50%);
+  margin: 8px 24px 15px 2px;
+  padding: 8px 4px;
+  border-radius: 8px 7px;
+  box-shadow: 3px 0px 8px rgba(218, 181, 144, 0.9);
+  transform: rotate(8deg) scale(1.28);
+  font-size: 18px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box729 {
+  --cssShared-v-729: 772951;
+  color: hsl(333, 77%, 33%);
+  background-color: hsl(153, 77%, 67%);
+  border: 5px solid hsl(63, 50%, 50%);
+  margin: 9px 27px 20px 9px;
+  padding: 9px 6px;
+  border-radius: 9px 0px;
+  box-shadow: 4px 1px 0px rgba(219, 183, 147, 0.1);
+  transform: rotate(9deg) scale(1.29);
+  font-size: 19px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box730 {
+  --cssShared-v-730: 780870;
+  color: hsl(10, 90%, 40%);
+  background-color: hsl(190, 90%, 60%);
+  border: 1px solid hsl(100, 50%, 50%);
+  margin: 10px 0px 0px 16px;
+  padding: 10px 8px;
+  border-radius: 10px 2px;
+  box-shadow: 0px 2px 1px rgba(220, 185, 150, 0.2);
+  transform: rotate(10deg) scale(1.30);
+  font-size: 20px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box731 {
+  --cssShared-v-731: 788789;
+  color: hsl(47, 3%, 47%);
+  background-color: hsl(227, 3%, 53%);
+  border: 2px solid hsl(137, 50%, 50%);
+  margin: 11px 3px 5px 5px;
+  padding: 11px 10px;
+  border-radius: 11px 4px;
+  box-shadow: 1px 3px 2px rgba(221, 187, 153, 0.3);
+  transform: rotate(11deg) scale(1.31);
+  font-size: 21px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box732 {
+  --cssShared-v-732: 796708;
+  color: hsl(84, 16%, 54%);
+  background-color: hsl(264, 16%, 46%);
+  border: 3px solid hsl(174, 50%, 50%);
+  margin: 12px 6px 10px 12px;
+  padding: 12px 12px;
+  border-radius: 0px 6px;
+  box-shadow: 2px 4px 3px rgba(222, 189, 156, 0.4);
+  transform: rotate(12deg) scale(1.32);
+  font-size: 22px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box733 {
+  --cssShared-v-733: 804627;
+  color: hsl(121, 29%, 61%);
+  background-color: hsl(301, 29%, 39%);
+  border: 4px solid hsl(211, 50%, 50%);
+  margin: 13px 9px 15px 1px;
+  padding: 13px 14px;
+  border-radius: 1px 8px;
+  box-shadow: 3px 5px 4px rgba(223, 191, 159, 0.5);
+  transform: rotate(13deg) scale(1.33);
+  font-size: 23px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box734 {
+  --cssShared-v-734: 812546;
+  color: hsl(158, 42%, 68%);
+  background-color: hsl(338, 42%, 32%);
+  border: 5px solid hsl(248, 50%, 50%);
+  margin: 14px 12px 20px 8px;
+  padding: 14px 16px;
+  border-radius: 2px 1px;
+  box-shadow: 4px 6px 5px rgba(224, 193, 162, 0.6);
+  transform: rotate(14deg) scale(1.34);
+  font-size: 24px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box735 {
+  --cssShared-v-735: 820465;
+  color: hsl(195, 55%, 75%);
+  background-color: hsl(15, 55%, 25%);
+  border: 1px solid hsl(285, 50%, 50%);
+  margin: 15px 15px 0px 15px;
+  padding: 0px 18px;
+  border-radius: 3px 3px;
+  box-shadow: 0px 0px 6px rgba(225, 195, 165, 0.7);
+  transform: rotate(15deg) scale(1.35);
+  font-size: 25px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box736 {
+  --cssShared-v-736: 828384;
+  color: hsl(232, 68%, 32%);
+  background-color: hsl(52, 68%, 68%);
+  border: 2px solid hsl(322, 50%, 50%);
+  margin: 16px 18px 5px 4px;
+  padding: 1px 20px;
+  border-radius: 4px 5px;
+  box-shadow: 1px 1px 7px rgba(226, 197, 168, 0.8);
+  transform: rotate(16deg) scale(1.36);
+  font-size: 26px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box737 {
+  --cssShared-v-737: 836303;
+  color: hsl(269, 81%, 39%);
+  background-color: hsl(89, 81%, 61%);
+  border: 3px solid hsl(359, 50%, 50%);
+  margin: 17px 21px 10px 11px;
+  padding: 2px 0px;
+  border-radius: 5px 7px;
+  box-shadow: 2px 2px 8px rgba(227, 199, 171, 0.9);
+  transform: rotate(17deg) scale(1.37);
+  font-size: 27px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box738 {
+  --cssShared-v-738: 844222;
+  color: hsl(306, 94%, 46%);
+  background-color: hsl(126, 94%, 54%);
+  border: 4px solid hsl(36, 50%, 50%);
+  margin: 18px 24px 15px 0px;
+  padding: 3px 2px;
+  border-radius: 6px 0px;
+  box-shadow: 3px 3px 0px rgba(228, 201, 174, 0.1);
+  transform: rotate(18deg) scale(1.38);
+  font-size: 28px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box739 {
+  --cssShared-v-739: 852141;
+  color: hsl(343, 7%, 53%);
+  background-color: hsl(163, 7%, 47%);
+  border: 5px solid hsl(73, 50%, 50%);
+  margin: 19px 27px 20px 7px;
+  padding: 4px 4px;
+  border-radius: 7px 2px;
+  box-shadow: 4px 4px 1px rgba(229, 203, 177, 0.2);
+  transform: rotate(19deg) scale(1.39);
+  font-size: 29px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box740 {
+  --cssShared-v-740: 860060;
+  color: hsl(20, 20%, 60%);
+  background-color: hsl(200, 20%, 40%);
+  border: 1px solid hsl(110, 50%, 50%);
+  margin: 0px 0px 0px 14px;
+  padding: 5px 6px;
+  border-radius: 8px 4px;
+  box-shadow: 0px 5px 2px rgba(230, 205, 180, 0.3);
+  transform: rotate(20deg) scale(1.40);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box741 {
+  --cssShared-v-741: 867979;
+  color: hsl(57, 33%, 67%);
+  background-color: hsl(237, 33%, 33%);
+  border: 2px solid hsl(147, 50%, 50%);
+  margin: 1px 3px 5px 3px;
+  padding: 6px 8px;
+  border-radius: 9px 6px;
+  box-shadow: 1px 6px 3px rgba(231, 207, 183, 0.4);
+  transform: rotate(21deg) scale(1.41);
+  font-size: 11px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box742 {
+  --cssShared-v-742: 875898;
+  color: hsl(94, 46%, 74%);
+  background-color: hsl(274, 46%, 26%);
+  border: 3px solid hsl(184, 50%, 50%);
+  margin: 2px 6px 10px 10px;
+  padding: 7px 10px;
+  border-radius: 10px 8px;
+  box-shadow: 2px 0px 4px rgba(232, 209, 186, 0.5);
+  transform: rotate(22deg) scale(1.42);
+  font-size: 12px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box743 {
+  --cssShared-v-743: 883817;
+  color: hsl(131, 59%, 31%);
+  background-color: hsl(311, 59%, 69%);
+  border: 4px solid hsl(221, 50%, 50%);
+  margin: 3px 9px 15px 17px;
+  padding: 8px 12px;
+  border-radius: 11px 1px;
+  box-shadow: 3px 1px 5px rgba(233, 211, 189, 0.6);
+  transform: rotate(23deg) scale(1.43);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box744 {
+  --cssShared-v-744: 891736;
+  color: hsl(168, 72%, 38%);
+  background-color: hsl(348, 72%, 62%);
+  border: 5px solid hsl(258, 50%, 50%);
+  margin: 4px 12px 20px 6px;
+  padding: 9px 14px;
+  border-radius: 0px 3px;
+  box-shadow: 4px 2px 6px rgba(234, 213, 192, 0.7);
+  transform: rotate(24deg) scale(1.44);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box745 {
+  --cssShared-v-745: 899655;
+  color: hsl(205, 85%, 45%);
+  background-color: hsl(25, 85%, 55%);
+  border: 1px solid hsl(295, 50%, 50%);
+  margin: 5px 15px 0px 13px;
+  padding: 10px 16px;
+  border-radius: 1px 5px;
+  box-shadow: 0px 3px 7px rgba(235, 215, 195, 0.8);
+  transform: rotate(25deg) scale(1.45);
+  font-size: 15px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box746 {
+  --cssShared-v-746: 907574;
+  color: hsl(242, 98%, 52%);
+  background-color: hsl(62, 98%, 48%);
+  border: 2px solid hsl(332, 50%, 50%);
+  margin: 6px 18px 5px 2px;
+  padding: 11px 18px;
+  border-radius: 2px 7px;
+  box-shadow: 1px 4px 8px rgba(236, 217, 198, 0.9);
+  transform: rotate(26deg) scale(1.46);
+  font-size: 16px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box747 {
+  --cssShared-v-747: 915493;
+  color: hsl(279, 11%, 59%);
+  background-color: hsl(99, 11%, 41%);
+  border: 3px solid hsl(9, 50%, 50%);
+  margin: 7px 21px 10px 9px;
+  padding: 12px 20px;
+  border-radius: 3px 0px;
+  box-shadow: 2px 5px 0px rgba(237, 219, 201, 0.1);
+  transform: rotate(27deg) scale(1.47);
+  font-size: 17px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}
+.cssShared_box748 {
+  --cssShared-v-748: 923412;
+  color: hsl(316, 24%, 66%);
+  background-color: hsl(136, 24%, 34%);
+  border: 4px solid hsl(46, 50%, 50%);
+  margin: 8px 24px 15px 16px;
+  padding: 13px 0px;
+  border-radius: 4px 2px;
+  box-shadow: 3px 6px 1px rgba(238, 221, 204, 0.2);
+  transform: rotate(28deg) scale(1.48);
+  font-size: 18px;
+  line-height: 1.1;
+  letter-spacing: 0.1px;
+  opacity: 0.2;
+}
+.cssShared_box749 {
+  --cssShared-v-749: 931331;
+  color: hsl(353, 37%, 73%);
+  background-color: hsl(173, 37%, 27%);
+  border: 5px solid hsl(83, 50%, 50%);
+  margin: 9px 27px 20px 5px;
+  padding: 14px 2px;
+  border-radius: 5px 4px;
+  box-shadow: 4px 0px 2px rgba(239, 223, 207, 0.3);
+  transform: rotate(29deg) scale(1.49);
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  opacity: 0.3;
+}
+.cssShared_box750 {
+  --cssShared-v-750: 939250;
+  color: hsl(30, 50%, 30%);
+  background-color: hsl(210, 50%, 70%);
+  border: 1px solid hsl(120, 50%, 50%);
+  margin: 10px 0px 0px 12px;
+  padding: 0px 4px;
+  border-radius: 6px 6px;
+  box-shadow: 0px 1px 3px rgba(240, 225, 210, 0.4);
+  transform: rotate(30deg) scale(1.00);
+  font-size: 20px;
+  line-height: 1.3;
+  letter-spacing: 0.3px;
+  opacity: 0.4;
+}
+.cssShared_box751 {
+  --cssShared-v-751: 947169;
+  color: hsl(67, 63%, 37%);
+  background-color: hsl(247, 63%, 63%);
+  border: 2px solid hsl(157, 50%, 50%);
+  margin: 11px 3px 5px 1px;
+  padding: 1px 6px;
+  border-radius: 7px 8px;
+  box-shadow: 1px 2px 4px rgba(241, 227, 213, 0.5);
+  transform: rotate(31deg) scale(1.01);
+  font-size: 21px;
+  line-height: 1.4;
+  letter-spacing: 0.4px;
+  opacity: 0.5;
+}
+.cssShared_box752 {
+  --cssShared-v-752: 955088;
+  color: hsl(104, 76%, 44%);
+  background-color: hsl(284, 76%, 56%);
+  border: 3px solid hsl(194, 50%, 50%);
+  margin: 12px 6px 10px 8px;
+  padding: 2px 8px;
+  border-radius: 8px 1px;
+  box-shadow: 2px 3px 5px rgba(242, 229, 216, 0.6);
+  transform: rotate(32deg) scale(1.02);
+  font-size: 22px;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+.cssShared_box753 {
+  --cssShared-v-753: 963007;
+  color: hsl(141, 89%, 51%);
+  background-color: hsl(321, 89%, 49%);
+  border: 4px solid hsl(231, 50%, 50%);
+  margin: 13px 9px 15px 15px;
+  padding: 3px 10px;
+  border-radius: 9px 3px;
+  box-shadow: 3px 4px 6px rgba(243, 231, 219, 0.7);
+  transform: rotate(33deg) scale(1.03);
+  font-size: 23px;
+  line-height: 1.6;
+  letter-spacing: 0.6px;
+  opacity: 0.7;
+}
+.cssShared_box754 {
+  --cssShared-v-754: 970926;
+  color: hsl(178, 2%, 58%);
+  background-color: hsl(358, 2%, 42%);
+  border: 5px solid hsl(268, 50%, 50%);
+  margin: 14px 12px 20px 4px;
+  padding: 4px 12px;
+  border-radius: 10px 5px;
+  box-shadow: 4px 5px 7px rgba(244, 233, 222, 0.8);
+  transform: rotate(34deg) scale(1.04);
+  font-size: 24px;
+  line-height: 1.7;
+  letter-spacing: 0.7px;
+  opacity: 0.8;
+}
+.cssShared_box755 {
+  --cssShared-v-755: 978845;
+  color: hsl(215, 15%, 65%);
+  background-color: hsl(35, 15%, 35%);
+  border: 1px solid hsl(305, 50%, 50%);
+  margin: 15px 15px 0px 11px;
+  padding: 5px 14px;
+  border-radius: 11px 7px;
+  box-shadow: 0px 6px 8px rgba(245, 235, 225, 0.9);
+  transform: rotate(35deg) scale(1.05);
+  font-size: 25px;
+  line-height: 1.8;
+  letter-spacing: 0.8px;
+  opacity: 0.9;
+}
+.cssShared_box756 {
+  --cssShared-v-756: 986764;
+  color: hsl(252, 28%, 72%);
+  background-color: hsl(72, 28%, 28%);
+  border: 2px solid hsl(342, 50%, 50%);
+  margin: 16px 18px 5px 0px;
+  padding: 6px 16px;
+  border-radius: 0px 0px;
+  box-shadow: 1px 0px 0px rgba(246, 237, 228, 0.1);
+  transform: rotate(36deg) scale(1.06);
+  font-size: 26px;
+  line-height: 1.0;
+  letter-spacing: 0.0px;
+  opacity: 0.1;
+}

--- a/app/javascript/packs/css_demo_one.js
+++ b/app/javascript/packs/css_demo_one.js
@@ -1,0 +1,14 @@
+// CSS-only carrier pack for the RSC *server-component* page one (/css-demo/one/rsc-server).
+//
+// Server components' CSS lives only in the server/RSC bundle and never reaches the
+// browser, so the streamed markup renders unstyled. This pack re-imports the SAME CSS
+// the server components use (cssShared + cssA, page one's exact set — no cssB) into a
+// CLIENT entry, so the bytes get extracted into a client chunk that the controller links
+// in the <head> via `append_stylesheet_pack_tag('css_demo_one')`.
+//
+// Import order matters: shared first, page-specific second (preserve the cascade).
+// Side-effect imports only (global CSS) — never `import styles from ...`.
+// This entry carries NO runtime JS; render it with `stylesheet_pack_tag` only, never
+// `javascript_pack_tag` (we don't want to ship an empty script).
+import '../components/css-demo/cssShared.css';
+import '../components/css-demo/cssA.css';

--- a/app/javascript/packs/css_demo_two.js
+++ b/app/javascript/packs/css_demo_two.js
@@ -1,0 +1,9 @@
+// CSS-only carrier pack for the RSC *server-component* page two (/css-demo/two/rsc-server).
+// See css_demo_one.js for the rationale. Page two's exact CSS set is cssShared + cssB
+// (no cssA). cssShared is shared with page one and is factored into a single chunk by
+// splitChunks {chunks:'all'}, so it downloads once per page and is cached across pages.
+//
+// Import order matters: shared first, page-specific second (preserve the cascade).
+// Side-effect imports only; link via `stylesheet_pack_tag`, never `javascript_pack_tag`.
+import '../components/css-demo/cssShared.css';
+import '../components/css-demo/cssB.css';

--- a/app/javascript/startup/CssPageOneClientCss.tsx
+++ b/app/javascript/startup/CssPageOneClientCss.tsx
@@ -1,0 +1,1 @@
+export { default } from '../components/css-demo/CssPageOneClientCss';

--- a/app/javascript/startup/CssPageOneSSR.tsx
+++ b/app/javascript/startup/CssPageOneSSR.tsx
@@ -1,0 +1,2 @@
+'use client';
+export { default } from '../components/css-demo/CssPageOne';

--- a/app/javascript/startup/CssPageOneServerCss.tsx
+++ b/app/javascript/startup/CssPageOneServerCss.tsx
@@ -1,0 +1,1 @@
+export { default } from '../components/css-demo/CssPageOne';

--- a/app/javascript/startup/CssPageTwoClientCss.tsx
+++ b/app/javascript/startup/CssPageTwoClientCss.tsx
@@ -1,0 +1,1 @@
+export { default } from '../components/css-demo/CssPageTwoClientCss';

--- a/app/javascript/startup/CssPageTwoSSR.tsx
+++ b/app/javascript/startup/CssPageTwoSSR.tsx
@@ -1,0 +1,2 @@
+'use client';
+export { default } from '../components/css-demo/CssPageTwo';

--- a/app/javascript/startup/CssPageTwoServerCss.tsx
+++ b/app/javascript/startup/CssPageTwoServerCss.tsx
@@ -1,0 +1,1 @@
+export { default } from '../components/css-demo/CssPageTwo';

--- a/app/views/css_demo/one_rsc_client.html.erb
+++ b/app/views/css_demo/one_rsc_client.html.erb
@@ -1,0 +1,1 @@
+<%= stream_react_component("CssPageOneClientCss", prerender: true) %>

--- a/app/views/css_demo/one_rsc_server.html.erb
+++ b/app/views/css_demo/one_rsc_server.html.erb
@@ -1,0 +1,1 @@
+<%= stream_react_component("CssPageOneServerCss", prerender: true) %>

--- a/app/views/css_demo/one_rsc_server.html.erb
+++ b/app/views/css_demo/one_rsc_server.html.erb
@@ -1,1 +1,6 @@
+<%# Server-component CSS (cssShared + cssA) lives only in the RSC/server bundle, so it never %>
+<%# reaches the browser and this page renders unstyled. Link the page's exact CSS set from a %>
+<%# client-built carrier pack. This append runs during the view render (before the layout), so %>
+<%# the <link> lands in the <head>'s stylesheet_pack_tag — render-blocking, scoped, no over-fetch. %>
+<% append_stylesheet_pack_tag('css_demo_one') %>
 <%= stream_react_component("CssPageOneServerCss", prerender: true) %>

--- a/app/views/css_demo/one_ssr.html.erb
+++ b/app/views/css_demo/one_ssr.html.erb
@@ -1,0 +1,1 @@
+<%= react_component("CssPageOneSSR", prerender: true) %>

--- a/app/views/css_demo/two_rsc_client.html.erb
+++ b/app/views/css_demo/two_rsc_client.html.erb
@@ -1,0 +1,1 @@
+<%= stream_react_component("CssPageTwoClientCss", prerender: true) %>

--- a/app/views/css_demo/two_rsc_server.html.erb
+++ b/app/views/css_demo/two_rsc_server.html.erb
@@ -1,1 +1,6 @@
+<%# Server-component CSS (cssShared + cssB) lives only in the RSC/server bundle, so it never %>
+<%# reaches the browser and this page renders unstyled. Link the page's exact CSS set from a %>
+<%# client-built carrier pack. This append runs during the view render (before the layout), so %>
+<%# the <link> lands in the <head>'s stylesheet_pack_tag — render-blocking, scoped, no over-fetch. %>
+<% append_stylesheet_pack_tag('css_demo_two') %>
 <%= stream_react_component("CssPageTwoServerCss", prerender: true) %>

--- a/app/views/css_demo/two_rsc_server.html.erb
+++ b/app/views/css_demo/two_rsc_server.html.erb
@@ -1,0 +1,1 @@
+<%= stream_react_component("CssPageTwoServerCss", prerender: true) %>

--- a/app/views/css_demo/two_ssr.html.erb
+++ b/app/views/css_demo/two_ssr.html.erb
@@ -1,0 +1,1 @@
+<%= react_component("CssPageTwoSSR", prerender: true) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,14 @@ Rails.application.routes.draw do
   get '/blog/rsc-step4', to: 'blog#post_rsc_step4'
   get '/blog/rsc-step5', to: 'blog#post_rsc_step5'
 
+  # CSS code-splitting experiment — per-page big CSS files, cssShared shared across pages.
+  # one = Shared + A, two = Shared + B. Three rendering shapes: ssr / rsc-server / rsc-client.
+  get '/css-demo/one/ssr', to: 'css_demo#one_ssr'
+  get '/css-demo/two/ssr', to: 'css_demo#two_ssr'
+  get '/css-demo/one/rsc-server', to: 'css_demo#one_rsc_server'
+  get '/css-demo/two/rsc-server', to: 'css_demo#two_rsc_server'
+  get '/css-demo/one/rsc-client', to: 'css_demo#one_rsc_client'
+  get '/css-demo/two/rsc-client', to: 'css_demo#two_rsc_client'
 
   # API endpoints (Task 2)
   namespace :api do

--- a/docs/css-code-splitting-experiment.md
+++ b/docs/css-code-splitting-experiment.md
@@ -1,0 +1,94 @@
+# CSS code-splitting under SSR vs RSC — does each page download only the CSS it needs?
+
+Experiment to test whether the webpack CSS pipeline + the React on Rails RSC plugin ship **only the
+per-component CSS each page actually uses**, and how SSR and RSC differ. The demo normally styles
+everything with one global Tailwind bundle, which hides per-component CSS behaviour — so this
+introduces large per-component CSS files instead.
+
+## Setup
+
+Three large CSS files (~300 KB raw / ~42 KB gzip each, unique non-compressible rules, each carries a
+greppable `SENTINEL_*` string and a `*_marker` class with a distinctive `outline-width` for
+ground-truth "did it apply?" checks):
+
+- `cssShared.css` — **shared** by both pages (marker outline 7px)
+- `cssA.css` — **only** page one (marker 11px)
+- `cssB.css` — **only** page two (marker 13px)
+
+Leaf components import one CSS file each (`CssShared`/`CssBlockA`/`CssBlockB`, plus `*Client` variants
+with `'use client'`). Two pages × three rendering shapes (registered components in `app/javascript/startup/`):
+
+| Route | Shape | Renders |
+|---|---|---|
+| `/css-demo/{one,two}/ssr` | SSR `react_component` (client component) | Shared + A / Shared + B |
+| `/css-demo/{one,two}/rsc-server` | RSC `stream_react_component`, CSS imported by **server** components | Shared + A / Shared + B |
+| `/css-demo/{one,two}/rsc-client` | RSC streamed, CSS imported by nested **`'use client'`** leaves | Shared + A / Shared + B |
+
+Page one = Shared + A, page two = Shared + B (so `cssShared` is shared, `cssA`/`cssB` are per-page).
+Measured on a **production build** (`:5000`, minified) with Chrome DevTools network capture + a
+`getComputedStyle(outline-width)` check on each block (7/11/13 px = the file loaded and applied;
+0 px = element present but its CSS never arrived). CSS chunks identified by their `SENTINEL_*` content,
+not filename (splitChunks renames/duplicates).
+
+## Results
+
+| Page | CSS files downloaded | Applied (outline-width) | Needed vs downloaded |
+|---|---|---|---|
+| one / ssr | `cssShared` + `cssA` | shared 7px, A 11px | **exactly needed** ✅ |
+| two / ssr | `cssShared` + `cssB` | shared 7px, B 13px | **exactly needed** ✅ |
+| one / rsc-server | *(none of the module CSS)* | shared **0px**, A **0px** (unstyled) | **under-fetch** ❌ |
+| two / rsc-server | *(none of the module CSS)* | unstyled (0px) | **under-fetch** ❌ |
+| one / rsc-client | `cssShared` + `cssA` | shared 7px, A 11px | **exactly needed** ✅ |
+| two / rsc-client | `cssShared` + `cssB` | shared 7px, B 13px | **exactly needed** ✅ |
+
+(Every page also loads the global `application.css` (Tailwind, ~113 KB) and a 2 KB markdown chunk.
+Module files transfer uncompressed (~300 KB each) in this local static-file setup; a CDN/gzip would
+send ~42 KB.)
+
+## Answer: does each page download only the CSS it needs?
+
+- **SSR (client components): YES — exactly the needed CSS.** Page one downloads `cssShared` + `cssA`
+  and **not** `cssB`; page two downloads `cssShared` + `cssB` and **not** `cssA`. The shared file is
+  downloaded **once**. No over-fetch, no under-fetch — and the styles apply.
+- **RSC with CSS imported by `'use client'` components: YES — identical to SSR.** Per-page splitting
+  and shared-file dedup both work; the right CSS downloads and applies.
+- **RSC with CSS imported by pure SERVER components: NO — it downloads *less* than needed (under-fetch).**
+  None of the per-component CSS reaches the client, so the server-rendered markup is **unstyled**
+  (outline 0px). The class names are emitted in the HTML/RSC payload, but the stylesheet defining them
+  is never sent to the browser.
+
+So: **no page ever over-fetches** (page one never pulls page two's CSS, and shared CSS loads once).
+The only failure mode is the RSC **server-component** path, which *under*-fetches — the CSS is missing
+entirely.
+
+## Why (mechanism)
+
+- A **client** component's generated pack imports the component
+  (`import Foo from 'startup/Foo.client'; ReactOnRails.register({Foo})`), so its imported CSS rides in
+  the `generated/Foo` client chunk; react_on_rails' `load_pack_for_generated_component` calls
+  `append_stylesheet_pack_tag('generated/Foo')` per rendered component, so each page links only the CSS
+  for the components it renders. Shared CSS is extracted by `splitChunks {chunks:'all'}` into a chunk
+  both pages share.
+- A **server** component's generated pack is only `registerServerComponent("Foo")` (no import), so the
+  component — and its CSS — exist **only in the server/RSC bundle**, never the client. Streamed body
+  chunks can't append `<head>` stylesheet tags after the head is flushed, so server-component CSS has
+  no path to the client.
+- **`'use client'` leaves inside an RSC tree** are client references: the webpack RSC plugin records
+  their CSS in `react-client-manifest.json`, React emits stylesheet (`S`) hints in the flight stream,
+  and the browser loads exactly those files — which is why `rsc-client` matches SSR.
+
+## Implications / recommendations
+
+- In RSC, **import per-component CSS from a `'use client'` component (or use global CSS)** if it must
+  style client-visible markup. **CSS imported by a pure server component will not reach the browser**
+  and the markup renders unstyled (today this is masked only because everything also gets global
+  Tailwind). This is the key gotcha to document for RSC adopters.
+- Per-page CSS splitting + shared-file dedup work well for SSR and RSC-client — pages pay only for the
+  CSS of the components they render.
+- Build note: because `cssShared` is imported via two different client boundaries (the SSR client
+  component and the `'use client'` leaf), it is emitted into **two** client chunks. Any single page
+  loads only one copy, but the build ships the shared CSS twice across the two paths — consolidate the
+  import path (one shared client component) if that matters.
+
+(Design and predictions cross-reviewed with Codex gpt-5.5 @ xhigh; measured results matched its
+predictions for all three shapes.)

--- a/docs/css-code-splitting-experiment.md
+++ b/docs/css-code-splitting-experiment.md
@@ -92,3 +92,42 @@ entirely.
 
 (Design and predictions cross-reviewed with Codex gpt-5.5 @ xhigh; measured results matched its
 predictions for all three shapes.)
+
+## The fix — deliver server-component CSS, scoped, without over-fetch
+
+The `rsc-server` under-fetch is fixed **at the app level**, keeping the visible tree as pure server
+components. Because a server component's CSS only exists in the RSC/server bundle, we re-import that
+page's exact CSS set into a **client-built carrier pack** and link it from the `<head>`:
+
+- `app/javascript/packs/css_demo_one.js` → `import cssShared.css; import cssA.css;` (page one's set)
+- `app/javascript/packs/css_demo_two.js` → `import cssShared.css; import cssB.css;` (page two's set)
+- Each `rsc-server` view appends only its own pack's **stylesheet** (never the JS):
+  `app/views/css_demo/one_rsc_server.html.erb` → `<% append_stylesheet_pack_tag('css_demo_one') %>`
+  (and `css_demo_two` for page two), placed before the `stream_react_component` call.
+
+The append runs during the view render — before the layout — so the `<link>` lands in the layout's
+single `stylesheet_pack_tag` in the `<head>`, which is flushed before the streamed body paints. This
+is exactly how the gem's own `load_pack_for_generated_component` injects client-component CSS; the
+server-component pack just happens to carry no CSS, which is why these pages were unstyled. Put it in
+the **view, not the controller** — `append_stylesheet_pack_tag` is a Shakapacker view helper and is
+not mixed into `ActionController`.
+
+Why it is scoped (no over-fetch): `splitChunks {chunks:'all'}` factors `cssShared` into one chunk
+shared by both packs, and `cssA`/`cssB` stay in their own per-page chunks. The carrier-pack JS entry
+is never rendered (`stylesheet_pack_tag` only), so no stray script ships.
+
+### Verified (production build, `:5000`, Playwright + network capture)
+
+| Page | marker outlines | CSS chunks requested | over-fetch |
+|---|---|---|---|
+| one / rsc-server | shared **7px**, A **11px** | `cssShared` + `cssA` (no `cssB`) | none ✅ |
+| two / rsc-server | shared **7px**, B **13px** | `cssShared` + `cssB` (no `cssA`) | none ✅ |
+
+All six pages now render styled, SSR'd, hydrated (where they have client components), with **zero**
+console/hydration errors. `cssShared` downloads exactly once per page; the head `<link>`s are present
+in the initial response (render-blocking → no FOUC). Net effect: `rsc-server` now matches `ssr` and
+`rsc-client` — each page pays for exactly the CSS its components use, no more and no less.
+
+(Fix design + implementation cross-reviewed with Codex gpt-5.5 @ xhigh: it chose this Rails
+carrier-pack approach over a `'use client'` CSS-sidecar — head-time render-blocking, no added
+hydration surface — and caught that the append must live in the view, not the controller.)

--- a/scripts/gen-demo-css.mjs
+++ b/scripts/gen-demo-css.mjs
@@ -1,0 +1,32 @@
+import { writeFileSync } from 'node:fs';
+const [, , outFile, prefix, kb, outline] = process.argv;
+const targetBytes = (Number(kb) || 300) * 1024;
+// Sentinel string survives css-loader hashing + minification (it's a content value) -> greppable in
+// downloaded assets. Marker class has a unique outline-width for getComputedStyle assertions.
+let css =
+  `/* ${prefix} ~${kb}KB */\n` +
+  `.${prefix}_sentinel::after { content: "SENTINEL_${prefix.toUpperCase()}"; }\n` +
+  `.${prefix}_marker { outline-style: solid; outline-width: ${outline}px; outline-color: hsl(${(outline * 17) % 360},80%,40%); }\n`;
+let i = 0;
+while (css.length < targetBytes) {
+  const h = (i * 37) % 360, s = (i * 13) % 100, l = 30 + (i * 7) % 50;
+  css +=
+    `.${prefix}_box${i} {\n` +
+    `  --${prefix}-v-${i}: ${(i * 7919) % 1000000};\n` +
+    `  color: hsl(${h}, ${s}%, ${l}%);\n` +
+    `  background-color: hsl(${(h + 180) % 360}, ${s}%, ${100 - l}%);\n` +
+    `  border: ${1 + (i % 5)}px solid hsl(${(h + 90) % 360}, 50%, 50%);\n` +
+    `  margin: ${i % 20}px ${(i * 3) % 30}px ${(i * 5) % 25}px ${(i * 7) % 18}px;\n` +
+    `  padding: ${i % 15}px ${(i * 2) % 22}px;\n` +
+    `  border-radius: ${i % 12}px ${(i * 2) % 9}px;\n` +
+    `  box-shadow: ${i % 5}px ${i % 7}px ${i % 9}px rgba(${i % 255}, ${(i * 2) % 255}, ${(i * 3) % 255}, 0.${(i % 9) + 1});\n` +
+    `  transform: rotate(${i % 360}deg) scale(1.${(i % 50).toString().padStart(2, '0')});\n` +
+    `  font-size: ${10 + (i % 20)}px;\n` +
+    `  line-height: 1.${i % 9};\n` +
+    `  letter-spacing: 0.${i % 9}px;\n` +
+    `  opacity: 0.${(i % 9) + 1};\n` +
+    `}\n`;
+  i++;
+}
+writeFileSync(outFile, css);
+console.log(`${outFile}: ${(css.length / 1024).toFixed(0)}KB raw, ${i + 2} rules`);

--- a/scripts/verify-css-demo-server-css.mjs
+++ b/scripts/verify-css-demo-server-css.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Regression guard for the RSC server-component CSS fix (see docs/css-code-splitting-experiment.md).
+//
+// Asserts, against a running server, that each /css-demo/{one,two}/rsc-server page:
+//   - links its own CSS in the <head> (render-blocking → no FOUC),
+//   - downloads exactly its set: page one = cssShared + cssA, page two = cssShared + cssB,
+//   - never downloads the OTHER page's CSS (no over-fetch / no unneeded CSS),
+//   - downloads cssShared exactly once,
+//   - ships no carrier-pack <script> (css_demo_one/two are stylesheet-only).
+// Sentinels (content, not filenames) are the ground truth, since splitChunks renames chunks.
+//
+// Usage: BASE=http://localhost:5000 node scripts/verify-css-demo-server-css.mjs
+const BASE = process.env.BASE || 'http://localhost:5000';
+
+const PAGES = {
+  one: { path: '/css-demo/one/rsc-server', want: ['SENTINEL_CSSSHARED', 'SENTINEL_CSSA'], forbid: 'SENTINEL_CSSB' },
+  two: { path: '/css-demo/two/rsc-server', want: ['SENTINEL_CSSSHARED', 'SENTINEL_CSSB'], forbid: 'SENTINEL_CSSA' },
+};
+
+const fail = (msg) => { console.error(`✗ ${msg}`); process.exitCode = 1; };
+const ok = (msg) => console.log(`✓ ${msg}`);
+
+const headOf = (html) => html.split('</head>')[0];
+const styleHrefs = (html) =>
+  [...html.matchAll(/<link[^>]+rel="stylesheet"[^>]+href="([^"]+)"/g)].map((m) => m[1]);
+const carrierScripts = (html) =>
+  [...html.matchAll(/<script[^>]+src="([^"]*css_demo_(?:one|two)[^"]*)"/g)].map((m) => m[1]);
+
+for (const [name, cfg] of Object.entries(PAGES)) {
+  const html = await (await fetch(BASE + cfg.path)).text();
+  const head = headOf(html);
+
+  // every stylesheet link this page uses must be in the <head> (no late body-injected CSS)
+  const allHrefs = styleHrefs(html);
+  const headHrefs = styleHrefs(head);
+  for (const href of allHrefs) {
+    if (!headHrefs.includes(href)) fail(`${name}: stylesheet not in <head>: ${href}`);
+  }
+
+  // fetch served CSS and check sentinels
+  let css = '';
+  for (const href of [...new Set(allHrefs)]) css += await (await fetch(BASE + href)).text();
+  const count = (s) => (css.match(new RegExp(s, 'g')) || []).length;
+
+  for (const s of cfg.want) {
+    if (count(s) < 1) fail(`${name}: missing required CSS ${s}`);
+  }
+  if (count('SENTINEL_CSSSHARED') !== 1) fail(`${name}: cssShared not downloaded exactly once (${count('SENTINEL_CSSSHARED')}x)`);
+  if (count(cfg.forbid) !== 0) fail(`${name}: OVER-FETCH — downloaded ${cfg.forbid}`);
+
+  const scripts = carrierScripts(html);
+  if (scripts.length) fail(`${name}: carrier-pack script shipped: ${scripts.join(', ')}`);
+
+  if (!process.exitCode) ok(`${name}/rsc-server: ${cfg.want.join(' + ')} in <head>, no ${cfg.forbid}, no carrier JS`);
+}
+
+if (process.exitCode) console.error('\nCSS-demo server-component CSS guard FAILED');
+else console.log('\nAll CSS-demo server-component CSS checks passed');


### PR DESCRIPTION
## What this is

A **standalone experiment** (based directly on `main`) testing whether the webpack + RSC CSS pipeline ships **only the CSS each page needs**, and how **SSR vs RSC** differ. The demo normally styles everything with one global Tailwind bundle, which hides per-component CSS behaviour — so this introduces large per-component CSS files and dedicated pages to exercise it. Independent of #101.

## Setup
- 3 big per-component CSS files (~300 KB each, unique non-compressible rules + a greppable `SENTINEL_*` string + a `*_marker` class with a distinctive `outline-width` for "did it apply?" checks): `cssShared.css` (shared by both pages), `cssA.css` (page one only), `cssB.css` (page two only). Generated by `scripts/gen-demo-css.mjs`.
- 6 routes — `/css-demo/{one,two}/{ssr,rsc-server,rsc-client}` — rendering the same big CSS three ways: SSR (client component), RSC with CSS imported by a **server** component, and RSC with CSS imported by a nested **`'use client'`** leaf.

## Result (production build; verified in-browser via Playwright)

All six pages render with **no errors / no error overlay**. Computed `outline-width` confirms whether each block's CSS actually applied:

| Page | renders | CSS downloaded | styled? |
|---|---|---|---|
| `one/ssr`, `two/ssr` (client component) | ✅ | own module + shared | ✅ (7px / 11px / 13px) |
| `one/rsc-client`, `two/rsc-client` (`'use client'` leaf CSS) | ✅ | own module + shared | ✅ (7px / 11px / 13px) |
| `one/rsc-server`, `two/rsc-server` (server-component CSS) | ✅ | **none** | ❌ **unstyled (0px)** |

- **SSR and RSC-with-`'use client'`-CSS download exactly the needed CSS** — each page gets its own module + the shared one, never the other page's, and the shared file loads once. No over-fetch.
- **RSC where CSS is imported by a pure *Server Component* downloads none of it → the markup renders unstyled.** Server-component CSS lives only in the RSC/server bundle and never reaches the client.

This is the minimal reproduction behind the upstream issue **shakacode/react_on_rails#4049** ("support CSS imported by Server Components"). Full write-up in `docs/css-code-splitting-experiment.md`.

## Note for reviewers
This is a **demonstration / repro**, not a feature — it intentionally ships ~900 KB of synthetic CSS and throwaway components. Treat it as a discussion/repro PR, not as something to merge into the demo's normal pages as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)---

## Update — fix added (commit 2)

This PR now also **fixes** the `rsc-server` under-fetch it documents. A pure server component's CSS lives only in the RSC/server bundle and never reaches the client, so those pages rendered unstyled. The fix delivers each page's exact CSS set from a client-built **carrier pack** linked in the `<head>`:

- `app/javascript/packs/css_demo_{one,two}.js` — re-import `cssShared`+`cssA` / `cssShared`+`cssB`.
- `app/views/css_demo/{one,two}_rsc_server.html.erb` — `append_stylesheet_pack_tag(...)` (in the **view**, since the Shakapacker helper isn't on the controller), so the `<link>` lands in the head before the streamed body paints (render-blocking → no FOUC).
- `stylesheet`-only (no `javascript_pack_tag`), so the carrier's empty JS never ships. `splitChunks` factors `cssShared` once → **no over-fetch** (page one never pulls `cssB`, and vice-versa).
- `scripts/verify-css-demo-server-css.mjs` — regression guard for the no-cross-page-leak property.

**Verified (prod build, Playwright + network):** both `rsc-server` pages now styled (marker outlines `7/11` and `7/13` px, were `0px`); all 6 css-demo pages SSR'd + hydrated, 0 console errors; each page downloads exactly the CSS its components use. Fix design + review co-signed by Codex gpt-5.5 (xhigh).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSS code-splitting experiment with six new demo pages testing different rendering modes (server-side rendering and React Server Components in both server and client variants)

* **Documentation**
  * Added comprehensive guide documenting CSS behavior across rendering modes, measured outcomes, and CSS delivery mechanisms

* **Tests**
  * Added regression verification script to validate server-rendered pages correctly load required CSS without over-fetching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->