### PR TITLE
Validate React on Rails 17 RC 10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,8 @@ gem 'turbo-rails'
 gem 'stimulus-rails'
 
 # React on Rails
-gem 'react_on_rails', '17.0.0.rc.7'
-gem 'react_on_rails_pro', '17.0.0.rc.7'
+gem 'react_on_rails', '17.0.0.rc.10'
+gem 'react_on_rails_pro', '17.0.0.rc.10'
 
 # Shakapacker for webpack integration
 gem 'shakapacker', '10.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,21 +298,21 @@ GEM
       prism (>= 1.6.0)
       rbs (>= 4.0.0)
       tsort
-    react_on_rails (17.0.0.rc.7)
+    react_on_rails (17.0.0.rc.10)
       addressable
       connection_pool
       execjs (~> 2.5)
       rails (>= 5.2)
       rainbow (~> 3.0)
       shakapacker (>= 6.0)
-    react_on_rails_pro (17.0.0.rc.7)
+    react_on_rails_pro (17.0.0.rc.10)
       async (>= 2.29)
       async-http (~> 0.95)
       execjs (~> 2.9)
       io-endpoint (~> 0.17.0)
       jwt (>= 2.5, < 4)
       nokogiri (>= 1.12, < 2)
-      react_on_rails (= 17.0.0.rc.7)
+      react_on_rails (= 17.0.0.rc.10)
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -431,8 +431,8 @@ DEPENDENCIES
   pry-byebug (~> 3.12)
   puma (~> 8.0)
   rails (~> 8.1)
-  react_on_rails (= 17.0.0.rc.7)
-  react_on_rails_pro (= 17.0.0.rc.7)
+  react_on_rails (= 17.0.0.rc.10)
+  react_on_rails_pro (= 17.0.0.rc.10)
   rspec-rails (~> 8.0)
   rubocop
   rubocop-rails

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-image-lightbox": "^5.1.4",
-    "react-on-rails-pro": "17.0.0-rc.7",
-    "react-on-rails-pro-node-renderer": "17.0.0-rc.7",
-    "react-on-rails-rsc": "19.2.1-rc.0",
+    "react-on-rails-pro": "17.0.0-rc.10",
+    "react-on-rails-pro-node-renderer": "17.0.0-rc.10",
+    "react-on-rails-rsc": "19.2.1-rc.1",
     "react-player": "^3.4.0",
     "react-server-dom-webpack": "19.2.7",
     "sanitize-html": "^2.17.5",
@@ -59,7 +59,7 @@
   "pnpm": {
     "overrides": {
       "@ungap/structured-clone": "1.3.1",
-      "react-on-rails": "17.0.0-rc.7",
+      "react-on-rails": "17.0.0-rc.10",
       "shakapacker": "10.2.0"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@ungap/structured-clone': 1.3.1
-  react-on-rails: 17.0.0-rc.7
+  react-on-rails: 17.0.0-rc.10
   shakapacker: 10.2.0
 
 importers:
@@ -77,14 +77,14 @@ importers:
         specifier: ^5.1.4
         version: 5.1.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-on-rails-pro:
-        specifier: 17.0.0-rc.7
-        version: 17.0.0-rc.7(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4))(react@19.2.7)
+        specifier: 17.0.0-rc.10
+        version: 17.0.0-rc.10(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.1-rc.1(@rspack/core@2.1.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4))(react@19.2.7)
       react-on-rails-pro-node-renderer:
-        specifier: 17.0.0-rc.7
-        version: 17.0.0-rc.7
+        specifier: 17.0.0-rc.10
+        version: 17.0.0-rc.10
       react-on-rails-rsc:
-        specifier: 19.2.1-rc.0
-        version: 19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4)
+        specifier: 19.2.1-rc.1
+        version: 19.2.1-rc.1(@rspack/core@2.1.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4)
       react-player:
         specifier: ^3.4.0
         version: 3.4.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -3118,9 +3118,6 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
-
   fast-uri@3.1.3:
     resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
@@ -4487,8 +4484,8 @@ packages:
       react: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19
       react-dom: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19
 
-  react-on-rails-pro-node-renderer@17.0.0-rc.7:
-    resolution: {integrity: sha512-qyB0wd1AU7KsPMJJyc3U3l4rgq8ZVR8FOAqNQ4riZ2adqeNfz5k5Gx1NKwKMWd51ri7fGqyZDFC8295bAIQEZw==}
+  react-on-rails-pro-node-renderer@17.0.0-rc.10:
+    resolution: {integrity: sha512-80UtYZrs+EveZ0hF4Xs5NuVW0UXUqFOtWMzRsCvzD8XKmVBPHnyXbUi30GojAJulBKohQg68nRrsEzTVWl4aCg==}
     engines: {node: '>=18.19.0'}
     peerDependencies:
       '@fastify/otel': '>=0.18.0 <1.0.0'
@@ -4529,14 +4526,14 @@ packages:
       '@sentry/tracing':
         optional: true
 
-  react-on-rails-pro@17.0.0-rc.7:
-    resolution: {integrity: sha512-tfHNFjlX0Vnb/t4GxUc3X3mw742hHcrR3VapYfz3kAlDPNnpMi03PzPVPxwAO5FeQloHvAKq9/rjUemdsRDSQQ==}
+  react-on-rails-pro@17.0.0-rc.10:
+    resolution: {integrity: sha512-Rk2whObHBFPr0+wf4ENXHFSqYsAXgiIGob/sgQGwZdweZwIRvF80wcNurQ4BMYbBB9XwaWQIgay+eC7+E+orYA==}
     peerDependencies:
       '@tanstack/react-router': '>=1.139.0 <2.0.0'
       ioredis: '>= 5'
       react: '>= 16'
       react-dom: '>= 16'
-      react-on-rails-rsc: '>=19.2.1-rc.0 <20.0.0'
+      react-on-rails-rsc: '>=19.2.1-rc.1 <20.0.0'
     peerDependenciesMeta:
       '@tanstack/react-router':
         optional: true
@@ -4545,15 +4542,19 @@ packages:
       react-on-rails-rsc:
         optional: true
 
-  react-on-rails-rsc@19.2.1-rc.0:
-    resolution: {integrity: sha512-lWUQloOMYS2/Jio7M9pKaY84+gNJ1ZD2pMTj37HDZtf6GsJjb0CJfJlizvxbquUdMQawX+1h59c63syFZ7AWmQ==}
+  react-on-rails-rsc@19.2.1-rc.1:
+    resolution: {integrity: sha512-ZwfZ2THm95Oo6a9cihkpK6SCEnEuZk298+q0DYACHImRXGlMXOzS5xwWl7jrB4FOYRWY576HC9sF7yRwO5wTrA==}
     peerDependencies:
+      '@rspack/core': ^1.0.0 || ^2.0.0
       react: ^19.2.7
       react-dom: ^19.2.7
       webpack: ^5.59.0
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
 
-  react-on-rails@17.0.0-rc.7:
-    resolution: {integrity: sha512-JWeDJeFUc8TEWtz4MWLMHpCIPBw3stKBx//EY8aPDZDwL1UxX3tnDDt/4JlIOzvGonz4ncGxEbEKcnBheyafDw==}
+  react-on-rails@17.0.0-rc.10:
+    resolution: {integrity: sha512-3W0xVwNxcNEyVX/Ayhiv0uybpRM1Rh4xonam9hPmDnbImDg6FJOyRO9q1IsD9Xu0hQCX15xKi9+LHu1VPzk94A==}
     peerDependencies:
       react: '>= 16'
       react-dom: '>= 16'
@@ -6680,7 +6681,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.0
+      fast-uri: 3.1.3
 
   '@fastify/busboy@3.2.0': {}
 
@@ -8653,7 +8654,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.0
+      fast-uri: 3.1.3
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -8662,8 +8663,6 @@ snapshots:
   fast-querystring@1.1.2:
     dependencies:
       fast-decode-uri-component: 1.0.1
-
-  fast-uri@3.1.0: {}
 
   fast-uri@3.1.3: {}
 
@@ -10062,7 +10061,7 @@ snapshots:
       react-lifecycles-compat: 3.0.4
       warning: 4.0.3
 
-  react-on-rails-pro-node-renderer@17.0.0-rc.7:
+  react-on-rails-pro-node-renderer@17.0.0-rc.10:
     dependencies:
       '@fastify/formbody': 8.0.2
       '@fastify/multipart': 9.4.0
@@ -10072,15 +10071,15 @@ snapshots:
       lockfile: 1.0.4
       pino: 9.14.0
 
-  react-on-rails-pro@17.0.0-rc.7(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4))(react@19.2.7):
+  react-on-rails-pro@17.0.0-rc.10(react-dom@19.2.7(react@19.2.7))(react-on-rails-rsc@19.2.1-rc.1(@rspack/core@2.1.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      react-on-rails: 17.0.0-rc.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-on-rails: 17.0.0-rc.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:
-      react-on-rails-rsc: 19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4)
+      react-on-rails-rsc: 19.2.1-rc.1(@rspack/core@2.1.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4)
 
-  react-on-rails-rsc@19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4):
+  react-on-rails-rsc@19.2.1-rc.1(@rspack/core@2.1.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
@@ -10088,9 +10087,11 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       react-server-dom-webpack: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4)
       webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)(webpack-cli@7.2.1)
-      webpack-sources: 3.3.4
+      webpack-sources: 3.5.1
+    optionalDependencies:
+      '@rspack/core': 2.1.2
 
-  react-on-rails@17.0.0-rc.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-on-rails@17.0.0-rc.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)


### PR DESCRIPTION
## Why

Replace the stale RC9 validation head with a clean RC10 dependency-only diff from the current default branch. This keeps the Marketplace hard-gate lane on the published RC10 package set without changing React, Shakapacker, application code, deployment configuration, or policy.

Tracker: https://github.com/shakacode/react_on_rails/issues/3823

## Exact versions

- `react_on_rails` and `react_on_rails_pro`: `17.0.0.rc.10`
- `react-on-rails`, `react-on-rails-pro`, and `react-on-rails-pro-node-renderer`: `17.0.0-rc.10`
- `react-on-rails-rsc`: `19.2.1-rc.1`
- Unchanged: React/React DOM `19.2.7`; Shakapacker `10.2.0`

## Scope and lockfiles

- Changed only `Gemfile`, `Gemfile.lock`, `package.json`, and `pnpm-lock.yaml`.
- The Bundler lock changes only the two requested gem versions and their exact dependency edge.
- The pnpm lock records the requested package versions, RSC RC1's optional Rspack peer edge, and the expected `fast-uri`/`webpack-sources` transitive resolutions.
- No platform-precompiled/source-build dependency changed. The only build-graph change is the RSC RC1 peer/transitive metadata above.
- Root Bundler and root pnpm lockfiles remain compatible with the repository's update ecosystem and directories.

## Evidence

- Frozen dependency checks passed; reinstall left all four artifact hashes unchanged.
- `bundle exec rubocop`: 82 files, no offenses.
- `script/demo-fleet-verify`: RSpec completed with no failures; RSC import lint passed; production build passed; 13 RSC entry packs passed chunk validation.
- Requested development build plus RSC chunk validation passed.
- Full production build passed.
- Local browser smoke passed for `/` and `/products`; temporary services were stopped.
- Local locked-package RSC smoke passed all 12 RSC routes; temporary services were stopped.
- Current-head review-app deployment passed, and its hosted browser smoke passed all 26 routes.
- Current-head Claude and CodeRabbit reviews passed; no inline or unresolved review threads remain.
- Bundled Codex CLI 0.144.2 reviewed the uncommitted four-file patch in a read-only, isolated configuration and reported no actionable regression.
- `git diff --check` passed.

The existing ESLint 10 configuration and TypeScript 6 deprecation failures predate this dependency diff and remain deliberately out of scope.

## Hosted E2E decision

- **Non-blocking skip:** the advisory `RSC + Rspack E2E gate` on the PR head (run `29300828038`) is red.
- **Decision:** do not change this dependency-only PR for that result.
- **Why:** the workflow discards this repository's pnpm lockfile and replaces the PR packages with source-checkout builds. It reproduces the same `atob` VM-global failure and exact error count as stale RC9 head `962d6204d646df8355ea37efcae4affe3c67340c`. An exact-tag dispatch for RC10/RC1 (run `29301266531`) repeats the unlocked-install failure, while both the committed-lock review app (26/26 routes) and local committed-lock RC10/RC1 smoke (12/12 RSC routes) pass. The unlocked range can now resolve `sanitize-html` `2.17.6` and its newer parser graph; the committed lock intentionally remains on the known-green graph.
- **Review later:** repair the source-checkout workflow's lockfile/install contract separately. This PR must not absorb workflow, sanitizer, parser, or renderer-policy changes.

## Immutable refs

- Base: `76f568b144ae9c0795af66452ad774929d085e84`
- Head: `558dd3b5a80c50009ae43109caaa5630c99b3a54`
- Replaced stale head: `962d6204d646df8355ea37efcae4affe3c67340c`

Tracker mode is development, so this PR must not be merged as part of this lane.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the application’s React on Rails integration to newer release candidates.
  - Improved compatibility and stability across server-rendered, client-rendered, and React Server Components workflows.
  - Included the latest corresponding integration updates to keep application components aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->