### PR TITLE
Harden Docker Ruby version validation

### DIFF
--- a/bin/check-ruby-versions
+++ b/bin/check-ruby-versions
@@ -5,13 +5,19 @@ require 'pathname'
 
 ROOT = Pathname.new(__dir__).join('..').expand_path
 
+DOCKERFILE_RUBY_VERSION_PATTERN = /
+  ^ARG[ \t]+RUBY_VERSION=(\S+)[ \t]*\r?\n
+  (?:[ \t]*(?:\#[^\r\n]*)?\r?\n)*
+  FROM[ \t]+ruby:\$\{RUBY_VERSION\}-slim[ \t]+AS[ \t]+base[ \t]*$
+/x
+
 DECLARATIONS = {
   'Gemfile' => [ROOT.join('Gemfile'), /^ruby\s+["']([^"']+)["']/],
   'Gemfile.lock' => [ROOT.join('Gemfile.lock'), /^RUBY VERSION\s*\n\s+ruby\s+(\S+)/],
   'mise.toml' => [ROOT.join('mise.toml'), /^ruby\s*=\s*["']([^"']+)["']/],
   '.controlplane/Dockerfile' => [
     ROOT.join('.controlplane/Dockerfile'),
-    /^ARG\s+RUBY_VERSION=(\S+)\nFROM\s+ruby:\$\{RUBY_VERSION\}-slim\s+AS\s+base$/
+    DOCKERFILE_RUBY_VERSION_PATTERN
   ],
   'CONTRIBUTING.md' => [ROOT.join('CONTRIBUTING.md'), /^\s*1\. Install Ruby\s+`([^`]+)`,/],
   '.rubocop.yml' => [ROOT.join('.rubocop.yml'), /^\s*TargetRubyVersion:\s+(\S+)$/]

--- a/test/bin/check_ruby_versions_test.rb
+++ b/test/bin/check_ruby_versions_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'minitest/autorun'
+require 'open3'
+require 'rbconfig'
+require 'tmpdir'
+
+# Exercises the repository-level Ruby declaration consistency check.
+class CheckRubyVersionsTest < Minitest::Test
+  CHECKER = File.expand_path('../../bin/check-ruby-versions', __dir__)
+
+  def test_accepts_non_adjacent_dockerfile_version_declarations
+    stdout, stderr, status = run_checker(<<~DOCKERFILE)
+      ARG RUBY_VERSION=3.4.6
+
+      # Keep the base image declaration readable and independently documented.
+      FROM ruby:${RUBY_VERSION}-slim AS base
+    DOCKERFILE
+
+    assert_predicate status, :success?, stderr
+    assert_includes stdout, 'Ruby version declarations agree: 3.4.6'
+  end
+
+  def test_requires_dockerfile_base_image_to_use_the_version_argument
+    _stdout, stderr, status = run_checker(<<~DOCKERFILE)
+      ARG RUBY_VERSION=3.4.6
+      FROM ruby:3.4.6-slim AS base
+    DOCKERFILE
+
+    assert_equal false, status.success?
+    assert_includes stderr, 'could not find the Ruby version in .controlplane/Dockerfile'
+  end
+
+  def test_rejects_a_stale_version_before_a_duplicate_argument
+    _stdout, stderr, status = run_checker(<<~DOCKERFILE)
+      ARG RUBY_VERSION=3.4.6
+      ARG RUBY_VERSION=3.3.0
+      FROM ruby:${RUBY_VERSION}-slim AS base
+    DOCKERFILE
+
+    assert_equal false, status.success?
+    assert_includes stderr, '.controlplane/Dockerfile: 3.3.0 (expected 3.4.6)'
+  end
+
+  private
+
+  def run_checker(dockerfile)
+    Dir.mktmpdir do |root|
+      write_declarations(root, dockerfile)
+      FileUtils.mkdir_p(File.join(root, 'bin'))
+      FileUtils.cp(CHECKER, File.join(root, 'bin/check-ruby-versions'))
+
+      Open3.capture3(RbConfig.ruby, File.join(root, 'bin/check-ruby-versions'))
+    end
+  end
+
+  def write_declarations(root, dockerfile)
+    write_fixture(root, 'Gemfile', "ruby '3.4.6'\n")
+    write_fixture(root, 'Gemfile.lock', "RUBY VERSION\n   ruby 3.4.6\n")
+    write_fixture(root, 'mise.toml', "ruby = '3.4.6'\n")
+    write_fixture(root, '.controlplane/Dockerfile', dockerfile)
+    write_fixture(root, 'CONTRIBUTING.md', "1. Install Ruby `3.4.6`, then install dependencies.\n")
+    write_fixture(root, '.rubocop.yml', "AllCops:\n  TargetRubyVersion: 3.4\n")
+  end
+
+  def write_fixture(root, relative_path, contents)
+    path = File.join(root, relative_path)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, contents)
+  end
+end


### PR DESCRIPTION
Valid Dockerfile comments or blank lines between the Ruby build argument and base image no longer cause production validation to abort. The check remains fail-closed: it still rejects a hard-coded base image and catches duplicate arguments when the effective value drifts. Focused regressions, full RuboCop, and the complete production asset build pass.

Related: #132

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
