### PR TITLE
docs: note TanStack Query in Data Fetching Patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Examples: StatusBadge, WaitTimeBadge, RatingBadge, SpecialsList, TrendingItems
 
 ### Data Fetching Patterns
 
+> **Three options, composable.** This demo contrasts traditional client lazy-loading with RSC server-fetch + streaming. The third option, for interactive client-owned state, is [TanStack Query](https://reactonrails.com/docs/building-features/tanstack-query): a client cache over the Rails JSON API (request dedup, background refetch, optimistic updates, invalidation). RSC for first paint, TanStack Query for the live app. See the [TanStack starter](https://starter.reactonrails.com).
+
 **Both versions use the same RSC webpack config.** The difference is which bundle renders the page:
 
 **Traditional Version** (uses client bundle with SSR):


### PR DESCRIPTION
Adds a short note to the **Data Fetching Patterns** section: alongside traditional lazy-loading and RSC server-fetch, [TanStack Query](https://reactonrails.com/docs/building-features/tanstack-query) is the client-owned option (a cache over the Rails JSON API). RSC for first paint, TanStack Query for the live app. Links the [guide](https://reactonrails.com/docs/building-features/tanstack-query) and [starter](https://starter.reactonrails.com).

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)
