### PR TITLE
Fix Ruby version drift in Docker builds

### DIFF
--- a/.controlplane/Dockerfile
+++ b/.controlplane/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM ruby:3.3.0-slim AS base
+FROM ruby:3.4.6-slim AS base
 
 ENV NODE_VERSION=20.19.5
 ENV PNPM_VERSION=9.15.2

--- a/.controlplane/Dockerfile
+++ b/.controlplane/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1
-FROM ruby:3.4.6-slim AS base
+ARG RUBY_VERSION=3.4.6
+FROM ruby:${RUBY_VERSION}-slim AS base
 
 ENV NODE_VERSION=20.19.5
 ENV PNPM_VERSION=9.15.2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ plugins:
   - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.4
   # Warn about cops added by future RuboCop upgrades without failing this baseline.
   NewCops: pending
   # Avoid the local Prism parser load failure: cannot load such file --

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ This repo exists to make SSR, client components, and React Server Components eas
 
 ## Local setup
 
-1. Install Ruby `3.3.0`, PostgreSQL, and Node `20.x` or newer.
+1. Install Ruby `3.4.6`, PostgreSQL, and Node `20.x` or newer.
 2. Install dependencies:
 
    ```bash

--- a/bin/build-production
+++ b/bin/build-production
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+bin/check-ruby-versions
+
 echo "=== Building production assets ==="
 
 export RAILS_ENV=production

--- a/bin/check-ruby-versions
+++ b/bin/check-ruby-versions
@@ -9,21 +9,34 @@ DECLARATIONS = {
   'Gemfile' => [ROOT.join('Gemfile'), /^ruby\s+["']([^"']+)["']/],
   'Gemfile.lock' => [ROOT.join('Gemfile.lock'), /^RUBY VERSION\s*\n\s+ruby\s+(\S+)/],
   'mise.toml' => [ROOT.join('mise.toml'), /^ruby\s*=\s*["']([^"']+)["']/],
-  '.controlplane/Dockerfile' => [ROOT.join('.controlplane/Dockerfile'), /^FROM\s+ruby:([^-\s]+)-slim\b/],
-  'CONTRIBUTING.md' => [ROOT.join('CONTRIBUTING.md'), /Install Ruby\s+`([^`]+)`/]
+  '.controlplane/Dockerfile' => [
+    ROOT.join('.controlplane/Dockerfile'),
+    /^ARG\s+RUBY_VERSION=(\S+)\nFROM\s+ruby:\$\{RUBY_VERSION\}-slim\s+AS\s+base$/
+  ],
+  'CONTRIBUTING.md' => [ROOT.join('CONTRIBUTING.md'), /^\s*1\. Install Ruby\s+`([^`]+)`,/],
+  '.rubocop.yml' => [ROOT.join('.rubocop.yml'), /^\s*TargetRubyVersion:\s+(\S+)$/]
 }.freeze
 
 versions = DECLARATIONS.to_h do |label, (path, pattern)|
+  abort "Ruby version check failed: could not read #{label}" unless path.file?
+
   match = path.read.match(pattern)
   abort "Ruby version check failed: could not find the Ruby version in #{label}" unless match
 
   [label, match[1]]
 end
 
-if versions.values.uniq.one?
-  puts "Ruby version declarations agree: #{versions.values.first}"
+runtime_version = versions.fetch('Gemfile')
+expected_versions = versions.to_h { |label, _version| [label, runtime_version] }
+expected_versions['.rubocop.yml'] = runtime_version.split('.').first(2).join('.')
+mismatches = versions.reject { |label, version| version == expected_versions.fetch(label) }
+
+if mismatches.empty?
+  puts "Ruby version declarations agree: #{runtime_version}"
 else
   warn 'Ruby version declarations do not agree:'
-  versions.each { |label, version| warn "  #{label}: #{version}" }
+  versions.each do |label, version|
+    warn "  #{label}: #{version} (expected #{expected_versions.fetch(label)})"
+  end
   exit 1
 end

--- a/bin/check-ruby-versions
+++ b/bin/check-ruby-versions
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'pathname'
+
+ROOT = Pathname.new(__dir__).join('..').expand_path
+
+DECLARATIONS = {
+  'Gemfile' => [ROOT.join('Gemfile'), /^ruby\s+["']([^"']+)["']/],
+  'Gemfile.lock' => [ROOT.join('Gemfile.lock'), /^RUBY VERSION\s*\n\s+ruby\s+(\S+)/],
+  'mise.toml' => [ROOT.join('mise.toml'), /^ruby\s*=\s*["']([^"']+)["']/],
+  '.controlplane/Dockerfile' => [ROOT.join('.controlplane/Dockerfile'), /^FROM\s+ruby:([^-\s]+)-slim\b/],
+  'CONTRIBUTING.md' => [ROOT.join('CONTRIBUTING.md'), /Install Ruby\s+`([^`]+)`/]
+}.freeze
+
+versions = DECLARATIONS.to_h do |label, (path, pattern)|
+  match = path.read.match(pattern)
+  abort "Ruby version check failed: could not find the Ruby version in #{label}" unless match
+
+  [label, match[1]]
+end
+
+if versions.values.uniq.one?
+  puts "Ruby version declarations agree: #{versions.values.first}"
+else
+  warn 'Ruby version declarations do not agree:'
+  versions.each { |label, version| warn "  #{label}: #{version}" }
+  exit 1
+end


### PR DESCRIPTION
## Summary

- align the Control Plane Docker image with the app's Ruby 3.4.6 requirement
- make the Docker Ruby version a single explicit build argument consumed by the base image
- add an executable consistency check across the Gemfile, lockfile, mise config, Dockerfile, contributor setup docs, and RuboCop target
- run the check at the start of the CI-used production asset build

## Root cause

PR #126 updated `Gemfile`, `Gemfile.lock`, and `mise.toml` from Ruby 3.3.0 to 3.4.6, but `.controlplane/Dockerfile` stayed on `ruby:3.3.0-slim`. Bundler therefore failed before dependency installation with `Your Ruby version is 3.3.0, but your Gemfile specified 3.4.6`.

The PR review-app check appeared green because no review app existed, so it did not build the production image. That workflow gap is tracked upstream in [shakacode/control-plane-flow#412](https://github.com/shakacode/control-plane-flow/issues/412).

## Validation

- Red: before aligning the Dockerfile and docs, `bin/check-ruby-versions` exited 1 and identified both remaining 3.3.0 declarations.
- Green: `git diff --check origin/main...HEAD`, `bin/check-ruby-versions`, Ruby syntax, shell syntax, and full-repo RuboCop pass.
- `bin/build-production` completes pack generation and the Rspack production build.
- Independent QA completed `docker build --progress=plain --target build -f .controlplane/Dockerfile -t pr132-final-qa:a132da3 .`, producing image `sha256:8d75fca38636091484083537840e5a8bcee8d60c7c1773706b3558f29c4bba7f`.
- The QA image reports Ruby 3.4.6 and Bundler 4.0.10.
- A current-head second-model review found no actionable defect.

## Decisions

- Browser Smoke already invokes `bin/build-production`, so declaration drift fails on every PR even when no review app is provisioned.
- The checker verifies both the Docker Ruby argument and that the base image consumes it.
- The existing Docker `SECRET_KEY_BASE` ARG warning and Rspack size/module warnings are unchanged and outside this fix.
- Changelog classification: not user-visible.
- Merge authority: `auto_merge_when_gates_pass`.

### QA Evidence

- QA lane: `pr132_final_qa`, read-only `/private/tmp/rsc-ruby-docker-runtime`; exact committed head and clean worktree verified before and after testing
- Scope checked: complete diff, Ruby declarations, CI safeguard wiring, production asset build, actual Docker build target, and image runtime versions
- Tested at: `a132da3b3e18f0a18e99d3791a033e10020ec767`
- Automated checks: diff check, version checker, Ruby and shell syntax, full-repo RuboCop, production asset build, Docker build target, and image runtime probes all passed
- Findings: none; pre-existing Docker secret-ARG, RuboCop new-cop, and Rspack warnings are non-blocking and unchanged
- QA required: yes
- QA required rationale: this changes the production deployment runtime and build configuration
- QA lane status: satisfied
- Release-blocking status: clear
- Process-gap disposition: upstream issue [#412](https://github.com/shakacode/control-plane-flow/issues/412)

<!-- qa-evidence v1
required: yes
status: satisfied
head_sha: a132da3b3e18f0a18e99d3791a033e10020ec767
tested_at: a132da3b3e18f0a18e99d3791a033e10020ec767
scope: complete diff, Ruby declarations, CI safeguard wiring, production asset build, Control Plane Docker build target, and image runtime versions
automated_checks: diff check, version checker, syntax, full-repo RuboCop, production asset build, Docker build, and image runtime probes all passed
manual_checks: inspected exact committed diff and confirmed Ruby 3.4.6 plus Bundler 4.0.10 in the QA image
findings: none
release_blocking: clear
process_gap_disposition: script
-->

<!-- priority-finding-dispositions v1
head_sha: a132da3b3e18f0a18e99d3791a033e10020ec767
finding: url=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/pull/132#discussion_r3569114432 | severity=Must-Fix | disposition=fixed | evidence=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/commit/a132da3b3e18f0a18e99d3791a033e10020ec767 | waiver=none
finding: url=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/pull/132#discussion_r3569114607 | severity=P3 | disposition=fixed | evidence=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/commit/a132da3b3e18f0a18e99d3791a033e10020ec767 | waiver=none
finding: url=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/pull/132#discussion_r3569114800 | severity=P3 | disposition=fixed | evidence=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/commit/a132da3b3e18f0a18e99d3791a033e10020ec767 | waiver=none
finding: url=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/pull/132#discussion_r3569115023 | severity=Must-Fix | disposition=fixed | evidence=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/commit/a132da3b3e18f0a18e99d3791a033e10020ec767 | waiver=none
-->
