### PR TITLE
Bump React on Rails RC dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,8 @@ gem 'turbo-rails'
 gem 'stimulus-rails'
 
 # React on Rails
-gem 'react_on_rails', '17.0.0.rc.3'
-gem 'react_on_rails_pro', '17.0.0.rc.3'
+gem 'react_on_rails', '17.0.0.rc.6'
+gem 'react_on_rails_pro', '17.0.0.rc.6'
 
 # Shakapacker for webpack integration
 gem 'shakapacker', '10.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
       xpath (~> 3.2)
     cgi (0.5.1)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (2.5.5)
     console (1.36.0)
       fiber-annotation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,14 +298,14 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
-    react_on_rails (17.0.0.rc.3)
+    react_on_rails (17.0.0.rc.6)
       addressable
       connection_pool
       execjs (~> 2.5)
       rails (>= 5.2)
       rainbow (~> 3.0)
       shakapacker (>= 6.0)
-    react_on_rails_pro (17.0.0.rc.3)
+    react_on_rails_pro (17.0.0.rc.6)
       addressable
       async (>= 2.29)
       async-http (~> 0.95)
@@ -313,7 +313,7 @@ GEM
       io-endpoint (~> 0.17.0)
       jwt (>= 2.5, < 4)
       rainbow
-      react_on_rails (= 17.0.0.rc.3)
+      react_on_rails (= 17.0.0.rc.6)
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -434,8 +434,8 @@ DEPENDENCIES
   pry-byebug (~> 3.12)
   puma (~> 6.0)
   rails (~> 7.1)
-  react_on_rails (= 17.0.0.rc.3)
-  react_on_rails_pro (= 17.0.0.rc.3)
+  react_on_rails (= 17.0.0.rc.6)
+  react_on_rails_pro (= 17.0.0.rc.6)
   rspec-rails (~> 6.1)
   rubocop
   rubocop-rails

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
     "intl-messageformat": "^11.2.4",
     "marked": "^17.0.2",
     "marked-highlight": "^2.2.3",
-    "react": "19.0.4",
-    "react-dom": "19.0.4",
-    "react-on-rails-pro": "17.0.0-rc.3",
-    "react-on-rails-pro-node-renderer": "17.0.0-rc.3",
-    "react-on-rails-rsc": "19.0.5-rc.7",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "react-on-rails-pro": "17.0.0-rc.6",
+    "react-on-rails-pro-node-renderer": "17.0.0-rc.6",
+    "react-on-rails-rsc": "19.2.0-rc.3",
     "sanitize-html": "^2.17.3",
     "simple-statistics": "^7.8.9",
     "web-vitals": "^4.2.0"
@@ -54,7 +54,7 @@
   "pnpm": {
     "overrides": {
       "@ungap/structured-clone": "1.3.1",
-      "react-on-rails": "17.0.0-rc.3",
+      "react-on-rails": "17.0.0-rc.6",
       "shakapacker": "10.1.0"
     }
   },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-on-rails-pro": "17.0.0-rc.6",
     "react-on-rails-pro-node-renderer": "17.0.0-rc.6",
     "react-on-rails-rsc": "19.2.0-rc.3",
+    "react-server-dom-webpack": "19.2.7",
     "sanitize-html": "^2.17.3",
     "simple-statistics": "^7.8.9",
     "web-vitals": "^4.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       react-on-rails-rsc:
         specifier: 19.2.0-rc.3
         version: 19.2.0-rc.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
+      react-server-dom-webpack:
+        specifier: 19.2.7
+        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
       sanitize-html:
         specifier: ^2.17.3
         version: 2.17.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@ungap/structured-clone': 1.3.1
-  react-on-rails: 17.0.0-rc.3
+  react-on-rails: 17.0.0-rc.6
   shakapacker: 10.1.0
 
 importers:
@@ -21,10 +21,10 @@ importers:
         version: 8.0.23
       '@loadable/component':
         specifier: ^5.16.7
-        version: 5.16.7(react@19.0.4)
+        version: 5.16.7(react@19.2.7)
       '@loadable/server':
         specifier: ^5.16.7
-        version: 5.16.7(@loadable/component@5.16.7(react@19.0.4))(react@19.0.4)
+        version: 5.16.7(@loadable/component@5.16.7(react@19.2.7))(react@19.2.7)
       '@loadable/webpack-plugin':
         specifier: ^5.15.2
         version: 5.15.2(webpack@5.105.4)
@@ -65,20 +65,20 @@ importers:
         specifier: ^2.2.3
         version: 2.2.3(marked@17.0.5)
       react:
-        specifier: 19.0.4
-        version: 19.0.4
+        specifier: 19.2.7
+        version: 19.2.7
       react-dom:
-        specifier: 19.0.4
-        version: 19.0.4(react@19.0.4)
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
       react-on-rails-pro:
-        specifier: 17.0.0-rc.3
-        version: 17.0.0-rc.3(react-dom@19.0.4(react@19.0.4))(react-on-rails-rsc@19.0.5-rc.7(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(webpack@5.105.4))(react@19.0.4)
+        specifier: 17.0.0-rc.6
+        version: 17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.0-rc.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4))(react@19.2.7)
       react-on-rails-pro-node-renderer:
-        specifier: 17.0.0-rc.3
-        version: 17.0.0-rc.3
+        specifier: 17.0.0-rc.6
+        version: 17.0.0-rc.6
       react-on-rails-rsc:
-        specifier: 19.0.5-rc.7
-        version: 19.0.5-rc.7(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(webpack@5.105.4)
+        specifier: 19.2.0-rc.3
+        version: 19.2.0-rc.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
       sanitize-html:
         specifier: ^2.17.3
         version: 2.17.3
@@ -4128,16 +4128,17 @@ packages:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
 
-  react-dom@19.0.4:
-    resolution: {integrity: sha512-JiVlwQwuINIQf2+XUjtRFtLxhTE6hcyX7ZyCmY0HM7I/Kgi7qyXThkzwzg6uCfu3rTg9Ofe1x8qWYrfqthIrzg==}
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
-      react: ^19.0.4
+      react: ^19.2.7
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
-  react-on-rails-pro-node-renderer@17.0.0-rc.3:
-    resolution: {integrity: sha512-Red3GaNEF33XhjtfCSkYAM4+GEoiCEjP0Yt1eknH5LmWqVnO1NMqWoFhtBfxaVr/K++qTVYY5yV28iNh6gTqzg==}
+  react-on-rails-pro-node-renderer@17.0.0-rc.6:
+    resolution: {integrity: sha512-nX9Nmgb3hiUMPItC5xfV/W/FGnYLLzefr5qJOURPxrkHgEa6dw1ndnH2mRPyh0zFkOaCB2FBIy8lkWfXvRpfiA==}
+    engines: {node: '>=18.19.0'}
     peerDependencies:
       '@fastify/otel': '>=0.18.0 <1.0.0'
       '@honeybadger-io/js': '>=4.0.0'
@@ -4177,14 +4178,14 @@ packages:
       '@sentry/tracing':
         optional: true
 
-  react-on-rails-pro@17.0.0-rc.3:
-    resolution: {integrity: sha512-DzBHKrDX+bHY2ojnNjH5cNxFXmwIncaL3SQL1SCVibU+G2I32IV8gKB3cUTZgNhMY3p1Onsgjt/cVt0x6+Cqhw==}
+  react-on-rails-pro@17.0.0-rc.6:
+    resolution: {integrity: sha512-Uc4IUmNYAJIk4iy4RatLN0qVM7MAi8zgXVvd7vZMEnVkGGhHqvj1A82ft97yJqgfqF9mm3eSPPyU3gyXrH5CsQ==}
     peerDependencies:
       '@tanstack/react-router': '>=1.139.0 <2.0.0'
       ioredis: '>= 5'
       react: '>= 16'
       react-dom: '>= 16'
-      react-on-rails-rsc: '*'
+      react-on-rails-rsc: ^19.0.5
     peerDependenciesMeta:
       '@tanstack/react-router':
         optional: true
@@ -4193,15 +4194,15 @@ packages:
       react-on-rails-rsc:
         optional: true
 
-  react-on-rails-rsc@19.0.5-rc.7:
-    resolution: {integrity: sha512-cyQwZm7YW9FS0PEgwael5P9S5HsNeHwhnMm10ScgepZTv38dOeidf+gWf9x+z6w0wrgJ92aExZ8uLjCgpImxcQ==}
+  react-on-rails-rsc@19.2.0-rc.3:
+    resolution: {integrity: sha512-lthw7rRbPdUOeZQMVR2rH1FdA3sp7wiZfMljmld1c/2epYtA7SYLLhg7jTn9FcVEIjWLZiyzC7GkNrNnLB4IOQ==}
     peerDependencies:
-      react: ^19.0.4
-      react-dom: ^19.0.4
+      react: ^19.2.7
+      react-dom: ^19.2.7
       webpack: ^5.59.0
 
-  react-on-rails@17.0.0-rc.3:
-    resolution: {integrity: sha512-VpLWgVt4mE6ETo1mGj5yLCL/sEK+SPYIut7nVqx10HY0F/P1IQodEWm18IYQ5ZBBxdAngvSsOArjypVUcFLP0w==}
+  react-on-rails@17.0.0-rc.6:
+    resolution: {integrity: sha512-/u2hzYvuUN+1HnH0gEdbfQvkWkgLMSN2kl/2x9CCOInIHffBvilgXzBgJrP5NlvjWpguUWSxO6PrYpgV0BzLMA==}
     peerDependencies:
       react: '>= 16'
       react-dom: '>= 16'
@@ -4210,8 +4211,16 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
-  react@19.0.4:
-    resolution: {integrity: sha512-6RpEg9/n0sThnO+2CaMLWuvL1iyctm9/lcSTwvmyCoJYD5eiIrwxevXtrMqrtUr96HCdQB8/Yf+oK1QGy8kXEQ==}
+  react-server-dom-webpack@19.2.7:
+    resolution: {integrity: sha512-bYfuvqPJnHB4CHo2Ze7fQyJAO77TUu1W/aKFt81ICXbLiOTg5jHaO/NPDlpvGWUALoEGaGb7Oi1uXAaO+Bw6jw==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.7
+      react-dom: ^19.2.7
+      webpack: ^5.59.0
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
   read-cache@1.0.0:
@@ -4399,8 +4408,8 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  scheduler@0.25.0:
-    resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
@@ -6393,18 +6402,18 @@ snapshots:
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
-  '@loadable/component@5.16.7(react@19.0.4)':
+  '@loadable/component@5.16.7(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.2
       hoist-non-react-statics: 3.3.2
-      react: 19.0.4
+      react: 19.2.7
       react-is: 16.13.1
 
-  '@loadable/server@5.16.7(@loadable/component@5.16.7(react@19.0.4))(react@19.0.4)':
+  '@loadable/server@5.16.7(@loadable/component@5.16.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@loadable/component': 5.16.7(react@19.0.4)
+      '@loadable/component': 5.16.7(react@19.2.7)
       lodash: 4.17.23
-      react: 19.0.4
+      react: 19.2.7
 
   '@loadable/webpack-plugin@5.15.2(webpack@5.105.4)':
     dependencies:
@@ -9480,14 +9489,14 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
-  react-dom@19.0.4(react@19.0.4):
+  react-dom@19.2.7(react@19.2.7):
     dependencies:
-      react: 19.0.4
-      scheduler: 0.25.0
+      react: 19.2.7
+      scheduler: 0.27.0
 
   react-is@16.13.1: {}
 
-  react-on-rails-pro-node-renderer@17.0.0-rc.3:
+  react-on-rails-pro-node-renderer@17.0.0-rc.6:
     dependencies:
       '@fastify/formbody': 8.0.2
       '@fastify/multipart': 9.4.0
@@ -9497,31 +9506,41 @@ snapshots:
       lockfile: 1.0.4
       pino: 9.14.0
 
-  react-on-rails-pro@17.0.0-rc.3(react-dom@19.0.4(react@19.0.4))(react-on-rails-rsc@19.0.5-rc.7(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(webpack@5.105.4))(react@19.0.4):
+  react-on-rails-pro@17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.0-rc.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4))(react@19.2.7):
     dependencies:
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
-      react-on-rails: 17.0.0-rc.3(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-on-rails: 17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:
-      react-on-rails-rsc: 19.0.5-rc.7(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(webpack@5.105.4)
+      react-on-rails-rsc: 19.2.0-rc.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
 
-  react-on-rails-rsc@19.0.5-rc.7(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(webpack@5.105.4):
+  react-on-rails-rsc@19.2.0-rc.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-server-dom-webpack: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
       webpack: 5.105.4(@swc/core@1.15.21)(webpack-cli@5.1.4)
       webpack-sources: 3.3.4
 
-  react-on-rails@17.0.0-rc.3(react-dom@19.0.4(react@19.0.4))(react@19.0.4):
+  react-on-rails@17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   react-refresh@0.14.2: {}
 
-  react@19.0.4: {}
+  react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4):
+    dependencies:
+      acorn-loose: 8.5.2
+      neo-async: 2.6.2
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      webpack: 5.105.4(@swc/core@1.15.21)(webpack-cli@5.1.4)
+      webpack-sources: 3.3.4
+
+  react@19.2.7: {}
 
   read-cache@1.0.0:
     dependencies:
@@ -9709,7 +9728,7 @@ snapshots:
     optionalDependencies:
       '@parcel/watcher': 2.5.6
 
-  scheduler@0.25.0: {}
+  scheduler@0.27.0: {}
 
   schema-utils@4.3.3:
     dependencies:


### PR DESCRIPTION
## Summary
- Bumps React on Rails Pro packages to 17.0.0-rc.6 / 17.0.0.rc.6.
- Bumps react-on-rails-rsc to 19.2.0-rc.3 and React/React DOM to 19.2.7.
- Regenerates the package-manager and Bundler lockfiles.

## Validation
- Regenerated package lockfile for this app.
- Ran bundle install for this app.
- Ran git diff --check.
- Scanned manifests and lockfiles for stale RC pins.