### PR TITLE
Fix production Docker server bundles

### DIFF
--- a/.controlplane/Dockerfile
+++ b/.controlplane/Dockerfile
@@ -52,21 +52,11 @@ ARG SECRET_KEY_BASE=dummy_secret_for_asset_compilation
 ARG RSC_CACHE_ENABLED=false
 ARG REACT_COMPILER_ENABLED=false
 
-RUN RAILS_ENV=production \
-    NODE_ENV=production \
-    SECRET_KEY_BASE=$SECRET_KEY_BASE \
+RUN SECRET_KEY_BASE=$SECRET_KEY_BASE \
     REACT_ON_RAILS_PRO_LICENSE=$REACT_ON_RAILS_PRO_LICENSE \
     RSC_CACHE_ENABLED=$RSC_CACHE_ENABLED \
     REACT_COMPILER_ENABLED=$REACT_COMPILER_ENABLED \
-    bundle exec rake react_on_rails:generate_packs
-
-RUN RAILS_ENV=production \
-    NODE_ENV=production \
-    SECRET_KEY_BASE=$SECRET_KEY_BASE \
-    REACT_ON_RAILS_PRO_LICENSE=$REACT_ON_RAILS_PRO_LICENSE \
-    RSC_CACHE_ENABLED=$RSC_CACHE_ENABLED \
-    REACT_COMPILER_ENABLED=$REACT_COMPILER_ENABLED \
-    bin/shakapacker
+    bin/build-production
 
 # ============================================================
 # Production stage - minimal runtime image

--- a/bin/build-production
+++ b/bin/build-production
@@ -26,11 +26,23 @@ bundle exec rake react_on_rails:generate_packs
 echo "--- Compiling ${SHAKAPACKER_ASSETS_BUNDLER} bundles ---"
 bin/shakapacker
 
-for artifact in \
-  ssr-generated/server-bundle.js \
-  ssr-generated/rsc-bundle.js \
-  ssr-generated/react-server-client-manifest.json \
-  public/packs/loadable-stats.json; do
+# 4. Validate the artifacts requested by the selected bundle mode
+if [[ -n "${WEBPACK_SERVE:-}" || -n "${CLIENT_BUNDLE_ONLY:-}" ]]; then
+  required_artifacts=(public/packs/loadable-stats.json)
+elif [[ -n "${SERVER_BUNDLE_ONLY:-}" ]]; then
+  required_artifacts=(ssr-generated/server-bundle.js)
+elif [[ -n "${RSC_BUNDLE_ONLY:-}" ]]; then
+  required_artifacts=(ssr-generated/rsc-bundle.js)
+else
+  required_artifacts=(
+    ssr-generated/server-bundle.js
+    ssr-generated/rsc-bundle.js
+    ssr-generated/react-server-client-manifest.json
+    public/packs/loadable-stats.json
+  )
+fi
+
+for artifact in "${required_artifacts[@]}"; do
   if [[ ! -s "${artifact}" ]]; then
     echo "Missing or empty required production artifact: ${artifact}" >&2
     exit 1

--- a/bin/build-production
+++ b/bin/build-production
@@ -16,13 +16,25 @@ rm -rf app/javascript/packs/generated
 rm -rf app/javascript/generated
 rm -rf .node-renderer-bundles
 rm -rf public/packs
+rm -rf ssr-generated
 
 # 2. Generate auto-bundled packs (react_on_rails auto_load_bundle)
 echo "--- Generating packs ---"
 bundle exec rake react_on_rails:generate_packs
 
-# 2. Compile all asset bundles (client, server, RSC)
+# 3. Compile all asset bundles (client, server, RSC)
 echo "--- Compiling ${SHAKAPACKER_ASSETS_BUNDLER} bundles ---"
 bin/shakapacker
+
+for artifact in \
+  ssr-generated/server-bundle.js \
+  ssr-generated/rsc-bundle.js \
+  ssr-generated/react-server-client-manifest.json \
+  public/packs/loadable-stats.json; do
+  if [[ ! -s "${artifact}" ]]; then
+    echo "Missing or empty required production artifact: ${artifact}" >&2
+    exit 1
+  fi
+done
 
 echo "=== Production build complete ==="

--- a/bin/build-production
+++ b/bin/build-production
@@ -28,9 +28,16 @@ bin/shakapacker
 
 # 4. Validate the artifacts requested by the selected bundle mode
 if [[ -n "${WEBPACK_SERVE:-}" || -n "${CLIENT_BUNDLE_ONLY:-}" ]]; then
-  required_artifacts=(public/packs/loadable-stats.json)
+  required_artifacts=(
+    public/packs/manifest.json
+    public/packs/react-client-manifest.json
+    public/packs/loadable-stats.json
+  )
 elif [[ -n "${SERVER_BUNDLE_ONLY:-}" ]]; then
-  required_artifacts=(ssr-generated/server-bundle.js)
+  required_artifacts=(
+    ssr-generated/server-bundle.js
+    ssr-generated/react-server-client-manifest.json
+  )
 elif [[ -n "${RSC_BUNDLE_ONLY:-}" ]]; then
   required_artifacts=(ssr-generated/rsc-bundle.js)
 else
@@ -38,6 +45,8 @@ else
     ssr-generated/server-bundle.js
     ssr-generated/rsc-bundle.js
     ssr-generated/react-server-client-manifest.json
+    public/packs/manifest.json
+    public/packs/react-client-manifest.json
     public/packs/loadable-stats.json
   )
 fi


### PR DESCRIPTION
## Summary

- run the Control Plane Docker asset build through the same `bin/build-production` path used by Browser Smoke
- clean prior server output and fail the build unless every required server/runtime artifact is non-empty
- keep the production image on the verified Rspack path instead of Docker's duplicated default-Webpack commands

Follow-up to #132. That PR fixed the Ruby 3.3.0/3.4.6 mismatch; once Bundler could finish, the first `main` staging build exposed this separate final-image failure.

## Root cause

The Dockerfile duplicated production asset commands instead of calling `bin/build-production`. The shared script defaults to Rspack, but the Docker path ran Shakapacker's default Webpack flow and never produced `/app/ssr-generated`. Earlier validation built only the Docker `build` target, so it did not exercise the production-stage `COPY --from=build /app/ssr-generated` instruction.

The PR review-app check did not catch either problem because no review app was provisioned, so the reusable workflow completed without building an image. The upstream safeguard/documentation gap is tracked in [control-plane-flow#412](https://github.com/shakacode/control-plane-flow/issues/412).

## Validation

- reproduced the clean full-image failure on the merged base: `/app/ssr-generated` not found ([failed staging run](https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/actions/runs/29238526217))
- `git diff --check origin/main...HEAD`
- `bash -n bin/build-production`
- `bin/check-ruby-versions`
- `bundle exec rubocop` — 81 files, 0 offenses
- `CLIENT_BUNDLE_ONLY=1 bin/build-production`
- `SERVER_BUNDLE_ONLY=1 bin/build-production`
- `RSC_BUNDLE_ONLY=1 bin/build-production`
- `bin/build-production`
- red/green missing-manifest probes: the prior checks accepted incomplete client/server outputs; the updated checks reject both with the exact missing-artifact error
- independent no-cache full production image build, with no `--target`: image `sha256:bcc514388fd4914ea21658fe67f30ee3cf6bce5d51ee95532b3e061d47b668fc`
- final image inspection: Ruby 3.4.6, Bundler 4.0.10, and six non-empty runtime bundles/manifests

### QA Evidence

- QA lane: `/root/ssr_docker_final_qa`, `jg-codex/fix-production-docker-ssr` at `/private/tmp/rsc-ruby-docker-runtime`; private QA claim/heartbeat UNKNOWN; lane completed with PASS
- Scope checked: Docker production build path, clean-output behavior, required runtime artifacts, Ruby/Bundler runtime, full branch diff
- Tested at: `f158d2717c3e68270aaabdccc523f5e2c6379d65`
- Automated checks: diff check, shell syntax, Ruby-version consistency, full RuboCop, red/green missing-manifest probes, client-only/server-only/RSC-only production builds, full production asset build, no-cache full final Docker image build
- Manual checks: overridden-entrypoint final-image inspection of runtime versions and six non-empty required artifacts
- Findings: five review findings fixed at the tested head; one Webpack-override finding rejected as a verified pre-existing silent incomplete build; no remaining blockers
- QA required: yes
- QA required rationale: this changes the release-affecting production image build and repairs a failed staging deployment
- QA lane status: satisfied
- Release-blocking status: clear
- Process-gap disposition: script

<!-- qa-evidence v1
required: yes
status: satisfied
head_sha: f158d2717c3e68270aaabdccc523f5e2c6379d65
tested_at: f158d2717c3e68270aaabdccc523f5e2c6379d65
scope: Docker production build path, clean server output, required runtime artifacts, and final image runtime
automated_checks: git diff check; shell syntax; Ruby version consistency; full RuboCop; red/green missing-manifest probes; client-only, server-only, and RSC-only production builds; full production asset build; no-cache full final Docker image build sha256:bcc514388fd4914ea21658fe67f30ee3cf6bce5d51ee95532b3e061d47b668fc
manual_checks: final-image inspection confirmed Ruby 3.4.6, Bundler 4.0.10, and six non-empty required runtime artifacts
findings: five review findings fixed at current head; one Webpack-override finding verified false-positive against merged base; no remaining blockers
release_blocking: clear
process_gap_disposition: script
-->

<!-- priority-finding-dispositions v1
head_sha: f158d2717c3e68270aaabdccc523f5e2c6379d65
finding: url=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/pull/133#issuecomment-4956583705 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/commit/2032acfc68fd5a00b20c7eaf22ff5d963f721883
finding: url=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/pull/133#issuecomment-4956583705 | severity=P3 | disposition=fixed | evidence=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/commit/2032acfc68fd5a00b20c7eaf22ff5d963f721883
finding: url=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/pull/133#discussion_r3569605146 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/commit/446e7092a5120acc1a7734a560f756c572645349
finding: url=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/pull/133#issuecomment-4956789008 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/commit/f158d2717c3e68270aaabdccc523f5e2c6379d65
finding: url=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/pull/133#issuecomment-4956789008 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/commit/f158d2717c3e68270aaabdccc523f5e2c6379d65
finding: url=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/pull/133#issuecomment-4956869858 | severity=P2 | disposition=false_positive | evidence=https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/pull/133#issuecomment-4956869858
-->

## Changelog

Not user-facing; no changelog entry needed.
