### PR TITLE
Add multimedia showcase page (HLS video + image galleries) as RSC

### DIFF
--- a/app/controllers/media_gallery_controller.rb
+++ b/app/controllers/media_gallery_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# MediaGalleryController — the multimedia showcase page (issue #98).
+#
+# Single RSC variant (the page is "RSC-first" per the brief: use server
+# components wherever possible). It follows the exact same streaming setup as
+# RestaurantsController#show_rsc:
+#   - include the two react-on-rails-pro concerns
+#   - enable async react rendering for the streamed action
+#   - render via stream_view_containing_react_components (NOT a plain render)
+class MediaGalleryController < ApplicationController
+  include ReactOnRailsPro::RSCPayloadRenderer
+  include ReactOnRailsPro::AsyncRendering
+
+  enable_async_react_rendering only: %i[show_rsc]
+
+  before_action :set_seo_meta
+
+  # GET /media-gallery (and /media-gallery/rsc)
+  def show_rsc
+    @gallery = MediaGalleryData.build
+    stream_view_containing_react_components(template: 'media_gallery/show_rsc')
+  end
+
+  private
+
+  def set_seo_meta
+    @page_title = 'Multimedia Showcase — React Server Components (RSC) | React on Rails RSC Demo'
+    @page_description =
+      'A media-heavy page (HLS video via react-player light mode and vanilla hls.js, ' \
+      'plus responsive image galleries with react-image-lightbox and yet-another-react-lightbox) ' \
+      'rendered RSC-first: only the interactive players and lightboxes ship JavaScript.'
+  end
+end

--- a/app/javascript/components/multimedia/LightboxThumbGrid.tsx
+++ b/app/javascript/components/multimedia/LightboxThumbGrid.tsx
@@ -1,0 +1,51 @@
+// LightboxThumbGrid — the responsive thumbnail grid shared by BOTH galleries.
+//
+// NO 'use client' — it has no browser state of its own; it just renders <img>
+// thumbnails and calls back with the clicked index. It's pulled into the client
+// graph by whichever gallery island imports it.
+//
+// This is where the issue's IMAGE acceptance criteria are satisfied:
+//   • responsive srcset/sizes  → browser downloads the smallest file that fills
+//     the slot (big mobile bandwidth saving)
+//   • explicit width/height    → the box is reserved at intrinsic 3:2 ratio, so
+//     the grid never reflows as images decode → CLS ~0
+//   • lazy loading below the fold → only the first row loads eagerly
+import React from 'react';
+import type { GalleryImage } from './types';
+
+interface Props {
+  images: GalleryImage[];
+  onOpen: (index: number) => void;
+  // Used only for accessible labels so screen-reader users know which lightbox.
+  label: string;
+}
+
+export function LightboxThumbGrid({ images, onOpen, label }: Props) {
+  return (
+    <ul className="m-0 grid list-none grid-cols-2 gap-3 p-0 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 md:gap-4">
+      {images.map((img, index) => (
+        <li key={img.id}>
+          <button
+            type="button"
+            onClick={() => onOpen(index)}
+            aria-label={`Open image ${index + 1} of ${images.length} in the ${label} lightbox`}
+            className="group block w-full overflow-hidden rounded-lg ring-1 ring-slate-200 transition hover:ring-slate-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+          >
+            <img
+              src={img.thumb_src}
+              srcSet={img.srcset}
+              sizes={img.sizes}
+              width={img.width}
+              height={img.height}
+              alt={img.alt}
+              // First row (4 thumbs on desktop) is likely above the fold.
+              loading={index < 4 ? 'eager' : 'lazy'}
+              decoding="async"
+              className="aspect-[3/2] w-full object-cover transition duration-300 group-hover:scale-105"
+            />
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/app/javascript/components/multimedia/MediaGalleryRSC.tsx
+++ b/app/javascript/components/multimedia/MediaGalleryRSC.tsx
@@ -1,0 +1,100 @@
+// MediaGalleryRSC — the /media-gallery page. A React SERVER component.
+//
+// No 'use client' — this is the RSC bundle. Everything in this file runs on the
+// server and streams as HTML: the layout, the section copy, and the markdown
+// (rendered with marked + sanitize-html HERE, so those libs never reach the
+// browser — the lint:rsc check enforces that). The only JavaScript the page
+// ships is the four media widgets below, each a small client island reached via
+// its *ForServer wrapper. That is the "use server components as much as possible"
+// goal made concrete: server-render everything that doesn't need the browser.
+import React from 'react';
+import { renderSanitizedMarkdown } from '../../utils/sanitizeAndRender';
+import { ReactPlayerLightVideo } from './ReactPlayerLightVideoForServer';
+import { VanillaHlsVideo } from './VanillaHlsVideoForServer';
+import { ReactImageLightboxGallery } from './ReactImageLightboxGalleryForServer';
+import { YetAnotherLightboxGallery } from './YetAnotherLightboxGalleryForServer';
+import type { MediaGalleryProps } from './types';
+
+// Server-rendered prose. marked + highlight.js + sanitize-html all run on the
+// server inside this function; the client receives only sanitized HTML.
+function Prose({ markdown }: { markdown: string }) {
+  return (
+    <div
+      className="prose prose-slate max-w-none"
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: renderSanitizedMarkdown(markdown) }}
+    />
+  );
+}
+
+// Small server-rendered section header so each demo explains what it shows.
+function SectionHeader({ kicker, title, blurb }: { kicker: string; title: string; blurb: string }) {
+  return (
+    <div className="mb-5">
+      <span className="inline-block rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-indigo-700">
+        {kicker}
+      </span>
+      <h2 className="mt-3 text-2xl font-bold text-slate-900">{title}</h2>
+      <p className="mt-1 max-w-3xl text-slate-500">{blurb}</p>
+    </div>
+  );
+}
+
+export default function MediaGalleryRSC(props: MediaGalleryProps) {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="container mx-auto max-w-5xl space-y-16 px-4 py-10 sm:py-14">
+        {/* Intro — pure server-rendered markdown, zero JS. */}
+        <header>
+          <Prose markdown={props.intro_markdown} />
+        </header>
+
+        {/* ── VIDEO 1: react-player v3, light/facade mode ── */}
+        <section>
+          <SectionHeader
+            kicker="Video · react-player v3"
+            title="Light mode (facade)"
+            blurb="react-player renders just the poster + a play icon; the hls.js engine and the player module are both fetched on click. The poster is a real video frame from Mux's image service."
+          />
+          {/* priority: first video on the page → its poster is the likely LCP. */}
+          <ReactPlayerLightVideo video={props.react_player_video} priority />
+        </section>
+
+        {/* ── VIDEO 2: vanilla <video> + hls.js ── */}
+        <section>
+          <SectionHeader
+            kicker="Video · hand-rolled"
+            title="Vanilla <video> + hls.js"
+            blurb="No player library. Feature-detected (MSE-first, native-HLS fallback), with hls.js dynamically imported only on the first click. The poster is self-supplied because this raw test stream has no thumbnail service."
+          />
+          <VanillaHlsVideo video={props.vanilla_video} />
+        </section>
+
+        {/* ── GALLERY 1: react-image-lightbox (deprecated) ── */}
+        <section>
+          <SectionHeader
+            kicker="Gallery · react-image-lightbox"
+            title="The deprecated incumbent"
+            blurb="A responsive thumbnail grid (srcset/sizes, explicit dimensions, lazy below the fold) wired to react-image-lightbox — archived since 2023 but still widely used. Click any thumbnail."
+          />
+          <ReactImageLightboxGallery images={props.ril_gallery} />
+        </section>
+
+        {/* ── GALLERY 2: yet-another-react-lightbox (recommended successor) ── */}
+        <section>
+          <SectionHeader
+            kicker="Gallery · yet-another-react-lightbox"
+            title="The maintained successor"
+            blurb="The same grid wired to yet-another-react-lightbox — actively maintained, React-19-ready, SSR-safe, with a cleaner controlled API. This is the recommended replacement."
+          />
+          <YetAnotherLightboxGallery images={props.yarl_gallery} />
+        </section>
+
+        {/* Closing notes — server-rendered markdown. */}
+        <footer className="border-t border-slate-200 pt-10">
+          <Prose markdown={props.closing_markdown} />
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/app/javascript/components/multimedia/ReactImageLightboxGallery.tsx
+++ b/app/javascript/components/multimedia/ReactImageLightboxGallery.tsx
@@ -1,0 +1,56 @@
+// ReactImageLightboxGallery — GALLERY demo #1: react-image-lightbox.
+//
+// NO 'use client' (directive lives in ReactImageLightboxGalleryForServer.tsx).
+//
+// ─── WHY THIS LIBRARY IS HERE (from the lightbox investigation) ──────────────
+// react-image-lightbox is DEPRECATED and its repo is archived (last release
+// 5.1.4, July 2021) yet still pulls ~130k downloads/week, so plenty of real apps
+// still ship it. We render it here purely as the BEFORE in a before/after against
+// its maintained successor (yet-another-react-lightbox, the next gallery). The
+// investigation's recommendation was to migrate to that successor; this page
+// lets you compare them in the same context.
+//
+// ─── SSR SAFETY NOTE ─────────────────────────────────────────────────────────
+// react-image-lightbox calls global.window/new global.Image() *during render* of
+// its <Lightbox>. That's fine here for two reasons:
+//   1. We only mount <Lightbox> when an image is open (index !== null) — which is
+//      a client-only state, so it never renders during SSR/RSC prerender.
+//   2. This repo bundles with rspack (node.global = true), so `global` resolves
+//      in the browser bundle. (Under Vite/esbuild it would need a `global`
+//      shim — a gotcha the investigation hit and worth remembering.)
+// Its stylesheet is imported globally in stylesheets/application.css (not here),
+// matching how the repo handles vendor CSS (e.g. highlight.js).
+import React, { useState } from 'react';
+import Lightbox from 'react-image-lightbox';
+import { LightboxThumbGrid } from './LightboxThumbGrid';
+import type { GalleryImage } from './types';
+
+interface Props {
+  images: GalleryImage[];
+}
+
+export function ReactImageLightboxGallery({ images }: Props) {
+  // null = closed (the SSR/initial state → <Lightbox> not mounted).
+  const [index, setIndex] = useState<number | null>(null);
+  const count = images.length;
+  const current = index ?? 0;
+
+  return (
+    <>
+      <LightboxThumbGrid images={images} onOpen={setIndex} label="react-image-lightbox" />
+
+      {index !== null && (
+        <Lightbox
+          mainSrc={images[current].full_src}
+          nextSrc={images[(current + 1) % count].full_src}
+          prevSrc={images[(current + count - 1) % count].full_src}
+          onCloseRequest={() => setIndex(null)}
+          onMovePrevRequest={() => setIndex((current + count - 1) % count)}
+          onMoveNextRequest={() => setIndex((current + 1) % count)}
+          imageTitle={images[current].alt}
+          imageCaption={images[current].caption}
+        />
+      )}
+    </>
+  );
+}

--- a/app/javascript/components/multimedia/ReactImageLightboxGalleryForServer.tsx
+++ b/app/javascript/components/multimedia/ReactImageLightboxGalleryForServer.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+// ForServer wrapper — the 'use client' boundary for ReactImageLightboxGallery.
+// Keeps react-image-lightbox (+ react-modal) in the client graph, out of RSC.
+export { ReactImageLightboxGallery } from './ReactImageLightboxGallery';

--- a/app/javascript/components/multimedia/ReactPlayerLightVideo.tsx
+++ b/app/javascript/components/multimedia/ReactPlayerLightVideo.tsx
@@ -1,0 +1,112 @@
+// ReactPlayerLightVideo — VIDEO demo #1: react-player v3 in "light" (facade) mode.
+//
+// NO 'use client' directive here on purpose. This is the repo's client-island
+// convention: the interactive component carries no directive and is pulled into
+// the client graph through its sibling *ForServer.tsx wrapper (which DOES carry
+// 'use client'). See ProductImageGallery / ProductImageGalleryForServer for the
+// same split. That keeps the RSC page's chunk group clean.
+//
+// ─── WHY THIS IS BUILT THE WAY IT IS (from the react-player web-vitals study) ───
+// The v2-vs-v3 benchmark found react-player v3 ships ~90 KB more critical JS than
+// v2 and bundles hls.js (~162 KB) as a SAME-ORIGIN chunk. With a naive mount,
+// that JS sits on the critical path and LCP regresses badly under CPU throttle
+// (desktop-4×: ~800 ms vs ~180 ms) — the player must download → parse → execute →
+// upgrade its custom element before the poster even paints. Two fixes from that
+// study are applied here:
+//
+//   1. LIGHT MODE (light={poster}). react-player renders ONLY the poster + a play
+//      icon and defers downloading the hls.js engine until the user clicks. For a
+//      page that could hold many videos, that's the biggest bandwidth/LCP win —
+//      N posters instead of N streaming engines.
+//
+//   2. DEFER THE PLAYER MODULE ITSELF. We import('react-player') lazily, after
+//      hydration, client-side only. Benefits: (a) react-player builds on
+//      web-component custom elements that assume a browser, so keeping it out of
+//      SSR avoids fragility; (b) the server-rendered poster paints first and is
+//      the LCP element; (c) the player JS never blocks first paint. While the
+//      lazy chunk loads we also hand react-player `fallback={<poster img>}` —
+//      the study specifically flagged that v3's default Suspense fallback is
+//      `null`, so nothing paints during load unless you supply an <img>.
+import React, { useEffect, useState, type ComponentType } from 'react';
+import type { VideoManifest } from './types';
+
+// react-player v3's prop types are broad; we only need it as a component here.
+type ReactPlayerComponent = ComponentType<Record<string, unknown>>;
+
+interface Props {
+  video: VideoManifest;
+  // First video on the page → its poster is the likely LCP element, so load it
+  // eagerly with high priority. Below-the-fold videos stay lazy.
+  priority?: boolean;
+}
+
+// Plain poster image that fills the 16:9 box. Server-rendered (and shown while
+// react-player's lazy chunk loads) so the slot is never empty → CLS ~0, fast LCP.
+function PosterImage({ video, priority }: { video: VideoManifest; priority?: boolean }) {
+  return (
+    <img
+      src={video.poster}
+      alt={`Poster frame for ${video.title}`}
+      width={video.width}
+      height={video.height}
+      className="absolute inset-0 h-full w-full object-cover"
+      // fetchPriority/loading mirror the LCP guidance used elsewhere in the repo
+      // (SearchResultCard, ProductImageGallery).
+      fetchPriority={priority ? 'high' : 'auto'}
+      loading={priority ? 'eager' : 'lazy'}
+      decoding="async"
+    />
+  );
+}
+
+export function ReactPlayerLightVideo({ video, priority }: Props) {
+  const [Player, setPlayer] = useState<ReactPlayerComponent | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    // Dynamic import → react-player lands in its own chunk, fetched only after
+    // this island hydrates (never during SSR, never on the critical path).
+    import('react-player')
+      .then((mod) => {
+        if (alive) setPlayer(() => mod.default as ReactPlayerComponent);
+      })
+      .catch(() => undefined);
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return (
+    <figure className="m-0">
+      {/* Fixed 16:9 box reserves the slot BEFORE the player or poster loads. */}
+      <div
+        className="relative w-full overflow-hidden rounded-xl bg-slate-900 shadow-sm ring-1 ring-slate-200"
+        style={{ aspectRatio: '16 / 9' }}
+      >
+        {Player ? (
+          <Player
+            src={video.src}
+            // ── light/facade mode: poster + play icon, hls.js loaded on click ──
+            light={video.poster}
+            // ── fallback that paints while react-player's lazy chunk loads ──
+            fallback={<PosterImage video={video} priority={priority} />}
+            controls
+            playsInline
+            width="100%"
+            height="100%"
+            previewAriaLabel={`Play ${video.title}`}
+            style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
+          />
+        ) : (
+          // SSR + pre-hydration: just the poster.
+          <PosterImage video={video} priority={priority} />
+        )}
+      </div>
+      <figcaption className="mt-2 text-sm text-slate-500">
+        <span className="font-semibold text-slate-700">{video.title}.</span>{' '}
+        Click to play — the hls.js engine and the player module are both fetched
+        on demand (light/facade mode), so the page loads only this poster frame.
+      </figcaption>
+    </figure>
+  );
+}

--- a/app/javascript/components/multimedia/ReactPlayerLightVideoForServer.tsx
+++ b/app/javascript/components/multimedia/ReactPlayerLightVideoForServer.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+// ForServer wrapper — the 'use client' boundary for ReactPlayerLightVideo.
+// The RSC server component (MediaGalleryRSC) imports THIS file; everything it
+// pulls in (react-player, loaded lazily inside the island) becomes client code
+// and stays out of the RSC bundle. Same pattern as ProductImageGalleryForServer.
+export { ReactPlayerLightVideo } from './ReactPlayerLightVideo';

--- a/app/javascript/components/multimedia/VanillaHlsVideo.tsx
+++ b/app/javascript/components/multimedia/VanillaHlsVideo.tsx
@@ -1,0 +1,119 @@
+// VanillaHlsVideo — VIDEO demo #2: a hand-rolled <video> + hls.js, no player lib.
+//
+// NO 'use client' (same client-island convention as ReactPlayerLightVideo —
+// the directive lives in VanillaHlsVideoForServer.tsx).
+//
+// ─── WHY THIS EXISTS / WHAT THE EXPERIMENTS TAUGHT ───────────────────────────
+// The "best-of-both" hls.js study showed you don't need a player library at all
+// for hosted HLS. The cross-browser core is tiny and well-understood:
+//
+//   • DETECTION ORDER: try Hls.isSupported() (MSE path) FIRST, native HLS
+//     (canPlayType('application/vnd.apple.mpegurl')) only as a fallback. This is
+//     deliberately the OPPOSITE of "check native first to save the download":
+//     desktop Chrome's canPlayType returns "maybe" for HLS, so a native-first
+//     order silently SKIPS hls.js on the very browsers that need it — a real bug
+//     the vanilla benchmark hit (its great numbers were native playback, not the
+//     hls.js path most users actually take). MSE-first = consistent everywhere.
+//
+//   • FACADE / DEFERRED LOAD: hls.js (~162 KB) is dynamically import()ed only on
+//     the first user click, and <video preload="none"> means no media bytes are
+//     fetched until then either. Same light-mode win as the react-player demo,
+//     done by hand: the page initially ships ZERO video JS — just a poster.
+//
+//   • CLS: the <video> lives in a fixed 16:9 box with a real poster, so the slot
+//     never reflows when playback finally attaches.
+//
+//   • CLEANUP: hls.destroy() on unmount (SPA-safe; avoids leaked buffers/loaders).
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import type Hls from 'hls.js';
+import type { VideoManifest } from './types';
+
+interface Props {
+  video: VideoManifest;
+}
+
+export function VanillaHlsVideo({ video }: Props) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const hlsRef = useRef<Hls | null>(null);
+  const [active, setActive] = useState(false);
+
+  // Tear down hls.js when the component unmounts (route change / navigation).
+  useEffect(
+    () => () => {
+      hlsRef.current?.destroy();
+      hlsRef.current = null;
+    },
+    [],
+  );
+
+  const activate = useCallback(async () => {
+    const el = videoRef.current;
+    if (!el || active) return;
+    setActive(true);
+
+    // Dynamic import → hls.js is a separate chunk fetched only now, on demand.
+    const { default: HlsLib } = await import('hls.js');
+
+    if (HlsLib.isSupported()) {
+      // MSE path (Chrome/Firefox/desktop Safari/Android): hls.js feeds the buffer.
+      const hls = new HlsLib({ enableWorker: true });
+      hlsRef.current = hls;
+      hls.loadSource(video.src);
+      hls.attachMedia(el);
+      // Autoplay (muted policy already satisfied below) once the manifest is in.
+      hls.on(HlsLib.Events.MANIFEST_PARSED, () => {
+        el.play().catch(() => undefined);
+      });
+    } else if (el.canPlayType('application/vnd.apple.mpegurl')) {
+      // Native HLS fallback (iOS Safari / older Safari with no MSE): just set src.
+      el.src = video.src;
+      el.play().catch(() => undefined);
+    }
+  }, [active, video.src]);
+
+  return (
+    <figure className="m-0">
+      <div
+        className="relative w-full overflow-hidden rounded-xl bg-black shadow-sm ring-1 ring-slate-200"
+        style={{ aspectRatio: '16 / 9' }}
+      >
+        <video
+          ref={videoRef}
+          poster={video.poster}
+          width={video.width}
+          height={video.height}
+          // controls appear only once activated so the facade owns the first click.
+          controls={active}
+          playsInline
+          muted
+          // No media bytes until the user plays.
+          preload="none"
+          className="absolute inset-0 h-full w-full object-cover"
+        />
+
+        {/* Click-to-load facade: a play button over the poster. Hidden once
+            activated. This is what defers BOTH the hls.js download and the media
+            bytes until intent is shown. */}
+        {!active && (
+          <button
+            type="button"
+            onClick={activate}
+            aria-label={`Play ${video.title}`}
+            className="group absolute inset-0 flex items-center justify-center bg-black/10 transition hover:bg-black/0"
+          >
+            <span className="flex h-16 w-16 items-center justify-center rounded-full bg-black/55 ring-1 ring-white/30 backdrop-blur-sm transition group-hover:scale-110 group-hover:bg-black/70">
+              <svg className="ml-1 h-7 w-7 text-white" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M8 5v14l11-7z" />
+              </svg>
+            </span>
+          </button>
+        )}
+      </div>
+      <figcaption className="mt-2 text-sm text-slate-500">
+        <span className="font-semibold text-slate-700">{video.title}.</span>{' '}
+        Feature-detected (MSE-first, native HLS fallback). hls.js is downloaded
+        only on click; the page ships no video JS up front.
+      </figcaption>
+    </figure>
+  );
+}

--- a/app/javascript/components/multimedia/VanillaHlsVideoForServer.tsx
+++ b/app/javascript/components/multimedia/VanillaHlsVideoForServer.tsx
@@ -1,0 +1,6 @@
+'use client';
+
+// ForServer wrapper — the 'use client' boundary for VanillaHlsVideo.
+// MediaGalleryRSC (server) imports this; hls.js (lazy-loaded inside the island)
+// is thereby kept entirely in the client graph.
+export { VanillaHlsVideo } from './VanillaHlsVideo';

--- a/app/javascript/components/multimedia/YetAnotherLightboxGallery.tsx
+++ b/app/javascript/components/multimedia/YetAnotherLightboxGallery.tsx
@@ -1,0 +1,49 @@
+// YetAnotherLightboxGallery — GALLERY demo #2: yet-another-react-lightbox.
+//
+// NO 'use client' (directive lives in YetAnotherLightboxGalleryForServer.tsx).
+//
+// ─── WHY THIS LIBRARY (the recommended successor) ────────────────────────────
+// yet-another-react-lightbox (v3, ~448k downloads/week) is the actively-
+// maintained replacement the investigation recommended over react-image-lightbox.
+// It declares React 16–19 peer deps, is SSR-safe by design, and has a cleaner
+// controlled API: a single <Lightbox open index slides close/> instead of the
+// older library's mainSrc/prevSrc/nextSrc + six move/close callbacks. Compare
+// the two source files side by side to feel the difference.
+//
+// Its stylesheet is imported globally in stylesheets/application.css.
+import React, { useState } from 'react';
+import Lightbox from 'yet-another-react-lightbox';
+import { LightboxThumbGrid } from './LightboxThumbGrid';
+import type { GalleryImage } from './types';
+
+interface Props {
+  images: GalleryImage[];
+}
+
+export function YetAnotherLightboxGallery({ images }: Props) {
+  // -1 = closed. yet-another-react-lightbox renders nothing when open={false},
+  // so this is SSR-safe even though we always include the element in the tree.
+  const [index, setIndex] = useState(-1);
+
+  // The full-resolution slides. width/height let the lightbox size correctly.
+  const slides = images.map((img) => ({
+    src: img.full_src,
+    alt: img.alt,
+    description: img.caption,
+    width: 1600,
+    height: 1067,
+  }));
+
+  return (
+    <>
+      <LightboxThumbGrid images={images} onOpen={setIndex} label="yet-another-react-lightbox" />
+
+      <Lightbox
+        open={index >= 0}
+        index={index < 0 ? 0 : index}
+        close={() => setIndex(-1)}
+        slides={slides}
+      />
+    </>
+  );
+}

--- a/app/javascript/components/multimedia/YetAnotherLightboxGalleryForServer.tsx
+++ b/app/javascript/components/multimedia/YetAnotherLightboxGalleryForServer.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+// ForServer wrapper — the 'use client' boundary for YetAnotherLightboxGallery.
+// Keeps yet-another-react-lightbox in the client graph, out of the RSC bundle.
+export { YetAnotherLightboxGallery } from './YetAnotherLightboxGallery';

--- a/app/javascript/components/multimedia/types.ts
+++ b/app/javascript/components/multimedia/types.ts
@@ -1,0 +1,38 @@
+// Shared types for the /media-gallery RSC page.
+//
+// NO 'use client' here — this file is plain type declarations imported by both
+// the server component (MediaGalleryRSC) and the client islands. Types are
+// erased at build time, so it lands in neither bundle's runtime.
+//
+// Keys are snake_case because they come straight from MediaGalleryData (Ruby).
+// We keep the wire shape verbatim rather than camelCasing in a mapping layer —
+// same convention the restaurant/product pages use.
+
+export interface VideoManifest {
+  src: string;
+  poster: string;
+  title: string;
+  width: number;
+  height: number;
+}
+
+export interface GalleryImage {
+  id: string;
+  thumb_src: string;
+  srcset: string;
+  sizes: string;
+  width: number;
+  height: number;
+  full_src: string;
+  alt: string;
+  caption: string;
+}
+
+export interface MediaGalleryProps {
+  intro_markdown: string;
+  closing_markdown: string;
+  react_player_video: VideoManifest;
+  vanilla_video: VideoManifest;
+  ril_gallery: GalleryImage[];
+  yarl_gallery: GalleryImage[];
+}

--- a/app/javascript/startup/MediaGalleryRSC.tsx
+++ b/app/javascript/startup/MediaGalleryRSC.tsx
@@ -1,0 +1,4 @@
+// Auto-registered as component "MediaGalleryRSC" (basename of this startup file).
+// Plain re-export, no 'use client' — it's a server component. Mirrors
+// startup/RestaurantDetailRSC.tsx.
+export { default } from '../components/multimedia/MediaGalleryRSC';

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -1,5 +1,11 @@
 @import 'highlight.js/styles/github-dark.css';
 
+/* Lightbox vendor CSS for the /media-gallery page. Imported here (the global CSS
+   pipeline) rather than inside the React islands, matching how this repo handles
+   vendor CSS like highlight.js above — keeps CSS out of the SSR/RSC JS bundles. */
+@import 'react-image-lightbox/style.css';
+@import 'yet-another-react-lightbox/styles.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/app/services/media_gallery_data.rb
+++ b/app/services/media_gallery_data.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+# MediaGalleryData — server-side manifest for the /media-gallery RSC demo page.
+#
+# WHY a data service (mirrors RestaurantDetailData.for / the repo convention):
+# the whole "media manifest" (which videos, which images, their posters, srcsets,
+# captions) is assembled ONCE on the server and handed to the RSC tree as props.
+# Nothing about *what* to render needs the browser, so it stays here. Only the
+# interactive players/lightboxes become client islands (see app/javascript/components/multimedia).
+#
+# This page is the landing point for a series of standalone experiments
+# (react-player v2-vs-v3 web-vitals, an hls.js best-of-both player, and a
+# react-image-lightbox vs yet-another-react-lightbox comparison). The asset
+# choices below are deliberate and encode findings from those experiments —
+# see the inline notes.
+class MediaGalleryData
+  # Returns the full props hash for MediaGalleryRSC. Snake_case keys to match the
+  # repo convention (the TS layer maps them) — see RestaurantDetailData#build.
+  def self.build
+    new.build
+  end
+
+  def build
+    {
+      intro_markdown: INTRO_MARKDOWN,
+      closing_markdown: CLOSING_MARKDOWN,
+      react_player_video: react_player_video,
+      vanilla_video: vanilla_video,
+      ril_gallery: gallery(RIL_IMAGE_IDS, 'ril'),
+      yarl_gallery: gallery(YARL_IMAGE_IDS, 'yarl')
+    }
+  end
+
+  private
+
+  # ---------------------------------------------------------------------------
+  # VIDEO 1 — react-player v3 in "light" mode.
+  #
+  # Source: Mux's public test asset. We use Mux specifically because the video
+  # experiments found that raw HLS hosts (Apple BipBop, plain .m3u8) have NO
+  # thumbnail service, whereas Mux exposes a real-frame image endpoint
+  # (image.mux.com/{id}/thumbnail.jpg?time=) — so the poster is an actual frame
+  # of the video, not a placeholder. A matching poster is what makes light mode
+  # (and the LCP story) honest: the same image the player shows before play.
+  # ---------------------------------------------------------------------------
+  MUX_PLAYBACK_ID = 'DS00Spx1CV902MCtPj5WknGlR102V5HFkDe'
+
+  def react_player_video
+    {
+      src: "https://stream.mux.com/#{MUX_PLAYBACK_ID}.m3u8",
+      poster: "https://image.mux.com/#{MUX_PLAYBACK_ID}/thumbnail.jpg?width=1280&height=720&fit_mode=smartcrop&time=12",
+      title: 'react-player v3 — light (facade) mode',
+      width: 1280,
+      height: 720
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # VIDEO 2 — vanilla <video> + hls.js (no React player library).
+  #
+  # Source: the classic Tears-of-Steel test stream on Mux's CDN. The experiments
+  # used this exact stream; it has NO companion image service (image.mux.com only
+  # works for real playback IDs, not this legacy path — confirmed 404 in the
+  # experiment), which is precisely why we must supply our OWN poster here. That
+  # contrast (Mux real-frame poster above vs. self-supplied poster here) is a
+  # deliberate teaching point.
+  # ---------------------------------------------------------------------------
+  def vanilla_video
+    {
+      src: 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8',
+      # Self-supplied poster (the stream has no thumbnail endpoint). Picsum gives
+      # us a stable, openly-licensed 16:9 image with explicit dimensions so the
+      # <video> reserves the right box and CLS stays ~0 before playback.
+      poster: 'https://picsum.photos/seed/hls-vanilla-poster/1280/720',
+      title: 'vanilla <video> + hls.js',
+      width: 1280,
+      height: 720
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # IMAGE GALLERIES.
+  #
+  # Two galleries render the SAME kind of responsive image grid but open two
+  # different lightbox libraries, so you can compare them side by side:
+  #   - react-image-lightbox (deprecated/archived, still ~130k downloads/wk)
+  #   - yet-another-react-lightbox (its actively-maintained, React-19 successor)
+  # The lightbox-library investigation recommended migrating to the latter; this
+  # page lets you feel the difference in the same context.
+  #
+  # Picsum is used (not the local /seed-images) because it serves arbitrary
+  # dimensions on demand, which lets us build a REAL responsive srcset
+  # (400w/800w/1200w) — one of the issue's acceptance criteria. Each image has
+  # explicit width/height (intrinsic 3:2) so the grid reserves layout space and
+  # CLS stays ~0; below-the-fold thumbs lazy-load.
+  # ---------------------------------------------------------------------------
+  RIL_IMAGE_IDS = [1015, 1016, 1018, 1019, 1024, 1025, 1033, 1036].freeze
+  YARL_IMAGE_IDS = [1037, 1038, 1039, 1043, 1044, 1047, 1050, 1051].freeze
+
+  THUMB_W = 600
+  THUMB_H = 400 # 3:2
+
+  def gallery(ids, key_prefix)
+    ids.map { |id| image_entry(id, key_prefix) }
+  end
+
+  # Grid columns: 4 on desktop, 2 on tablet, 1 on phone — drives the `sizes` hint.
+  THUMB_SIZES = '(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw'
+
+  def image_entry(id, key_prefix)
+    {
+      id: "#{key_prefix}-#{id}",
+      thumb_src: picsum(id, THUMB_W, THUMB_H), srcset: thumb_srcset(id), sizes: THUMB_SIZES,
+      width: THUMB_W, height: THUMB_H,
+      full_src: picsum(id, 1600, 1067), # full-resolution image opened in the lightbox
+      alt: "Open-licensed photo ##{id} from the Lorem Picsum collection",
+      caption: "Lorem Picsum ##{id} — responsive srcset (400/800/1200w), explicit 3:2 box, lazy below the fold."
+    }
+  end
+
+  # Builds the responsive srcset string the browser uses to pick a file size.
+  def thumb_srcset(id)
+    [
+      "#{picsum(id, 400, 267)} 400w",
+      "#{picsum(id, 800, 533)} 800w",
+      "#{picsum(id, 1200, 800)} 1200w"
+    ].join(', ')
+  end
+
+  def picsum(id, width, height)
+    "https://picsum.photos/id/#{id}/#{width}/#{height}"
+  end
+
+  INTRO_MARKDOWN = <<~MD
+    # Multimedia showcase
+
+    A media-heavy page rendered the **React Server Components** way: the page shell,
+    section layout, and this very copy are produced on the server and stream as
+    HTML — **zero** of this text ships as JavaScript. Only the genuinely interactive
+    pieces (the two video players and the two image lightboxes) hydrate as small
+    **client islands**.
+
+    Everything below distills hands-on experiments into one page:
+
+    - **Video, two ways** — `react-player` v3 in *light/facade* mode vs. a hand-rolled
+      `<video>` + `hls.js`. Both defer the heavy player/streaming JS until you click,
+      which is the single biggest LCP win the benchmarks found.
+    - **Image gallery, two ways** — the same responsive grid wired to
+      `react-image-lightbox` and to its maintained successor
+      `yet-another-react-lightbox`.
+
+    Read the code comments for *why* each choice was made — they cite the
+    measurements behind them.
+  MD
+
+  CLOSING_MARKDOWN = <<~MD
+    ## Why this is CLS-safe
+
+    Every media slot reserves its space **before** the heavy widget loads: videos sit
+    in a fixed `16:9` box behind a real poster frame, and gallery thumbnails declare
+    explicit `width`/`height` (intrinsic `3:2`). So when `hls.js`, `react-player`, or a
+    lightbox finally hydrates, nothing reflows — Cumulative Layout Shift stays ~0.
+
+    This mirrors the established SSR / Client / RSC demo pages: the markup you can
+    render on the server, we render on the server; the browser only gets JavaScript
+    for the parts that truly need it.
+  MD
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -447,6 +447,23 @@
         bundle_anchor: "product-search",
       } %>
 
+      <!-- Multimedia Showcase card — single RSC page (image galleries + HLS video). -->
+      <a href="/media-gallery" class="reveal demo-card bg-white rounded-2xl border border-slate-200 p-6 block group">
+        <div class="w-10 h-10 bg-pink-100 rounded-xl flex items-center justify-center mb-4">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><rect x="3" y="4" width="14" height="12" rx="2" stroke="#db2777" stroke-width="1.5"/><path d="M8 8.5l4 2.5-4 2.5z" fill="#db2777"/></svg>
+        </div>
+        <h3 class="font-bold text-slate-900 mb-2">Multimedia Showcase</h3>
+        <p class="text-sm text-slate-500 mb-4">HLS video (react-player light mode + vanilla hls.js) and responsive image galleries (react-image-lightbox + yet-another-react-lightbox), rendered RSC-first.</p>
+        <div class="flex items-center gap-2 text-xs">
+          <span class="rounded-full bg-green-50 border border-green-200 px-2 py-0.5 text-green-700 font-semibold">RSC</span>
+          <span class="rounded-full bg-pink-50 border border-pink-200 px-2 py-0.5 text-pink-700 font-semibold">Video</span>
+          <span class="rounded-full bg-pink-50 border border-pink-200 px-2 py-0.5 text-pink-700 font-semibold">Galleries</span>
+        </div>
+        <span class="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-pink-600 group-hover:text-pink-700 transition-colors">
+          Open showcase <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </span>
+      </a>
+
       <!-- Performance Showcase card -->
       <a href="/rsc-performance" class="reveal demo-card bg-gradient-to-br from-indigo-50 to-purple-50 rounded-2xl border border-indigo-200 p-6 block group">
         <div class="w-10 h-10 bg-indigo-100 rounded-xl flex items-center justify-center mb-4">

--- a/app/views/media_gallery/show_rsc.html.erb
+++ b/app/views/media_gallery/show_rsc.html.erb
@@ -1,0 +1,6 @@
+<%#
+  RSC streaming entry point. Same shape as restaurants/show_rsc.html.erb:
+  stream_react_component renders MediaGalleryRSC (a server component) and flushes
+  its HTML section-by-section. The whole @gallery manifest is passed as props.
+%>
+<%= stream_react_component("MediaGalleryRSC", props: @gallery, prerender: true) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,11 @@ Rails.application.routes.draw do
   get '/measure' => 'pages#measure'
   get '/lh-compare' => 'pages#lh_compare', as: :lh_compare
 
+  # Multimedia showcase — media-heavy page (HLS video + responsive image galleries).
+  # RSC-first single page (issue #98). Both paths hit the same RSC action.
+  get '/media-gallery', to: 'media_gallery#show_rsc', as: :media_gallery
+  get '/media-gallery/rsc', to: 'media_gallery#show_rsc'
+
   # Restaurant detail page — three versions for the markdown-heavy detail view
   get '/restaurant/:id/ssr', to: 'restaurants#show_ssr', as: :restaurant_show_ssr
   get '/restaurant/:id/client', to: 'restaurants#show_client', as: :restaurant_show_client

--- a/package.json
+++ b/package.json
@@ -39,18 +39,22 @@
     "date-fns": "^4.1.0",
     "gray-matter": "^4.0.3",
     "highlight.js": "^11.11.1",
+    "hls.js": "^1.6.16",
     "intl-messageformat": "^11.2.4",
     "marked": "^17.0.2",
     "marked-highlight": "^2.2.3",
     "react": "19.2.7",
     "react-dom": "19.2.7",
+    "react-image-lightbox": "^5.1.4",
     "react-on-rails-pro": "17.0.0-rc.6",
     "react-on-rails-pro-node-renderer": "17.0.0-rc.6",
     "react-on-rails-rsc": "19.2.0-rc.4",
+    "react-player": "^3.4.0",
     "react-server-dom-webpack": "19.2.7",
     "sanitize-html": "^2.17.3",
     "simple-statistics": "^7.8.9",
-    "web-vitals": "^4.2.0"
+    "web-vitals": "^4.2.0",
+    "yet-another-react-lightbox": "^3.32.0"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
+      hls.js:
+        specifier: ^1.6.16
+        version: 1.6.16
       intl-messageformat:
         specifier: ^11.2.4
         version: 11.2.4
@@ -70,6 +73,9 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
+      react-image-lightbox:
+        specifier: ^5.1.4
+        version: 5.1.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-on-rails-pro:
         specifier: 17.0.0-rc.6
         version: 17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.0-rc.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4))(react@19.2.7)
@@ -79,6 +85,9 @@ importers:
       react-on-rails-rsc:
         specifier: 19.2.0-rc.4
         version: 19.2.0-rc.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
+      react-player:
+        specifier: ^3.4.0
+        version: 3.4.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-server-dom-webpack:
         specifier: 19.2.7
         version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
@@ -91,6 +100,9 @@ importers:
       web-vitals:
         specifier: ^4.2.0
         version: 4.2.4
+      yet-another-react-lightbox:
+        specifier: ^3.32.0
+        version: 3.32.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.0
@@ -1347,6 +1359,31 @@ packages:
     peerDependencies:
       webpack: '>=4.6.0'
 
+  '@mux/mux-data-google-ima@0.3.17':
+    resolution: {integrity: sha512-4wpH6dYybyZhqLn9qGn/+67Z8MZnQRAdqTFEEZw2bx61M9q01uPYYHxd8qwOnYtUGEeafsdTwVHVxKHGD3oc1A==}
+
+  '@mux/mux-player-react@3.13.0':
+    resolution: {integrity: sha512-7IkImo1H3rUYeuWHI/L0L7sGUqBvZCvptx3+4igc+P/V3WgqNFjOyQlcyxzxgXNtNNhGmkn5NaF3TU9DPbOmAQ==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0
+      '@types/react-dom': '*'
+      react: ^17.0.2 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0
+      react-dom: ^17.0.2 || ^17.0.2-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@mux/mux-player@3.13.0':
+    resolution: {integrity: sha512-vh4CIMahUa29gys+mlfsOFKYKAKXxE07jSWk9WZxkdpGBW1fKfCQXlNxBoAIQlPa9Uk4MZuM3HVgqdW6aTuaZg==}
+
+  '@mux/mux-video@0.31.0':
+    resolution: {integrity: sha512-DvO2GynIJhPDc0LMuWvC144lCF+E07NI+chrg/vcRQlCf2fPdNNqCSMoaRdWu2S2v/Orsc85giT9K6GRbjbzgA==}
+
+  '@mux/playback-core@0.35.0':
+    resolution: {integrity: sha512-7Zi1EJ9sQNIUlQVBjJCXV0CB+rUVEsU3vNRElRV4xnD7dbpoioIAhe1SjZNBifjnK5aBKLDwQHypbnL3Cw3a5A==}
+
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
@@ -1607,6 +1644,68 @@ packages:
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
+
+  '@svta/cml-608@1.0.2':
+    resolution: {integrity: sha512-ZEJ68330gcLKfvVv6Qifr1HR7+GldDUxzkjqSbqRK7jHtHSLSV1JAyDwlYe8+C7ABuY1bp8MpgJ4/Gg+jl+pLQ==}
+    engines: {node: '>=20'}
+
+  '@svta/cml-cmcd@2.3.2':
+    resolution: {integrity: sha512-SKBBjLmci0WK8HMjuv+36tVIMktonoOoxsXblOFZmB+ePPV2zjRMTD+2ZmE/1VEPJkKHENyhSjSHgJyeOlvZ1A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-structured-field-values': 1.1.3
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-cmsd@1.0.6':
+    resolution: {integrity: sha512-LUORV6bb0TbU4rSC2HoPqUCix1igLrXkRQXWiIyJo2OMzb14kAK/1jsW0mzY6up6w1GrjKQcjc6OwqJdo/zd/g==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-cta': 1.0.6
+      '@svta/cml-structured-field-values': 1.1.3
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-cta@1.0.6':
+    resolution: {integrity: sha512-l13/4myTX1EbRd38nY8J1umVY5UdR/nZO6CeKqVLXnMMIayg7/fu0TueZckjTA9Loal55MGK1xbHnXVjz7OUUw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-structured-field-values': 1.1.3
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-dash@1.0.6':
+    resolution: {integrity: sha512-4XtHYlPrzL/dRe/8XmRQoLnTo9S86tISgrl67eUqKl5MtNTpZBYTncuPrspslPZPZROBBWNrBuepYfYUtU9CKA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-id3@1.0.6':
+    resolution: {integrity: sha512-63j8gkAnPOmOBWlp0hIZPvsIioZttdbg6/TgwITqMYbSLYVJ+6QGa/UtIP0I84NsfstANw6QdCn7i8SS08kn1A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-request@1.0.12':
+    resolution: {integrity: sha512-4sJvnnoNpq58j2mCGP8k+MF6wVy/qa4gbt6kfT1dPIKmn3mPxw+JVfilhcWsUi+peK2yCZxOJJYyHj1cAcQE1w==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-cmcd': 2.3.2
+      '@svta/cml-utils': 1.5.0
+      '@svta/cml-xml': 1.1.4
+
+  '@svta/cml-structured-field-values@1.1.3':
+    resolution: {integrity: sha512-XqLzQOTznz6kh/nsSh8dy1kV7GQjL4csG+2U5EvLGhAqNuNUczbVg5EAsDobKDVg8xhdthdXx2UuwM+ZHQCxSg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-utils@1.5.0':
+    resolution: {integrity: sha512-JMqclD7Akd+GSJiuaYNUHOP2wNtf/nauKeszlYeivSHfi0Lp3pmSW5PXDvJ2dO4aPmmSOQbF0ztTsW9Vcs2Whw==}
+    engines: {node: '>=20'}
+
+  '@svta/cml-xml@1.1.4':
+    resolution: {integrity: sha512-jbixqjiJIc16SGxylHwiOzO+DuhkGfuP+fJ9AHeVJKdFDKnabgfCDpnp6dvZpZnjMj4nHvzVtuUV7RISPIwYXw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-utils': 1.5.0
 
   '@swc/core-darwin-arm64@1.15.21':
     resolution: {integrity: sha512-SA8SFg9dp0qKRH8goWsax6bptFE2EdmPf2YRAQW9WoHGf3XKM1bX0nd5UdwxmC5hXsBUZAYf7xSciCler6/oyA==}
@@ -1873,6 +1972,9 @@ packages:
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@vimeo/player@2.29.0':
+    resolution: {integrity: sha512-9JjvjeqUndb9otCCFd0/+2ESsLk7VkDE6sxOBy9iy2ukezuQbplVRi+g9g59yAurKofbmTi/KcKxBGO/22zWRw==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -2191,6 +2293,9 @@ packages:
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
 
+  bcp-47-match@2.0.3:
+    resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
+
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
@@ -2264,6 +2369,14 @@ packages:
   caniuse-lite@1.0.30001780:
     resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
 
+  castable-video@1.1.16:
+    resolution: {integrity: sha512-wBhe2dZu2afhewL3EaGgVYTyDsa9HvNhY98clMZkNzDrLelOValSrTaoMos9YX7PPBCrgpd1j6YmNyyI2Vbq3w==}
+
+  ce-la-react@0.3.2:
+    resolution: {integrity: sha512-QJ6k4lOD/btI08xG8jBPxRCGXvCnusGGkTsiXk0u3NqUu/W+BXRnFD4PYjwtqh8AWmGa5LDbGk0fLQsqr0nSMA==}
+    peerDependencies:
+      react: '>=17.0.0'
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2296,6 +2409,12 @@ packages:
   clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
     engines: {node: '>=6'}
+
+  cloudflare-video-element@1.3.5:
+    resolution: {integrity: sha512-zj9gjJa6xW8MNrfc4oKuwgGS0njRLpOlQjdifbuNxvy8k4Y3pKCyKCMG2XIsjd2iQGhgjS57b1P5VWdJlxcXBw==}
+
+  codem-isoboxer@0.3.10:
+    resolution: {integrity: sha512-eNk3TRV+xQMJ1PEj0FQGY8KD4m0GPxT487XJ+Iftm7mVa9WpPFDMWqPt+46buiP5j5Wzqe5oMIhqBcAeKfygSA==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2421,6 +2540,9 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  custom-media-element@1.4.6:
+    resolution: {integrity: sha512-/HRYqJOa1ob5ik4q7FIJVYxTJCFs/FL3+cQPAJjUf2uiqrDEzbTgB315gQ2rG8oK3w094W9m5tcB8S5Qah+caA==}
+
   d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
     engines: {node: '>=12'}
@@ -2456,6 +2578,13 @@ packages:
   d3-time@3.1.0:
     resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
     engines: {node: '>=12'}
+
+  dash-video-element@0.3.2:
+    resolution: {integrity: sha512-eN1IqgtTAbq4zVkbt82BDwQtybQ6WOXyQU5HbftUSnqo+SHAPbZCif1Y7uViAhgvuEPvZtbiXDiacvvTeGxc/g==}
+
+  dashjs@5.2.0:
+    resolution: {integrity: sha512-2W2KHFN53Sk7+rtdnIfSUK/3Oov+hraMTeVZwDOTSCNKM1cQtFiJdblNzRMnl59a/QDseG7JW+PC9mh/B+CMcg==}
+    engines: {node: '>=20'}
 
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
@@ -2763,6 +2892,9 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  exenv@1.2.2:
+    resolution: {integrity: sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==}
+
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
@@ -3035,6 +3167,12 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
+  hls-video-element@1.5.11:
+    resolution: {integrity: sha512-tJJ65/52CDxj8XFyIve6zT9nVVdUIc6mqvKR25X0ycPKHk07rpjp4xxVteeCefDUBSf/tFLhlICFmn3KWj37xA==}
+
+  hls.js@1.6.16:
+    resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
+
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
@@ -3100,6 +3238,9 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   immutable@5.1.5:
     resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
 
@@ -3111,6 +3252,9 @@ packages:
     resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
     engines: {node: '>=8'}
     hasBin: true
+
+  imsc@1.1.5:
+    resolution: {integrity: sha512-V8je+CGkcvGhgl2C1GlhqFFiUOIEdwXbXLiu1Fcubvvbo+g9inauqT3l0pNYXGoLPBj3jxtZz9t+wCopMkwadQ==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -3398,6 +3542,9 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lie@3.1.1:
+    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
+
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
@@ -3415,6 +3562,9 @@ packages:
   loader-utils@2.0.4:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
     engines: {node: '>=8.9.0'}
+
+  localforage@1.10.0:
+    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -3489,6 +3639,15 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  media-chrome@4.19.2:
+    resolution: {integrity: sha512-4ai1ITN8wBhwugQcRgqe3tN0z6OSKGOXqHLNrS04MgKFfsLqu6Dm8MPq02pI9Y9ZKoXtFjIl85jOryIW9es3BA==}
+
+  media-played-ranges-mixin@0.1.0:
+    resolution: {integrity: sha512-zTsvkleu5sAyTsPVxDI+KUbCwy/lXwHgOPi3ER9S3lhtAWhGTQH6qxvfrVMym1cvoLU36SPbVr6Qe8Zxyc0WpA==}
+
+  media-tracks@0.3.5:
+    resolution: {integrity: sha512-l54rkKXlLBt3ob3zOLWHcnjvwUmX5bNEZ70igyapOZZC9imzqBmq1oz8p2roiV04KhjblFIi2hetLPF1oYVLRA==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -3567,6 +3726,9 @@ packages:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
 
+  mux-embed@5.18.1:
+    resolution: {integrity: sha512-ePsHjiEKY+FgrSBiMmaF+LOtTQSSBWv/1zqpREQFN96JE93xlsArT/MEi30yKOE06MgjOlL70YI750molu3y7g==}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -3574,6 +3736,9 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  native-promise-only@0.8.1:
+    resolution: {integrity: sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg==}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -3734,6 +3899,9 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-complete-extname@1.0.0:
     resolution: {integrity: sha512-CVjiWcMRdGU8ubs08YQVzhutOR5DEfO97ipRIlOGMK5Bek5nQySknBpuxVAVJ36hseTNs+vdIcv57ZrWxH7zvg==}
 
@@ -3806,6 +3974,9 @@ packages:
   pkijs@3.4.0:
     resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
     engines: {node: '>=16.0.0'}
+
+  player.style@0.3.4:
+    resolution: {integrity: sha512-5O9bkbq0APQIkhptyZwp0gUgheCeImGPFo4hvPF2M5xBmgsUYzsUPHCfMye2xyeRE1zvQBKtziaC3jPgnHE1tw==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4136,8 +4307,24 @@ packages:
     peerDependencies:
       react: ^19.2.7
 
+  react-image-lightbox@5.1.4:
+    resolution: {integrity: sha512-kTiAODz091bgT7SlWNHab0LSMZAPJtlNWDGKv7pLlLY1krmf7FuG1zxE0wyPpeA8gPdwfr3cu6sPwZRqWsc3Eg==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: 16.x || 17.x
+      react-dom: 16.x || 17.x
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-lifecycles-compat@3.0.4:
+    resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
+
+  react-modal@3.16.3:
+    resolution: {integrity: sha512-yCYRJB5YkeQDQlTt17WGAgFJ7jr2QYcWa1SHqZ3PluDmnKJ/7+tVU+E6uKyZ0nODaeEj+xCpK4LcSnKXLMC0Nw==}
+    peerDependencies:
+      react: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19
+      react-dom: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19
 
   react-on-rails-pro-node-renderer@17.0.0-rc.6:
     resolution: {integrity: sha512-nX9Nmgb3hiUMPItC5xfV/W/FGnYLLzefr5qJOURPxrkHgEa6dw1ndnH2mRPyh0zFkOaCB2FBIy8lkWfXvRpfiA==}
@@ -4209,6 +4396,13 @@ packages:
     peerDependencies:
       react: '>= 16'
       react-dom: '>= 16'
+
+  react-player@3.4.0:
+    resolution: {integrity: sha512-QpQSHXtnMBKjQVNeaCYMtTVcynWQ0DDDhz/FJu1OR9PHLC1Aih94UqNstywzSHbJ6Oc7lI8/7kDDqcIvyTI6zQ==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18 || ^19
+      react: ^17.0.2 || ^18 || ^19
+      react-dom: ^17.0.2 || ^18 || ^19
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
@@ -4410,6 +4604,9 @@ packages:
     resolution: {integrity: sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  sax@1.2.1:
+    resolution: {integrity: sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -4642,6 +4839,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  spotify-audio-element@1.0.4:
+    resolution: {integrity: sha512-QdKrJPkYCzaNwwz2vN2eDGyoW0KmQFmnwVprB41mpMzj4qujbqr6pegEchQeTn0b5PceKiLoVu0pp2QDpTcWnw==}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -4714,6 +4914,9 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  super-media-element@1.4.2:
+    resolution: {integrity: sha512-9pP/CVNp4NF2MNlRzLwQkjiTgKKe9WYXrLh9+8QokWmMxz+zt2mf1utkWLco26IuA3AfVcTb//qtlTIjY3VHxA==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4797,6 +5000,9 @@ packages:
   thunky@1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
 
+  tiktok-video-element@0.1.2:
+    resolution: {integrity: sha512-w6TboLm236XJKKiIXIhCbYCnUxbixBbaAoty0etaEAZ/2kHkVIdfZdv2oouMU/HGMsWCHI/VjQ3wU3MJ+s192Q==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -4837,6 +5043,9 @@ packages:
   tsyringe@4.10.0:
     resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
     engines: {node: '>= 6.0.0'}
+
+  twitch-video-element@0.1.6:
+    resolution: {integrity: sha512-X7l8gy+DEFKJ/EztUwaVnAYwQN9fUJxPkOVJj2sE62sGvGU4DNLyvmOsmVulM+8Plc5dMg6hYIMNRAPaH+39Uw==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -4930,12 +5139,22 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vimeo-video-element@1.7.2:
+    resolution: {integrity: sha512-7QM7fvSZvTTSq4igxBuO6Gc+0u3Exgk4IaLNixVzilCPzHEf7SN8b6YLXSM5QCs0ineTJI4XjiUCSoIbabHvwg==}
+
+  warning@4.0.3:
+    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
+
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
 
   wbuf@1.7.3:
     resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==}
+
+  weakmap-polyfill@2.0.4:
+    resolution: {integrity: sha512-ZzxBf288iALJseijWelmECm/1x7ZwQn3sMYIkDr2VvZp7r6SEKuT8D0O9Wiq6L9Nl5mazrOMcmiZE/2NCenaxw==}
+    engines: {node: '>=8.10.0'}
 
   web-vitals@4.2.4:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
@@ -5038,6 +5257,9 @@ packages:
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
 
+  wistia-video-element@1.4.0:
+    resolution: {integrity: sha512-udI8/yiMZ+KIGwYK1qNOFiXl+s/wffiY+XkwTXlBFICZylFalOS0QYEQqYOmuBsm3jNfGUS4O50tLuN7Ejqm3A==}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -5088,6 +5310,20 @@ packages:
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
+  yet-another-react-lightbox@3.32.0:
+    resolution: {integrity: sha512-FWODOMrE07i3O5MeWRcYlcnAUk518zkUYKAe307pVW5pkey3hKMcAIWn8yMIURzGvbd3m9eghWO9CocEZmQPIg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@types/react': ^16 || ^17 || ^18 || ^19
+      '@types/react-dom': ^16 || ^17 || ^18 || ^19
+      react: ^16.8.0 || ^17 || ^18 || ^19
+      react-dom: ^16.8.0 || ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -5095,6 +5331,9 @@ packages:
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
+
+  youtube-video-element@1.9.0:
+    resolution: {integrity: sha512-Hh0dbQM+FVlUaYUbpYkZNUvdKxTNcSNvTGzkQKYShltnX+LRHEp2eYvC2Zm43eU8Np+CBZuoNR2i+seCYzzAyg==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -6423,6 +6662,43 @@ snapshots:
       make-dir: 3.1.0
       webpack: 5.105.4(@swc/core@1.15.21)(webpack-cli@5.1.4)
 
+  '@mux/mux-data-google-ima@0.3.17':
+    dependencies:
+      mux-embed: 5.18.1
+
+  '@mux/mux-player-react@3.13.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@mux/mux-player': 3.13.0(react@19.2.7)
+      '@mux/playback-core': 0.35.0
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@mux/mux-player@3.13.0(react@19.2.7)':
+    dependencies:
+      '@mux/mux-video': 0.31.0
+      '@mux/playback-core': 0.35.0
+      media-chrome: 4.19.2(react@19.2.7)
+      player.style: 0.3.4(react@19.2.7)
+    transitivePeerDependencies:
+      - react
+
+  '@mux/mux-video@0.31.0':
+    dependencies:
+      '@mux/mux-data-google-ima': 0.3.17
+      '@mux/playback-core': 0.35.0
+      castable-video: 1.1.16
+      custom-media-element: 1.4.6
+      media-tracks: 0.3.5
+
+  '@mux/playback-core@0.35.0':
+    dependencies:
+      hls.js: 1.6.16
+      mux-embed: 5.18.1
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -6691,6 +6967,48 @@ snapshots:
       react-refresh: 0.14.2
     optionalDependencies:
       '@rspack/core': 2.0.3
+
+  '@svta/cml-608@1.0.2': {}
+
+  '@svta/cml-cmcd@2.3.2(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-structured-field-values': 1.1.3(@svta/cml-utils@1.5.0)
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-cmsd@1.0.6(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-cta': 1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      '@svta/cml-structured-field-values': 1.1.3(@svta/cml-utils@1.5.0)
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-structured-field-values': 1.1.3(@svta/cml-utils@1.5.0)
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-dash@1.0.6(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-id3@1.0.6(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-request@1.0.12(@svta/cml-cmcd@2.3.2(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@svta/cml-xml@1.1.4(@svta/cml-utils@1.5.0))':
+    dependencies:
+      '@svta/cml-cmcd': 2.3.2(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      '@svta/cml-utils': 1.5.0
+      '@svta/cml-xml': 1.1.4(@svta/cml-utils@1.5.0)
+
+  '@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-utils@1.5.0': {}
+
+  '@svta/cml-xml@1.1.4(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-utils': 1.5.0
 
   '@swc/core-darwin-arm64@1.15.21':
     optional: true
@@ -6976,6 +7294,11 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.3.1': {}
+
+  '@vimeo/player@2.29.0':
+    dependencies:
+      native-promise-only: 0.8.1
+      weakmap-polyfill: 2.0.4
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -7316,6 +7639,8 @@ snapshots:
 
   batch@0.6.1: {}
 
+  bcp-47-match@2.0.3: {}
+
   big.js@5.2.2: {}
 
   binary-extensions@2.3.0: {}
@@ -7400,6 +7725,14 @@ snapshots:
 
   caniuse-lite@1.0.30001780: {}
 
+  castable-video@1.1.16:
+    dependencies:
+      custom-media-element: 1.4.6
+
+  ce-la-react@0.3.2(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -7446,6 +7779,10 @@ snapshots:
       is-plain-object: 2.0.4
       kind-of: 6.0.3
       shallow-clone: 3.0.1
+
+  cloudflare-video-element@1.3.5: {}
+
+  codem-isoboxer@0.3.10: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -7556,6 +7893,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  custom-media-element@1.4.6: {}
+
   d3-array@3.2.4:
     dependencies:
       internmap: 2.0.3
@@ -7589,6 +7928,37 @@ snapshots:
   d3-time@3.1.0:
     dependencies:
       d3-array: 3.2.4
+
+  dash-video-element@0.3.2(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0):
+    dependencies:
+      custom-media-element: 1.4.6
+      dashjs: 5.2.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      media-tracks: 0.3.5
+    transitivePeerDependencies:
+      - '@svta/cml-cta'
+      - '@svta/cml-structured-field-values'
+      - '@svta/cml-utils'
+
+  dashjs@5.2.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0):
+    dependencies:
+      '@svta/cml-608': 1.0.2
+      '@svta/cml-cmcd': 2.3.2(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      '@svta/cml-cmsd': 1.0.6(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      '@svta/cml-dash': 1.0.6(@svta/cml-utils@1.5.0)
+      '@svta/cml-id3': 1.0.6(@svta/cml-utils@1.5.0)
+      '@svta/cml-request': 1.0.12(@svta/cml-cmcd@2.3.2(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@svta/cml-xml@1.1.4(@svta/cml-utils@1.5.0))
+      '@svta/cml-xml': 1.1.4(@svta/cml-utils@1.5.0)
+      bcp-47-match: 2.0.3
+      codem-isoboxer: 0.3.10
+      fast-deep-equal: 3.1.3
+      html-entities: 2.6.0
+      imsc: 1.1.5
+      localforage: 1.10.0
+      path-browserify: 1.0.1
+    transitivePeerDependencies:
+      - '@svta/cml-cta'
+      - '@svta/cml-structured-field-values'
+      - '@svta/cml-utils'
 
   data-uri-to-buffer@6.0.2: {}
 
@@ -7982,6 +8352,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  exenv@1.2.2: {}
+
   express@4.22.1:
     dependencies:
       accepts: 1.3.8
@@ -8317,6 +8689,14 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
+  hls-video-element@1.5.11:
+    dependencies:
+      custom-media-element: 1.4.6
+      hls.js: 1.6.16
+      media-tracks: 0.3.5
+
+  hls.js@1.6.16: {}
+
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
@@ -8403,6 +8783,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  immediate@3.0.6: {}
+
   immutable@5.1.5: {}
 
   import-fresh@3.3.1:
@@ -8414,6 +8796,10 @@ snapshots:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
+
+  imsc@1.1.5:
+    dependencies:
+      sax: 1.2.1
 
   imurmurhash@0.1.4: {}
 
@@ -8694,6 +9080,10 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lie@3.1.1:
+    dependencies:
+      immediate: 3.0.6
+
   light-my-request@6.6.0:
     dependencies:
       cookie: 1.1.1
@@ -8711,6 +9101,10 @@ snapshots:
       big.js: 5.2.2
       emojis-list: 3.0.0
       json5: 2.2.3
+
+  localforage@1.10.0:
+    dependencies:
+      lie: 3.1.1
 
   locate-path@5.0.0:
     dependencies:
@@ -8769,6 +9163,16 @@ snapshots:
   marked@17.0.5: {}
 
   math-intrinsics@1.1.0: {}
+
+  media-chrome@4.19.2(react@19.2.7):
+    dependencies:
+      ce-la-react: 0.3.2(react@19.2.7)
+    transitivePeerDependencies:
+      - react
+
+  media-played-ranges-mixin@0.1.0: {}
+
+  media-tracks@0.3.5: {}
 
   media-typer@0.3.0: {}
 
@@ -8843,6 +9247,8 @@ snapshots:
       dns-packet: 5.6.1
       thunky: 1.1.0
 
+  mux-embed@5.18.1: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -8850,6 +9256,8 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
+
+  native-promise-only@0.8.1: {}
 
   natural-compare@1.4.0: {}
 
@@ -9018,6 +9426,8 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  path-browserify@1.0.1: {}
+
   path-complete-extname@1.0.0: {}
 
   path-exists@4.0.0: {}
@@ -9082,6 +9492,12 @@ snapshots:
       pvtsutils: 1.3.6
       pvutils: 1.1.5
       tslib: 2.8.1
+
+  player.style@0.3.4(react@19.2.7):
+    dependencies:
+      media-chrome: 4.19.2(react@19.2.7)
+    transitivePeerDependencies:
+      - react
 
   possible-typed-array-names@1.1.0: {}
 
@@ -9497,7 +9913,25 @@ snapshots:
       react: 19.2.7
       scheduler: 0.27.0
 
+  react-image-lightbox@5.1.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-modal: 3.16.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
   react-is@16.13.1: {}
+
+  react-lifecycles-compat@3.0.4: {}
+
+  react-modal@3.16.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      exenv: 1.2.2
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-lifecycles-compat: 3.0.4
+      warning: 4.0.3
 
   react-on-rails-pro-node-renderer@17.0.0-rc.6:
     dependencies:
@@ -9531,6 +9965,27 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+
+  react-player@3.4.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@mux/mux-player-react': 3.13.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react': 19.2.14
+      cloudflare-video-element: 1.3.5
+      dash-video-element: 0.3.2(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      hls-video-element: 1.5.11
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      spotify-audio-element: 1.0.4
+      tiktok-video-element: 0.1.2
+      twitch-video-element: 0.1.6
+      vimeo-video-element: 1.7.2
+      wistia-video-element: 1.4.0
+      youtube-video-element: 1.9.0
+    transitivePeerDependencies:
+      - '@svta/cml-cta'
+      - '@svta/cml-structured-field-values'
+      - '@svta/cml-utils'
+      - '@types/react-dom'
 
   react-refresh@0.14.2: {}
 
@@ -9730,6 +10185,8 @@ snapshots:
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.5.6
+
+  sax@1.2.1: {}
 
   scheduler@0.27.0: {}
 
@@ -9958,6 +10415,8 @@ snapshots:
 
   split2@4.2.0: {}
 
+  spotify-audio-element@1.0.4: {}
+
   sprintf-js@1.0.3: {}
 
   stackframe@1.3.4: {}
@@ -10059,6 +10518,8 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  super-media-element@1.4.2: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -10179,6 +10640,8 @@ snapshots:
 
   thunky@1.1.0: {}
 
+  tiktok-video-element@0.1.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -10209,6 +10672,8 @@ snapshots:
   tsyringe@4.10.0:
     dependencies:
       tslib: 1.14.1
+
+  twitch-video-element@0.1.6: {}
 
   type-check@0.4.0:
     dependencies:
@@ -10300,6 +10765,15 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vimeo-video-element@1.7.2:
+    dependencies:
+      '@vimeo/player': 2.29.0
+      media-played-ranges-mixin: 0.1.0
+
+  warning@4.0.3:
+    dependencies:
+      loose-envify: 1.4.0
+
   watchpack@2.5.1:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -10308,6 +10782,8 @@ snapshots:
   wbuf@1.7.3:
     dependencies:
       minimalistic-assert: 1.0.1
+
+  weakmap-polyfill@2.0.4: {}
 
   web-vitals@4.2.4: {}
 
@@ -10490,6 +10966,10 @@ snapshots:
 
   wildcard@2.0.1: {}
 
+  wistia-video-element@1.4.0:
+    dependencies:
+      super-media-element: 1.4.2
+
   word-wrap@1.2.5: {}
 
   wrap-ansi@7.0.0:
@@ -10530,8 +11010,20 @@ snapshots:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
 
+  yet-another-react-lightbox@3.32.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
+
+  youtube-video-element@1.9.0:
+    dependencies:
+      media-played-ranges-mixin: 0.1.0
 
   zod@3.25.76: {}


### PR DESCRIPTION
Closes #98.

## What

A new **`/media-gallery`** page that demonstrates media-heavy content the **RSC-first** way. A server component (`MediaGalleryRSC`) assembles the media manifest server-side (`MediaGalleryData`) and streams as HTML; the only JavaScript shipped is four interactive **client islands**, each wired through the repo's `*ForServer.tsx` (`'use client'`) boundary convention — the same pattern as `ProductImageGallery`.

## Media demos (each applies a finding from prior standalone experiments)

| Demo | Technique |
|---|---|
| **react-player v3 — light mode** | `light={poster}` facade + `fallback={<img>}`; `react-player` lazily `import()`ed after mount so it stays off SSR and the critical path; hls.js loads on click |
| **Vanilla `<video>` + hls.js** | MSE-first feature detection (the "`canPlayType`-first silently skips hls.js on Chrome" finding), hls.js dynamically imported only on first click, `hls.destroy()` cleanup |
| **react-image-lightbox gallery** | the deprecated/archived incumbent (the "before") |
| **yet-another-react-lightbox gallery** | the maintained, React-19-ready successor (the "after") |

Both galleries share a responsive grid: `srcset`/`sizes`, explicit `width`/`height` (3:2), lazy-below-the-fold. Every media slot reserves space in a fixed box so **CLS ≈ 0**. Code comments throughout cite the measurements behind each decision.

## Also

- Routes `/media-gallery` and `/media-gallery/rsc`, controller, streaming view
- Lightbox vendor CSS imported in `application.css` (global pipeline, like highlight.js)
- Home-page "Multimedia Showcase" nav card
- New deps: `react-player@3.4.0`, `hls.js@1.6.16`, `react-image-lightbox@5.1.4`, `yet-another-react-lightbox@3.32.0`

## Verification

- `pnpm lint:rsc`, `pnpm type-check`, `eslint`, `rubocop` — all clean
- `generate_packs` registers `MediaGalleryRSC` as a server component
- Ran `bin/dev`; `/media-gallery` returns 200; Playwright: **zero console errors**, both video posters render, both lightboxes open correctly

## Scope note

This implements the two videos + two galleries requested, RSC-first with heavy explanatory comments. The issue's full acceptance criteria additionally mention an audio player, an iframe/embed, and SSR/Client variant routes — those are **not** included here and can follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Multimedia Showcase” page with RSC streaming, responsive image thumbnail galleries, and two click-to-play video experiences (light/facade and HLS).
  * Added new routes for the showcase and an accompanying homepage demo card linking to it.
* **Bug Fixes**
  * Improved initial-load behavior by deferring client-only video/lightbox rendering and using lazy/eager thumbnail loading where appropriate.
* **Style**
  * Added lightbox vendor CSS for image modal experiences.
* **Chores**
  * Added supporting gallery data wiring, SEO metadata, and required multimedia dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->