### PR TITLE
Bump react-on-rails-rsc to 19.2.0-rc.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-dom": "19.2.7",
     "react-on-rails-pro": "17.0.0-rc.6",
     "react-on-rails-pro-node-renderer": "17.0.0-rc.6",
-    "react-on-rails-rsc": "19.2.0-rc.3",
+    "react-on-rails-rsc": "19.2.0-rc.4",
     "react-server-dom-webpack": "19.2.7",
     "sanitize-html": "^2.17.3",
     "simple-statistics": "^7.8.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,13 +72,13 @@ importers:
         version: 19.2.7(react@19.2.7)
       react-on-rails-pro:
         specifier: 17.0.0-rc.6
-        version: 17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.0-rc.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4))(react@19.2.7)
+        version: 17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.0-rc.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4))(react@19.2.7)
       react-on-rails-pro-node-renderer:
         specifier: 17.0.0-rc.6
         version: 17.0.0-rc.6
       react-on-rails-rsc:
-        specifier: 19.2.0-rc.3
-        version: 19.2.0-rc.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
+        specifier: 19.2.0-rc.4
+        version: 19.2.0-rc.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
       react-server-dom-webpack:
         specifier: 19.2.7
         version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
@@ -4197,8 +4197,8 @@ packages:
       react-on-rails-rsc:
         optional: true
 
-  react-on-rails-rsc@19.2.0-rc.3:
-    resolution: {integrity: sha512-lthw7rRbPdUOeZQMVR2rH1FdA3sp7wiZfMljmld1c/2epYtA7SYLLhg7jTn9FcVEIjWLZiyzC7GkNrNnLB4IOQ==}
+  react-on-rails-rsc@19.2.0-rc.4:
+    resolution: {integrity: sha512-Jm9822vmAvXPbQ3gyx8B5RwbGcmxEXZ1eMEoVxd3rsnnxuZ7B35dr11Ygy2FBPPq4v5sJa/PFWGir/m8Cg1b9Q==}
     peerDependencies:
       react: ^19.2.7
       react-dom: ^19.2.7
@@ -9509,15 +9509,15 @@ snapshots:
       lockfile: 1.0.4
       pino: 9.14.0
 
-  react-on-rails-pro@17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.0-rc.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4))(react@19.2.7):
+  react-on-rails-pro@17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.0-rc.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-on-rails: 17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:
-      react-on-rails-rsc: 19.2.0-rc.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
+      react-on-rails-rsc: 19.2.0-rc.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
 
-  react-on-rails-rsc@19.2.0-rc.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4):
+  react-on-rails-rsc@19.2.0-rc.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2


### PR DESCRIPTION
## Summary
- Bump `react-on-rails-rsc` from `19.2.0-rc.3` to `19.2.0-rc.4`.
- Refresh pnpm lockfile resolution and integrity for the new RC.

## Verification
- `PATH=/Users/justin/.local/share/mise/installs/node/22.22.3/bin:$PATH COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm install --lockfile-only --frozen-lockfile`
- Exact stale-pin scan: `rg -n "19\.2\.0-rc\.3" /Users/justin/.codex/downstream-rc6 --glob "!node_modules/**" --glob "!public/lighthouse-reports/**" --glob "!tmp/**" --glob "!log/**"` returned no matches.