### PR TITLE
chore: group Dependabot into one PR per ecosystem + track npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Grouped Dependabot updates: one PR per ecosystem (Ruby / JavaScript / GitHub Actions)
+# instead of one PR per dependency. Tracks npm so the shakapacker gem and npm
+# package move together. 3-day cooldown so a freshly published version can't be
+# yanked after the PR opens. Patterned on shakacode/react_on_rails.
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+    groups:
+      ruby:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+    groups:
+      javascript:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Replaces the ungrouped Dependabot config so updates arrive as **one grouped PR per ecosystem** (Ruby / JavaScript / GitHub Actions) instead of one PR per dependency.

- **Adds npm/JS tracking** — previously only `bundler` + `github-actions` were tracked, so JS deps (including the shakapacker npm package) never got update PRs. That gap is what lets the shakapacker gem and npm versions drift apart.
- **Groups everything** per ecosystem via a catch-all `groups` pattern.
- **3-day cooldown** so a freshly published version can't be yanked from the registry after a PR opens.

Patterned on `shakacode/react_on_rails`'s `.github/dependabot.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
