### PR TITLE
Gate marketplace RSC demo on React on Rails 17.0.0.rc.7

### DIFF
--- a/.verify-routes.js
+++ b/.verify-routes.js
@@ -9,6 +9,7 @@ const puppeteer = require('puppeteer');
 const BASE = process.env.BASE_URL || 'http://localhost:3010';
 const DEFAULT_ROUTES = [
   '/',
+  '/products',
   '/why-rsc',
   '/measure',
   '/rsc-performance',

--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,8 @@ gem 'turbo-rails'
 gem 'stimulus-rails'
 
 # React on Rails
-gem 'react_on_rails', '17.0.0.rc.6'
-gem 'react_on_rails_pro', '17.0.0.rc.6'
+gem 'react_on_rails', '17.0.0.rc.7'
+gem 'react_on_rails_pro', '17.0.0.rc.7'
 
 # Shakapacker for webpack integration
 gem 'shakapacker', '10.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,22 +298,21 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
-    react_on_rails (17.0.0.rc.6)
+    react_on_rails (17.0.0.rc.7)
       addressable
       connection_pool
       execjs (~> 2.5)
       rails (>= 5.2)
       rainbow (~> 3.0)
       shakapacker (>= 6.0)
-    react_on_rails_pro (17.0.0.rc.6)
-      addressable
+    react_on_rails_pro (17.0.0.rc.7)
       async (>= 2.29)
       async-http (~> 0.95)
       execjs (~> 2.9)
       io-endpoint (~> 0.17.0)
       jwt (>= 2.5, < 4)
-      rainbow
-      react_on_rails (= 17.0.0.rc.6)
+      nokogiri (>= 1.12, < 2)
+      react_on_rails (= 17.0.0.rc.7)
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -434,8 +433,8 @@ DEPENDENCIES
   pry-byebug (~> 3.12)
   puma (~> 6.0)
   rails (~> 7.1)
-  react_on_rails (= 17.0.0.rc.6)
-  react_on_rails_pro (= 17.0.0.rc.6)
+  react_on_rails (= 17.0.0.rc.7)
+  react_on_rails_pro (= 17.0.0.rc.7)
   rspec-rails (~> 6.1)
   rubocop
   rubocop-rails

--- a/app/javascript/components/ssr-rsc-playground/ui/PprWalkthrough.tsx
+++ b/app/javascript/components/ssr-rsc-playground/ui/PprWalkthrough.tsx
@@ -509,7 +509,7 @@ export default function PprWalkthrough() {
       }
     };
     rafRef.current = requestAnimationFrame(tick);
-  }, [stepIndex, effMs, animating, stopRaf]);
+  }, [stepIndex, effMs, animating]);
 
   const goBack = useCallback(() => {
     if (animating || stepIndex <= 0) return;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   get '/measure' => 'pages#measure'
   get '/lh-compare' => 'pages#lh_compare', as: :lh_compare
   get '/ssr-rsc-playground' => 'pages#ssr_rsc_playground'
+  get '/products', to: 'product_search#search_rsc', as: :products
 
   # Multimedia showcase — media-heavy page (HLS video + responsive image galleries).
   # RSC-first single page (issue #98). Both paths hit the same RSC action.

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-image-lightbox": "^5.1.4",
-    "react-on-rails-pro": "17.0.0-rc.6",
-    "react-on-rails-pro-node-renderer": "17.0.0-rc.6",
-    "react-on-rails-rsc": "19.2.0",
+    "react-on-rails-pro": "17.0.0-rc.7",
+    "react-on-rails-pro-node-renderer": "17.0.0-rc.7",
+    "react-on-rails-rsc": "19.2.1-rc.0",
     "react-player": "^3.4.0",
     "react-server-dom-webpack": "19.2.7",
     "sanitize-html": "^2.17.3",
@@ -59,7 +59,7 @@
   "pnpm": {
     "overrides": {
       "@ungap/structured-clone": "1.3.1",
-      "react-on-rails": "17.0.0-rc.6",
+      "react-on-rails": "17.0.0-rc.7",
       "shakapacker": "10.2.0"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@ungap/structured-clone': 1.3.1
-  react-on-rails: 17.0.0-rc.6
+  react-on-rails: 17.0.0-rc.7
   shakapacker: 10.2.0
 
 importers:
@@ -77,14 +77,14 @@ importers:
         specifier: ^5.1.4
         version: 5.1.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-on-rails-pro:
-        specifier: 17.0.0-rc.6
-        version: 17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4))(react@19.2.7)
+        specifier: 17.0.0-rc.7
+        version: 17.0.0-rc.7(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4))(react@19.2.7)
       react-on-rails-pro-node-renderer:
-        specifier: 17.0.0-rc.6
-        version: 17.0.0-rc.6
+        specifier: 17.0.0-rc.7
+        version: 17.0.0-rc.7
       react-on-rails-rsc:
-        specifier: 19.2.0
-        version: 19.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
+        specifier: 19.2.1-rc.0
+        version: 19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
       react-player:
         specifier: ^3.4.0
         version: 3.4.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -4390,8 +4390,8 @@ packages:
       react: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19
       react-dom: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19
 
-  react-on-rails-pro-node-renderer@17.0.0-rc.6:
-    resolution: {integrity: sha512-nX9Nmgb3hiUMPItC5xfV/W/FGnYLLzefr5qJOURPxrkHgEa6dw1ndnH2mRPyh0zFkOaCB2FBIy8lkWfXvRpfiA==}
+  react-on-rails-pro-node-renderer@17.0.0-rc.7:
+    resolution: {integrity: sha512-qyB0wd1AU7KsPMJJyc3U3l4rgq8ZVR8FOAqNQ4riZ2adqeNfz5k5Gx1NKwKMWd51ri7fGqyZDFC8295bAIQEZw==}
     engines: {node: '>=18.19.0'}
     peerDependencies:
       '@fastify/otel': '>=0.18.0 <1.0.0'
@@ -4432,14 +4432,14 @@ packages:
       '@sentry/tracing':
         optional: true
 
-  react-on-rails-pro@17.0.0-rc.6:
-    resolution: {integrity: sha512-Uc4IUmNYAJIk4iy4RatLN0qVM7MAi8zgXVvd7vZMEnVkGGhHqvj1A82ft97yJqgfqF9mm3eSPPyU3gyXrH5CsQ==}
+  react-on-rails-pro@17.0.0-rc.7:
+    resolution: {integrity: sha512-tfHNFjlX0Vnb/t4GxUc3X3mw742hHcrR3VapYfz3kAlDPNnpMi03PzPVPxwAO5FeQloHvAKq9/rjUemdsRDSQQ==}
     peerDependencies:
       '@tanstack/react-router': '>=1.139.0 <2.0.0'
       ioredis: '>= 5'
       react: '>= 16'
       react-dom: '>= 16'
-      react-on-rails-rsc: ^19.0.5
+      react-on-rails-rsc: '>=19.2.1-rc.0 <20.0.0'
     peerDependenciesMeta:
       '@tanstack/react-router':
         optional: true
@@ -4448,15 +4448,15 @@ packages:
       react-on-rails-rsc:
         optional: true
 
-  react-on-rails-rsc@19.2.0:
-    resolution: {integrity: sha512-4PlfNFWGHl029al/yi10G3fcREbTwzqQ45uqYs6i9Baqds2OROyWp1xdorfX4Ok46IVJjje14SeaJVyN8pGDGg==}
+  react-on-rails-rsc@19.2.1-rc.0:
+    resolution: {integrity: sha512-lWUQloOMYS2/Jio7M9pKaY84+gNJ1ZD2pMTj37HDZtf6GsJjb0CJfJlizvxbquUdMQawX+1h59c63syFZ7AWmQ==}
     peerDependencies:
       react: ^19.2.7
       react-dom: ^19.2.7
       webpack: ^5.59.0
 
-  react-on-rails@17.0.0-rc.6:
-    resolution: {integrity: sha512-/u2hzYvuUN+1HnH0gEdbfQvkWkgLMSN2kl/2x9CCOInIHffBvilgXzBgJrP5NlvjWpguUWSxO6PrYpgV0BzLMA==}
+  react-on-rails@17.0.0-rc.7:
+    resolution: {integrity: sha512-JWeDJeFUc8TEWtz4MWLMHpCIPBw3stKBx//EY8aPDZDwL1UxX3tnDDt/4JlIOzvGonz4ncGxEbEKcnBheyafDw==}
     peerDependencies:
       react: '>= 16'
       react-dom: '>= 16'
@@ -10059,7 +10059,7 @@ snapshots:
       react-lifecycles-compat: 3.0.4
       warning: 4.0.3
 
-  react-on-rails-pro-node-renderer@17.0.0-rc.6:
+  react-on-rails-pro-node-renderer@17.0.0-rc.7:
     dependencies:
       '@fastify/formbody': 8.0.2
       '@fastify/multipart': 9.4.0
@@ -10069,15 +10069,15 @@ snapshots:
       lockfile: 1.0.4
       pino: 9.14.0
 
-  react-on-rails-pro@17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4))(react@19.2.7):
+  react-on-rails-pro@17.0.0-rc.7(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      react-on-rails: 17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-on-rails: 17.0.0-rc.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:
-      react-on-rails-rsc: 19.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
+      react-on-rails-rsc: 19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4)
 
-  react-on-rails-rsc@19.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4):
+  react-on-rails-rsc@19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.4):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
@@ -10087,7 +10087,7 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.21)(webpack-cli@5.1.4)
       webpack-sources: 3.3.4
 
-  react-on-rails@17.0.0-rc.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-on-rails@17.0.0-rc.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)


### PR DESCRIPTION
## RC Test Report

Status: DONE_WITH_CONCERNS. Local install, build, RSC chunk verification, and browser smoke passed. One repeatable non-fatal dev-mode server warning was observed on the `/products` RSC smoke; the route still returned 200 and the browser verifier reported no console/page errors.

## Target Versions

- `react_on_rails` gem: `17.0.0.rc.7` (from `17.0.0.rc.6`)
- `react-on-rails` npm override: `17.0.0-rc.7` (from `17.0.0-rc.6`)
- `react_on_rails_pro` gem: `17.0.0.rc.7` (from `17.0.0.rc.6`)
- `react-on-rails-pro`: `17.0.0-rc.7` (from `17.0.0-rc.6`)
- `react-on-rails-pro-node-renderer`: `17.0.0-rc.7` (from `17.0.0-rc.6`)
- `react-on-rails-rsc`: `19.2.1-rc.0` (from `19.2.0`; stable `19.2.1` is not published)
- `shakapacker`: unchanged at gem/npm `10.2.0`
- `cpflow`: no bundled gem in this checkout; generated workflow wrappers left unchanged

## Baseline

- Last production deployed commit/version: UNKNOWN. No successful production-promotion run or production deployment record was discoverable from GitHub.
- Best deployed baseline: latest successful “Deploy Staging to Control Plane” run on `main`, commit `6975c3760c06bd56f402219bf3e1583fbf5e061e`, created 2026-07-05.
- Baseline package versions from that commit/default-branch lockfiles: RoR/Pro `17.0.0.rc.6` / `17.0.0-rc.6`, `react-on-rails-rsc` `19.2.0`, Shakapacker `10.2.0`.

## Changes

- Bumped only the consumed React on Rails, Pro, Pro node renderer, and RSC package pins plus lockfiles.
- Added `/products` as a thin alias for the existing RSC product-search page so the manifest smoke path exercises the product-grid/filter RSC surface.
- Added `/products` to the route verifier.
- Fixed one existing ESLint hook dependency error in the playground so `pnpm lint` can pass.

## Features Accounted For

- Product-grid/filter RSC surface: covered by existing `ProductSearchRSC` and now smokeable at `/products`.
- React 19.2 / `react-on-rails-rsc` line: direct RSC package moved to the release-plan fallback `19.2.1-rc.0`; React/React DOM remain `19.2.7`.
- Rspack v2 guard: repo already pins Rspack v2 packages and keeps RSC Rspack configs; unchanged because the requested build path is `bin/shakapacker`.
- Cached/static/buffered RSC helper coverage: existing product/blog/restaurant cached routes and `cacheComponent(... revalidate: 60)` remain in place; no forced demo expansion.
- Provider-backed `prefetchServerComponent`: not applicable; no provider-prefetch surface found in this app.
- Typed response generation / `createRailsAction`: not applicable; this app uses controller JSON endpoints plus RSC async props.
- Observability marks / `Server-Timing`: not applicable in current product search implementation; no explicit Server-Timing or observability-mark integration found.
- Generator/create-app defaults, Redux path, `bin/dev` cleanup, RSC doctor diagnostics, sensitive-props redaction, and renderer shutdown fixes: not directly app-facing here; install/build/smoke exercise generated packs, node renderer, RSC payload rendering, and browser hydration health.

## Validation

- `pnpm install` — passed.
- `bundle install` — passed.
- `bundle exec rspec` — passed, 0 examples.
- `bundle exec rake` — passed, 0 examples.
- `bundle exec rubocop` — passed, no offenses.
- `pnpm lint` — passed with existing warnings.
- `bundle exec rake react_on_rails:generate_packs` — passed.
- `bin/shakapacker` — passed on final tree with existing RSC client-reference advisory warnings.
- `RAILS_ENV=production NODE_ENV=production SECRET_KEY_BASE=dummy_secret_key_base_for_demo_fleet pnpm build:production && pnpm verify:rsc` — passed; RSC chunk verifier confirmed no heavy-library chunks reachable from RSC entry packs.
- `bundle exec rails db:prepare` — passed.
- Local smoke with node renderer + Rails: `BASE_URL=http://127.0.0.1:3017 ROUTES='/,/products' node .verify-routes.js` — passed: 2 total, 2 OK, 0 failures.
- `git diff --check` — passed.

## Known Concerns

- `/products` local dev smoke repeatedly logged a non-fatal async cleanup warning from the streaming path. Browser smoke still passed with HTTP 200 and no console/page errors. No existing target-repo issue was found; leaving as a release-gate concern for maintainer triage rather than opening a speculative issue.
- Build output includes existing RSC client-reference duplication advisories and asset-size warnings; they did not fail the build or RSC chunk verifier.

## Release Impact

No blocking install, build, RSC chunk, or browser-smoke regression was found for this hard-gate demo. Release readiness is DONE_WITH_CONCERNS pending maintainer judgment on the repeated non-fatal dev-mode streaming warning.
