### PR TITLE
Add experimental PPR-style product route

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -107,7 +107,7 @@ class ProductsController < ApplicationController
     variant = SEO_VARIANTS[action_name]
     @page_title = "Product Page — #{variant} | React on Rails RSC Demo" if variant
     @page_description =
-      "An e-commerce product page rendered three ways — comparing React Server " \
+      "An e-commerce product page rendered multiple ways — comparing React Server " \
       "Components against SSR and client-side rendering in the React on Rails demo."
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -5,14 +5,15 @@ class ProductsController < ApplicationController
   include ReactOnRailsPro::AsyncRendering
   include ProductSerialization
 
-  enable_async_react_rendering only: %i[show_rsc show_rsc_cached]
+  enable_async_react_rendering only: %i[show_rsc show_rsc_cached show_ppr]
 
   before_action :set_seo_meta
 
   SEO_VARIANTS = {
     "show_ssr" => "Server-Side Rendering (SSR)",
     "show_client" => "Client-Side Rendering",
-    "show_rsc" => "React Server Components (RSC)"
+    "show_rsc" => "React Server Components (RSC)",
+    "show_ppr" => "Experimental PPR-style RSC"
   }.freeze
 
   # V1: Full Server SSR — fetch ALL data, return complete page
@@ -61,6 +62,15 @@ class ProductsController < ApplicationController
     stream_view_containing_react_components(template: "products/show_rsc_cached")
   end
 
+  # V4 experiment: keep the hero/editorial shell inline and cacheable while review/recommendation
+  # sections stay request-live async holes.
+  def show_ppr
+    @product = find_product
+    @product_data = product_ppr_shell_props(@product)
+    @product_ppr_async_payloads = product_ppr_async_payloads(@product)
+    stream_view_containing_react_components(template: "products/show_ppr")
+  end
+
   private
 
   # Full SSR props, built lazily for the cached view block (evaluated only on a cache miss).
@@ -73,6 +83,25 @@ class ProductsController < ApplicationController
     }
   end
   helper_method :product_ssr_props
+
+  def product_ppr_shell_props(product)
+    serialize_product(product)
+  end
+
+  def product_ppr_async_payloads(product)
+    reviews = product.top_reviews(5)
+    related = product.related_products(4)
+
+    {
+      review_stats: product.review_stats,
+      reviews: {
+        reviews: reviews.map { |review| serialize_review(review) }
+      },
+      related_products: {
+        products: related.map { |related_product| serialize_product_card(related_product) }
+      }
+    }
+  end
 
   def set_seo_meta
     variant = SEO_VARIANTS[action_name]

--- a/app/javascript/components/product/ProductPagePPR.tsx
+++ b/app/javascript/components/product/ProductPagePPR.tsx
@@ -1,0 +1,184 @@
+import React, { Suspense } from 'react';
+import { unstable_cache } from 'react-on-rails-pro/cache'; // eslint-disable-line camelcase
+import { Product, ProductCard, ProductReview, ReviewStats } from '../../types/product';
+import { ProductImageGallery } from './ProductImageGalleryForServer';
+import { ProductInfo } from './ProductInfo';
+import { AddToCartSection } from './AddToCartSectionForServer';
+import { Breadcrumb } from './Breadcrumb';
+import { buildProductCrumbs } from './productCrumbs';
+import { ProductDescription } from './ProductDescription';
+import { ProductFeatures } from './ProductFeatures';
+import { ProductSpecs } from './ProductSpecs';
+import { ProductSpecSheet } from './ProductSpecSheetForServer';
+import { buildProductSpecMarkdown } from './productSpecMarkdown';
+import { ReviewDistributionChart } from './ReviewDistributionChart';
+import { ReviewsList } from './ReviewsList';
+import { RelatedProducts } from './RelatedProducts';
+import { ProductDetailsSkeleton, ReviewStatsSkeleton, ReviewsSkeleton, RelatedProductsSkeleton } from './ProductSkeletons';
+
+interface AsyncPayloads {
+  review_stats: ReviewStats;
+  reviews: { reviews: ProductReview[] };
+  related_products: { products: ProductCard[] };
+}
+
+type AsyncPropReader = <K extends keyof AsyncPayloads>(propName: K) => Promise<AsyncPayloads[K]>;
+
+interface EditorialProductSlice {
+  name: Product['name'];
+  price: Product['price'];
+  sku: Product['sku'];
+  description: Product['description'];
+  features: Product['features'];
+  specs: Product['specs'];
+}
+
+interface Props {
+  product: Product;
+  getReactOnRailsAsyncProp: AsyncPropReader;
+}
+
+const CachedStaticEditorialSection = unstable_cache(
+  async ({
+    editorial,
+    specMarkdown,
+  }: {
+    editorial: EditorialProductSlice;
+    specMarkdown: string;
+  }) => (
+    <>
+      <ProductDescription description={editorial.description} />
+      <ProductFeatures features={editorial.features} />
+      <ProductSpecs specs={editorial.specs} />
+      <ProductSpecSheet
+        productName={editorial.name}
+        productPriceUsd={editorial.price}
+        specMarkdown={specMarkdown}
+      />
+    </>
+  ),
+  { id: 'product-ppr-static-editorial', revalidate: 60 },
+);
+
+function buildEditorialSlice(product: Product): EditorialProductSlice {
+  return {
+    name: product.name,
+    price: product.price,
+    sku: product.sku,
+    description: product.description,
+    features: product.features,
+    specs: product.specs,
+  };
+}
+
+async function ReviewStatsHole({
+  getReactOnRailsAsyncProp,
+}: {
+  getReactOnRailsAsyncProp: AsyncPropReader;
+}) {
+  const data = await getReactOnRailsAsyncProp('review_stats');
+
+  return (
+    <ReviewDistributionChart
+      distribution={data.distribution}
+      averageRating={data.average_rating}
+      totalReviews={data.total_reviews}
+    />
+  );
+}
+
+async function ReviewsHole({
+  getReactOnRailsAsyncProp,
+}: {
+  getReactOnRailsAsyncProp: AsyncPropReader;
+}) {
+  const data = await getReactOnRailsAsyncProp('reviews');
+
+  return <ReviewsList reviews={data.reviews} />;
+}
+
+async function RelatedProductsHole({
+  getReactOnRailsAsyncProp,
+}: {
+  getReactOnRailsAsyncProp: AsyncPropReader;
+}) {
+  const data = await getReactOnRailsAsyncProp('related_products');
+
+  return <RelatedProducts products={data.products} />;
+}
+
+export default function ProductPagePPR({ product, getReactOnRailsAsyncProp }: Props) {
+  const editorial = buildEditorialSlice(product);
+
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="container mx-auto max-w-6xl px-4 py-6">
+        <p className="text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded-lg px-4 py-2 mb-6">
+          V4: Experimental PPR-style RSC. Hero and editorial shell stay inline, static detail content is wrapped with
+          <code className="mx-1 rounded bg-amber-100 px-1.5 py-0.5">unstable_cache</code>
+          , and live review/recommendation holes still stream per request.
+        </p>
+
+        <Breadcrumb crumbs={buildProductCrumbs(product)} />
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12 mb-12">
+          <ProductImageGallery images={product.images} productName={product.name} />
+          <div className="space-y-6">
+            <ProductInfo product={product} />
+            <div className="border-t border-gray-200 pt-6">
+              <AddToCartSection
+                price={product.price}
+                inStock={product.in_stock}
+                stockQuantity={product.stock_quantity}
+              />
+            </div>
+          </div>
+        </div>
+
+        <section className="border-t border-gray-200 pt-8">
+          <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between mb-6">
+            <div>
+              <h2 className="text-xl font-bold text-gray-900">Cached Static Editorial Shell</h2>
+              <p className="text-sm text-gray-600">
+                Description, feature copy, specs, and the long-form spec sheet are product-stable and shell-cacheable.
+              </p>
+            </div>
+            <p className="text-xs uppercase tracking-[0.2em] text-amber-700">Warm hits replay without recomputing markdown</p>
+          </div>
+          <Suspense fallback={<ProductDetailsSkeleton />}>
+            <CachedStaticEditorialSection
+              editorial={editorial}
+              specMarkdown={buildProductSpecMarkdown(editorial.name, editorial.sku)}
+            />
+          </Suspense>
+        </section>
+
+        <section className="border-t border-gray-200 pt-8 mt-8">
+          <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between mb-6">
+            <div>
+              <h2 className="text-xl font-bold text-gray-900">Live Dynamic Holes</h2>
+              <p className="text-sm text-gray-600">
+                Review stats, recent reviews, and related products stay request-live to model the PPR hole boundary.
+              </p>
+            </div>
+            <p className="text-xs uppercase tracking-[0.2em] text-sky-700">Streamed on demand</p>
+          </div>
+
+          <Suspense fallback={<ReviewStatsSkeleton />}>
+            <ReviewStatsHole getReactOnRailsAsyncProp={getReactOnRailsAsyncProp} />
+          </Suspense>
+
+          <div className="mt-8">
+            <Suspense fallback={<ReviewsSkeleton />}>
+              <ReviewsHole getReactOnRailsAsyncProp={getReactOnRailsAsyncProp} />
+            </Suspense>
+          </div>
+        </section>
+
+        <Suspense fallback={<RelatedProductsSkeleton />}>
+          <RelatedProductsHole getReactOnRailsAsyncProp={getReactOnRailsAsyncProp} />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/app/javascript/startup/ProductPageRSC.tsx
+++ b/app/javascript/startup/ProductPageRSC.tsx
@@ -1,1 +1,7 @@
-export { default } from '../components/product/ProductPageRSC';
+import registerServerComponent from 'react-on-rails-pro/registerServerComponent/server';
+import ProductPageRSC from '../components/product/ProductPageRSC';
+import ProductPagePPR from '../components/product/ProductPagePPR';
+
+registerServerComponent({ ProductPagePPR });
+
+export default ProductPageRSC;

--- a/app/views/products/show_ppr.html.erb
+++ b/app/views/products/show_ppr.html.erb
@@ -1,0 +1,10 @@
+<% append_javascript_pack_tag "generated/ProductPageRSC", defer: true %>
+<% content_for :head do %>
+  <link rel="preload" as="image" href="<%= hero_image_url %>" fetchpriority="high">
+<% end %>
+<%= stream_react_component_with_async_props("ProductPagePPR",
+    props: { product: @product_data }, prerender: true, auto_load_bundle: false) do |emit|
+  @product_ppr_async_payloads.each do |prop_name, payload|
+    emit.call(prop_name.to_s, payload)
+  end
+end %>

--- a/app/views/products/show_ppr.html.erb
+++ b/app/views/products/show_ppr.html.erb
@@ -1,3 +1,6 @@
+<%# ProductPagePPR is registered inside startup/ProductPageRSC.tsx so it reuses the
+    existing generated/ProductPageRSC hydration pack instead of needing its own
+    generated/ProductPagePPR entrypoint. Keep this pack tag and auto_load_bundle: false in sync. %>
 <% append_javascript_pack_tag "generated/ProductPageRSC", defer: true %>
 <% content_for :head do %>
   <link rel="preload" as="image" href="<%= hero_image_url %>" fetchpriority="high">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
   get '/product/client', to: 'products#show_client'   # V2: Loadable components, client-side fetch
   get '/product/rsc', to: 'products#show_rsc'         # V3: RSC streaming
   get '/product/rsc-cached', to: 'products#show_rsc_cached' # V3 + cached_stream_react_component_with_async_props
+  get '/product/ppr', to: 'products#show_ppr'         # Experimental cached shell + live holes
 
   # Product search results — three versions demonstrating search page RSC gains
   get '/product-search/ssr', to: 'product_search#search_ssr'       # V1: Full SSR

--- a/docs/ppr-experiment-issue-113.md
+++ b/docs/ppr-experiment-issue-113.md
@@ -1,0 +1,133 @@
+# PPR-style product page experiment (issue #113)
+
+Issue: [#113](https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/issues/113)
+
+Branch: `113-ppr-experimental` | Date: 2026-07-01
+
+## Goal
+
+Add a product-page experiment that models a PPR split inside the existing React
+on Rails RSC demo without introducing a full Next-style `use cache`
+runtime/transport.
+
+This spike is intentionally narrower than "real" Partial Prerendering:
+
+- no React 19 `prerender()` / `resume()` transport
+- no CDN-served static shell
+- no full-page static artifact
+- no attempt to re-create Next.js PPR semantics inside the gem/runtime
+
+Instead, the route demonstrates the key design idea: a mostly-stable shell with
+request-live holes that stream independently.
+
+## Implemented route
+
+- Route: `/product/ppr`
+- Controller action: `ProductsController#show_ppr`
+- React server component: `ProductPagePPR`
+
+## Static vs dynamic split
+
+The page is divided along data-stability lines rather than visual lines.
+
+### Static editorial shell
+
+Wrapped in `unstable_cache` inside `ProductPagePPR`:
+
+- product description
+- product features
+- product specs table
+- long-form spec sheet / markdown render
+
+Important detail: the cache input is narrowed to the editorial fields actually
+used by this section:
+
+- `name`
+- `price`
+- `sku`
+- `description`
+- `features`
+- `specs`
+
+That avoids keying the static section on unrelated live values like stock count
+or review count.
+
+### Live dynamic holes
+
+Still emitted per request through async props:
+
+- `review_stats`
+- `reviews`
+- `related_products`
+
+These remain behind Suspense boundaries so the route still exercises streamed
+hole filling rather than replaying one monolithic cached page response.
+
+## Why this is "PPR-style" and not full PPR
+
+This route demonstrates a **static/dynamic boundary** on the same page, but it
+does not prove the full operational benefits associated with framework-native
+PPR:
+
+- the first request still goes to Rails, not a CDN shell
+- the static shell is cached at the server-component boundary, not pre-emitted
+  as a standalone document
+- resume semantics are not part of this experiment
+- warm hits still participate in the existing React on Rails streaming pipeline
+
+So the experiment is useful for understanding boundary placement and cache-key
+design, but not as a full PPR performance claim.
+
+## Verification evidence
+
+Live route checks on 2026-07-01:
+
+- `/product/ppr` returned `HTTP 200`
+- rendered title: `Product Page — Experimental PPR-style RSC`
+- rendered section labels:
+  - `Cached Static Editorial Shell`
+  - `Live Dynamic Holes`
+- emitted RSC payload buffer:
+  - `REACT_ON_RAILS_RSC_PAYLOADS`
+- emitted Suspense templates for streamed sections
+
+Focused validation:
+
+- `bundle exec rspec spec/products_ppr_split_spec.rb spec/products_ppr_routing_spec.rb`
+- `pnpm exec tsc --noEmit`
+- `pnpm exec eslint app/javascript/components/product/ProductPagePPR.tsx app/javascript/startup/ProductPageRSC.tsx`
+- `bin/shakapacker --mode development`
+
+## Timing snapshot
+
+Development-mode curl timings after warmup, same machine, unthrottled:
+
+| Route | Warm sample TTFB range | Warm sample total range |
+|---|---:|---:|
+| `/product/ppr` | 189-288 ms | 229-551 ms |
+| `/product/rsc` | 212-371 ms | 223-544 ms |
+| `/product/rsc-cached` | 190-311 ms | 286-393 ms |
+
+What this shows:
+
+- the experiment works
+- the new route is in the same rough latency band as the existing RSC variants
+- this run does **not** show a decisive warm-path speed win for the PPR-style
+  route in dev mode
+
+That is acceptable for this spike. The point of issue #113 is the shape of the
+experiment and the explicit boundary, not proof that this transport-free version
+beats the existing cached page path.
+
+## Conclusion
+
+Issue #113 is viable as an experimental demo route.
+
+It is useful for:
+
+- showing how to place a static/dynamic boundary
+- demonstrating `unstable_cache` on a page subsection
+- comparing shell-first streaming behavior against existing product variants
+
+It should not be described as production-ready PPR or as evidence that React on
+Rails now implements framework-native Partial Prerendering.

--- a/spec/products_ppr_routing_spec.rb
+++ b/spec/products_ppr_routing_spec.rb
@@ -1,0 +1,10 @@
+ENV["RAILS_ENV"] ||= "test"
+
+require_relative "../config/environment"
+require "rspec/rails"
+
+RSpec.describe ProductsController, type: :routing do
+  it "routes /product/ppr to the experimental PPR action" do
+    expect(get: "/product/ppr").to route_to("products#show_ppr")
+  end
+end

--- a/spec/products_ppr_split_spec.rb
+++ b/spec/products_ppr_split_spec.rb
@@ -1,0 +1,78 @@
+ENV["RAILS_ENV"] ||= "test"
+
+require_relative "../config/environment"
+require "rspec/rails"
+
+RSpec.describe ProductsController do
+  around do |example|
+    ProductReview.delete_all
+    Product.delete_all
+    example.run
+  ensure
+    ProductReview.delete_all
+    Product.delete_all
+  end
+
+  it "keeps editorial product fields in the PPR shell props" do
+    product = create_product!("PPR-CAM-001")
+
+    shell_props = controller.send(:product_ppr_shell_props, product)
+
+    expect(shell_props[:description]).to eq(product.description)
+    expect(shell_props[:features]).to eq(product.features)
+    expect(shell_props[:specs]).to eq(product.specs)
+    expect(shell_props).not_to have_key(:review_stats)
+    expect(shell_props).not_to have_key(:reviews)
+    expect(shell_props).not_to have_key(:related_products)
+  end
+
+  it "keeps only live review and recommendation data in async holes" do
+    product = create_product!("PPR-CAM-001")
+    create_product!("PPR-REL-001", name: "Related Camera 1")
+    create_product!("PPR-REL-002", name: "Related Camera 2")
+
+    ProductReview.create!(
+      product: product,
+      rating: 5,
+      title: "Excellent",
+      comment: "Very fast autofocus.",
+      reviewer_name: "Pat",
+      verified_purchase: true,
+      helpful_count: 4
+    )
+    product.update_cached_rating!
+
+    async_payloads = controller.send(:product_ppr_async_payloads, product)
+
+    expect(async_payloads.keys).to contain_exactly(:review_stats, :reviews, :related_products)
+    expect(async_payloads).not_to have_key(:product_details)
+    expect(async_payloads[:reviews][:reviews].size).to eq(1)
+    expect(async_payloads[:related_products][:products].size).to eq(2)
+    expect(async_payloads[:review_stats][:total_reviews]).to eq(product.review_count)
+  end
+
+  def controller
+    @controller ||= described_class.new
+  end
+
+  def create_product!(sku, overrides = {})
+    Product.create!(
+      {
+        name: "PPR Demo Camera #{sku}",
+        description: "Static shell copy for #{sku}",
+        price: 299.0,
+        original_price: 349.0,
+        category: "Cameras",
+        brand: "ShakaCam",
+        sku: sku,
+        images: [{ url: "/#{sku.downcase}.jpg", alt: sku, position: 1 }],
+        specs: { "Sensor" => "Full Frame" },
+        features: ["4K video", "Weather sealed"],
+        stock_quantity: 12,
+        in_stock: true,
+        average_rating: 4.5,
+        review_count: 3
+      }.merge(overrides)
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- add an experimental `/product/ppr` route that models a PPR-style split on the product page
- keep editorial content behind `unstable_cache` while reviews and related products remain streamed async holes
- document the experiment scope, validation, and timing caveats for issue #113

## Verification
- bundle exec rspec spec/products_ppr_split_spec.rb spec/products_ppr_routing_spec.rb
- pnpm exec tsc --noEmit
- pnpm exec eslint app/javascript/components/product/ProductPagePPR.tsx app/javascript/startup/ProductPageRSC.tsx
- bin/shakapacker --mode development
- curl http://127.0.0.1:4010/product/ppr

Refs #113
