### PR TITLE
Bump React on Rails RSC to final 19.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-image-lightbox": "^5.1.4",
     "react-on-rails-pro": "17.0.0-rc.6",
     "react-on-rails-pro-node-renderer": "17.0.0-rc.6",
-    "react-on-rails-rsc": "19.2.0-rc.4",
+    "react-on-rails-rsc": "19.2.0",
     "react-player": "^3.4.0",
     "react-server-dom-webpack": "19.2.7",
     "sanitize-html": "^2.17.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,13 +78,13 @@ importers:
         version: 5.1.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-on-rails-pro:
         specifier: 17.0.0-rc.6
-        version: 17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.0-rc.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4))(react@19.2.7)
+        version: 17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4))(react@19.2.7)
       react-on-rails-pro-node-renderer:
         specifier: 17.0.0-rc.6
         version: 17.0.0-rc.6
       react-on-rails-rsc:
-        specifier: 19.2.0-rc.4
-        version: 19.2.0-rc.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
+        specifier: 19.2.0
+        version: 19.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
       react-player:
         specifier: ^3.4.0
         version: 3.4.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -4426,8 +4426,8 @@ packages:
       react-on-rails-rsc:
         optional: true
 
-  react-on-rails-rsc@19.2.0-rc.4:
-    resolution: {integrity: sha512-Jm9822vmAvXPbQ3gyx8B5RwbGcmxEXZ1eMEoVxd3rsnnxuZ7B35dr11Ygy2FBPPq4v5sJa/PFWGir/m8Cg1b9Q==}
+  react-on-rails-rsc@19.2.0:
+    resolution: {integrity: sha512-4PlfNFWGHl029al/yi10G3fcREbTwzqQ45uqYs6i9Baqds2OROyWp1xdorfX4Ok46IVJjje14SeaJVyN8pGDGg==}
     peerDependencies:
       react: ^19.2.7
       react-dom: ^19.2.7
@@ -10031,15 +10031,15 @@ snapshots:
       lockfile: 1.0.4
       pino: 9.14.0
 
-  react-on-rails-pro@17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.0-rc.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4))(react@19.2.7):
+  react-on-rails-pro@17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-on-rails: 17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:
-      react-on-rails-rsc: 19.2.0-rc.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
+      react-on-rails-rsc: 19.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
 
-  react-on-rails-rsc@19.2.0-rc.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4):
+  react-on-rails-rsc@19.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2


### PR DESCRIPTION
## Summary
- updates the Marketplace RSC demo to `react-on-rails-rsc` final `19.2.0`
- refreshes `pnpm-lock.yaml` for the final package tarball

## Rationale
The demo should consume the final RSC release now that `19.2.0` is no longer an RC.

## Verification
- `corepack pnpm@9.15.2 --dir . install --frozen-lockfile`
- `corepack pnpm@9.15.2 --dir . run type-check`
- `corepack pnpm@9.15.2 --dir . run lint:rsc`
- `corepack pnpm@9.15.2 --dir . run verify:rsc`
- production `react_on_rails:generate_packs` with explicit Ruby 3.3.0 / Node 22.12.0 paths and local-only dummy environment values
- production `bin/shakapacker` with explicit Ruby 3.3.0 / Node 22.12.0 paths and local-only dummy environment values
- `rg -n "19\\.2\\.0-rc\\.4" .` returned no matches in this checkout

## Notes
- Shell startup still reports the repo `mise.toml` is untrusted, so validation avoided trusting it and used explicit tool paths.
- The production build retained existing RSC client-reference chunk contamination and asset-size warnings; this PR only changes the RSC package version.
