### PR TITLE
Restore marketplace validation gates

### DIFF
--- a/.github/workflows/browser-smoke.yml
+++ b/.github/workflows/browser-smoke.yml
@@ -67,6 +67,12 @@ jobs:
       - name: Install JavaScript dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run canonical lint gate
+        run: .agents/bin/lint
+
+      - name: Audit high-severity JavaScript dependencies
+        run: pnpm audit:high
+
       - name: Cache Puppeteer Chromium
         id: puppeteer-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -96,8 +102,8 @@ jobs:
         # db:seed again duplicates order numbers and fails the smoke setup.
         run: bin/rails db:prepare
 
-      - name: Build production assets
-        run: bin/build-production
+      - name: Run canonical demo validation
+        run: .agents/bin/validate
 
       - name: Smoke real routes in Chromium
         shell: bash

--- a/.github/workflows/browser-smoke.yml
+++ b/.github/workflows/browser-smoke.yml
@@ -103,6 +103,8 @@ jobs:
         run: bin/rails db:prepare
 
       - name: Run canonical demo validation
+        env:
+          RAILS_ENV: test
         run: .agents/bin/validate
 
       - name: Smoke real routes in Chromium

--- a/app/helpers/rsc_manifest_css_helper.rb
+++ b/app/helpers/rsc_manifest_css_helper.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
+# Resolves stylesheet assets emitted for React Server Components.
 module RscManifestCssHelper
-  RSC_MANIFEST_IMPLEMENTATION_DEFAULT = "release"
-  CLIENT_MANIFEST_PATH = Rails.root.join("public/packs/react-client-manifest.json")
-  SERVER_MANIFEST_PATH = Rails.root.join("ssr-generated/react-server-client-manifest.json")
+  RSC_MANIFEST_IMPLEMENTATION_DEFAULT = 'release'
+  CLIENT_MANIFEST_PATH = Rails.root.join('public/packs/react-client-manifest.json')
+  SERVER_MANIFEST_PATH = Rails.root.join('ssr-generated/react-server-client-manifest.json')
   STARTUP_EXTENSIONS = %w[.tsx .ts .jsx .js].freeze
   GENERATED_PACK_EXTENSIONS = %w[.js .jsx .ts .tsx].freeze
   SIMPLE_REEXPORT_RE = /^\s*export\s+\{\s*default\s*\}\s+from\s+["']([^"']+)["']/
 
   def current_rsc_build_implementation
-    ENV.fetch("RSC_BUILD_IMPLEMENTATION", RSC_MANIFEST_IMPLEMENTATION_DEFAULT)
+    ENV.fetch('RSC_BUILD_IMPLEMENTATION', RSC_MANIFEST_IMPLEMENTATION_DEFAULT)
   end
 
   def append_rsc_server_component_manifest_css(component_name)
@@ -17,7 +18,7 @@ module RscManifestCssHelper
     return false if hrefs.empty?
 
     content_for :head do
-      safe_join(hrefs.map { |href| stylesheet_link_tag(href, media: "all") }, "\n")
+      safe_join(hrefs.map { |href| stylesheet_link_tag(href, media: 'all') }, "\n")
     end
 
     true
@@ -39,18 +40,17 @@ module RscManifestCssHelper
     @combined_rsc_server_component_css ||= begin
       manifests = [load_rsc_manifest(CLIENT_MANIFEST_PATH), load_rsc_manifest(SERVER_MANIFEST_PATH)]
       manifests.each_with_object({}) do |manifest, result|
-        server_component_css = manifest["serverComponentCss"]
-        next result unless server_component_css.is_a?(Hash)
-
-        server_component_css.each do |key, hrefs|
-          next unless hrefs.is_a?(Array)
-
-          result[key] ||= []
-          hrefs.each do |href|
-            result[key] << href unless result[key].include?(href)
-          end
-        end
+        merge_server_component_css(manifest, result)
       end
+    end
+  end
+
+  def merge_server_component_css(manifest, result)
+    server_component_css = manifest['serverComponentCss']
+    return unless server_component_css.is_a?(Hash)
+
+    server_component_css.each do |key, hrefs|
+      result[key] = Array(result[key]) | hrefs if hrefs.is_a?(Array)
     end
   end
 
@@ -95,7 +95,7 @@ module RscManifestCssHelper
   end
 
   def resolve_relative_module_path(base_directory, specifier)
-    return nil unless specifier.start_with?(".", "..")
+    return nil unless specifier.start_with?('.', '..')
 
     base_path = base_directory.join(specifier)
     candidates = [base_path]

--- a/app/javascript/components/blog/ReadingModeToggle.tsx
+++ b/app/javascript/components/blog/ReadingModeToggle.tsx
@@ -1,10 +1,13 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useSyncExternalStore } from 'react';
 
 type ReadingMode = 'default' | 'compact' | 'dark';
 
 const STORAGE_KEY = 'blog:reading-mode';
+const subscribeToHydration = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
 
 const modes: { value: ReadingMode; label: string; icon: string }[] = [
   { value: 'default', label: 'Default', icon: 'A' },
@@ -19,19 +22,30 @@ function applyMode(mode: ReadingMode) {
   root.classList.add(`reading-mode-${mode}`);
 }
 
+function storedMode(): ReadingMode {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return stored === 'compact' || stored === 'dark' || stored === 'default' ? stored : 'default';
+  } catch {
+    return 'default';
+  }
+}
+
 export function ReadingModeToggle() {
-  const [mode, setMode] = useState<ReadingMode>('default');
+  const hydrated = useSyncExternalStore(subscribeToHydration, getClientSnapshot, getServerSnapshot);
+  const [selectedMode, setSelectedMode] = useState<ReadingMode | null>(null);
+  const mode = selectedMode ?? (hydrated ? storedMode() : 'default');
 
   useEffect(() => {
-    const stored = (typeof window !== 'undefined' && window.localStorage.getItem(STORAGE_KEY)) as ReadingMode | null;
-    const initial: ReadingMode = stored === 'compact' || stored === 'dark' || stored === 'default' ? stored : 'default';
-    setMode(initial);
-    applyMode(initial);
+    applyMode(mode);
+  }, [mode]);
+
+  useEffect(() => {
     return () => applyMode('default');
   }, []);
 
   const handleSelect = (next: ReadingMode) => {
-    setMode(next);
+    setSelectedMode(next);
     applyMode(next);
     try {
       window.localStorage.setItem(STORAGE_KEY, next);

--- a/app/javascript/components/product-search/SearchInput.tsx
+++ b/app/javascript/components/product-search/SearchInput.tsx
@@ -7,11 +7,13 @@ interface Props {
 
 export function SearchInput({ initialQuery, onSearch }: Props) {
   const [query, setQuery] = useState(initialQuery);
+  const [previousInitialQuery, setPreviousInitialQuery] = useState(initialQuery);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  useEffect(() => {
+  if (initialQuery !== previousInitialQuery) {
+    setPreviousInitialQuery(initialQuery);
     setQuery(initialQuery);
-  }, [initialQuery]);
+  }
 
   useEffect(() => () => {
     if (debounceRef.current) {

--- a/app/javascript/components/ssr-rsc-playground/model/simulate.ts
+++ b/app/javascript/components/ssr-rsc-playground/model/simulate.ts
@@ -125,7 +125,7 @@ function simulateSSR(sections: PageSection[], net: NetworkProfile): Architecture
     startMs: hydrationStart,
     endMs: hydrationEnd,
     color: '#ef4444',
-    row: row++,
+    row,
   });
 
   const ttiMs = hydrationEnd;

--- a/app/javascript/components/ssr-rsc-playground/ui/RscSolution.tsx
+++ b/app/javascript/components/ssr-rsc-playground/ui/RscSolution.tsx
@@ -100,7 +100,7 @@ function tokenizeLine(raw: string): Seg[] {
     if ((match = rest.match(/^(export|default|async|function|return|await)\b/))) {
       segs.push({ text: match[0], color: '#c084fc' });
       rest = rest.slice(match[0].length);
-    } else if ((match = rest.match(/^<\/?/)) && rest.match(/^<\/?(Layout|Suspense|Header|Menu|Cart|Reviews|div)/)) {
+    } else if (/^<\/?(Layout|Suspense|Header|Menu|Cart|Reviews|div)/.test(rest)) {
       const tagMatch = rest.match(/^(<\/?)(Layout|Suspense|Header|Menu|Cart|Reviews|div)/)!;
       segs.push({ text: tagMatch[1], color: '#cbd5e1' });
       segs.push({ text: tagMatch[2], color: '#60a5fa' });

--- a/app/javascript/types/assets.d.ts
+++ b/app/javascript/types/assets.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,12 @@ import globals from 'globals';
 
 export default [
   {
-    ignores: ['public/**', 'node_modules/**'],
+    ignores: [
+      'public/**',
+      'node_modules/**',
+      'app/javascript/packs/generated/**',
+      'app/javascript/generated/**',
+    ],
   },
   js.configs.recommended,
   ...typescriptEslint.configs['flat/recommended'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,53 @@
+import { fixupConfigRules } from '@eslint/compat';
+import js from '@eslint/js';
+import typescriptEslint from '@typescript-eslint/eslint-plugin';
+import react from 'eslint-plugin-react';
+import reactCompiler from 'eslint-plugin-react-compiler';
+import reactHooks from 'eslint-plugin-react-hooks';
+import globals from 'globals';
+
+export default [
+  {
+    ignores: ['public/**', 'node_modules/**'],
+  },
+  js.configs.recommended,
+  ...typescriptEslint.configs['flat/recommended'],
+  ...fixupConfigRules(react.configs.flat.recommended),
+  ...fixupConfigRules(react.configs.flat['jsx-runtime']),
+  reactHooks.configs.flat.recommended,
+  reactCompiler.configs.recommended,
+  {
+    files: ['app/javascript/**/*.{js,jsx,ts,tsx}'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+    rules: {
+      // Existing demo/RSC boundary code intentionally keeps legacy React imports
+      // and loose payload types; keep the first lint gate focused on new issues.
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^(_|React$)' },
+      ],
+      'react/no-unescaped-entities': 'off',
+      'react/prop-types': 'off',
+      'react-hooks/exhaustive-deps': 'error',
+      'react-compiler/react-compiler': 'error',
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "renderer": "node node-renderer.js",
     "lint": "eslint app/javascript --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint app/javascript --ext .js,.jsx,.ts,.tsx --fix",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit --ignoreDeprecations 6.0 --types node",
+    "audit:high": "pnpm audit --audit-level high",
     "yalc:publish": "cd /mnt/ssd/react_on_rails_v16.3 && pnpm build && cd packages/react-on-rails && yalc publish --force && cd ../react-on-rails-pro && yalc publish --force && cd ../react-on-rails-pro-node-renderer && yalc publish --force",
     "yalc:link": "yalc add react-on-rails-pro react-on-rails-pro-node-renderer",
     "yalc:setup": "pnpm yalc:publish && pnpm yalc:link && pnpm install",
@@ -61,12 +62,15 @@
   "pnpm": {
     "overrides": {
       "@ungap/structured-clone": "1.3.1",
+      "lodash": "4.18.1",
       "react-on-rails": "17.0.0-rc.10",
       "shakapacker": "10.2.0"
     }
   },
   "devDependencies": {
     "acorn-loose": "^8.5.2",
+    "@eslint/compat": "^2.1.0",
+    "@eslint/js": "^10.0.1",
     "@babel/core": "^8.0.1",
     "@babel/preset-env": "^8.0.2",
     "@babel/preset-react": "^8.0.1",
@@ -88,6 +92,7 @@
     "@types/d3-time": "^3.0.4",
     "@types/d3-time-format": "^4.0.3",
     "@types/express": "^4.17.25",
+    "@types/node": "^22.20.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.0.0",
     "@types/sanitize-html": "^2.16.1",
@@ -102,6 +107,7 @@
     "eslint-plugin-react": "^7.34.0",
     "eslint-plugin-react-compiler": "19.1.0-rc.2",
     "eslint-plugin-react-hooks": "^7.1.1",
+    "globals": "^17.7.0",
     "mini-css-extract-plugin": "^2.10.2",
     "postcss": "^8.5.16",
     "postcss-loader": "^8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@ungap/structured-clone': 1.3.1
+  lodash: 4.18.1
   react-on-rails: 17.0.0-rc.10
   shakapacker: 10.2.0
 
@@ -116,6 +117,12 @@ importers:
       '@babel/preset-typescript':
         specifier: ^8.0.1
         version: 8.0.1(@babel/core@8.0.1)
+      '@eslint/compat':
+        specifier: ^2.1.0
+        version: 2.1.0(eslint@10.6.0(jiti@2.7.0))
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.6.0(jiti@2.7.0))
       '@loadable/babel-plugin':
         specifier: ^5.16.1
         version: 5.16.1(@babel/core@8.0.1)
@@ -167,6 +174,9 @@ importers:
       '@types/express':
         specifier: ^4.17.25
         version: 4.17.25
+      '@types/node':
+        specifier: ^22.20.1
+        version: 22.20.1
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -212,6 +222,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
         version: 7.1.1(eslint@10.6.0(jiti@2.7.0))
+      globals:
+        specifier: ^17.7.0
+        version: 17.7.0
       mini-css-extract-plugin:
         specifier: ^2.10.2
         version: 2.10.2(webpack@5.108.4)
@@ -1294,6 +1307,15 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
+  '@eslint/compat@2.1.0':
+    resolution: {integrity: sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^8.40 || 9 || 10
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+
   '@eslint/config-array@0.23.5':
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -1305,6 +1327,15 @@ packages:
   '@eslint/core@1.2.1':
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
 
   '@eslint/object-schema@3.0.5':
     resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
@@ -2178,8 +2209,8 @@ packages:
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
-  '@types/node@26.1.0':
-    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@types/qs@6.15.1':
     resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
@@ -3269,6 +3300,10 @@ packages:
     peerDependencies:
       tslib: '2'
 
+  globals@17.7.0:
+    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
+    engines: {node: '>=18'}
+
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
@@ -3825,8 +3860,8 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -5203,8 +5238,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@8.3.0:
-    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -6657,6 +6692,12 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.2': {}
 
+  '@eslint/compat@2.1.0(eslint@10.6.0(jiti@2.7.0))':
+    dependencies:
+      '@eslint/core': 1.2.1
+    optionalDependencies:
+      eslint: 10.6.0(jiti@2.7.0)
+
   '@eslint/config-array@0.23.5':
     dependencies:
       '@eslint/object-schema': 3.0.5
@@ -6672,6 +6713,10 @@ snapshots:
   '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
+
+  '@eslint/js@10.0.1(eslint@10.6.0(jiti@2.7.0))':
+    optionalDependencies:
+      eslint: 10.6.0(jiti@2.7.0)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -6921,7 +6966,7 @@ snapshots:
   '@loadable/server@5.16.7(@loadable/component@5.16.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@loadable/component': 5.16.7(react@19.2.7)
-      lodash: 4.17.23
+      lodash: 4.18.1
       react: 19.2.7
 
   '@loadable/webpack-plugin@5.15.2(webpack@5.108.4)':
@@ -7427,20 +7472,20 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 26.1.0
+      '@types/node': 22.20.1
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.1
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 5.1.2
-      '@types/node': 26.1.0
+      '@types/node': 22.20.1
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -7466,14 +7511,14 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.9':
     dependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.1
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
 
   '@types/express-serve-static-core@5.1.2':
     dependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.1
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -7491,7 +7536,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.1
 
   '@types/jsesc@2.5.1': {}
 
@@ -7499,9 +7544,9 @@ snapshots:
 
   '@types/mime@1.3.5': {}
 
-  '@types/node@26.1.0':
+  '@types/node@22.20.1':
     dependencies:
-      undici-types: 8.3.0
+      undici-types: 6.21.0
 
   '@types/qs@6.15.1': {}
 
@@ -7524,11 +7569,11 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 26.1.0
+      '@types/node': 22.20.1
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.1
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -7537,16 +7582,16 @@ snapshots:
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 26.1.0
+      '@types/node': 22.20.1
       '@types/send': 0.17.6
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.1
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.1
 
   '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -8829,6 +8874,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  globals@17.7.0: {}
+
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
@@ -9167,7 +9214,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -9360,7 +9407,7 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -10763,7 +10810,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@8.3.0: {}
+  undici-types@6.21.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/script/demo-fleet-verify
+++ b/script/demo-fleet-verify
@@ -3,6 +3,5 @@ set -euo pipefail
 
 bundle exec rake
 pnpm lint:rsc
-bundle exec rake react_on_rails:generate_packs
-RAILS_ENV=production NODE_ENV=production SECRET_KEY_BASE=dummy_secret_key_base_for_demo_fleet pnpm build:production
+SECRET_KEY_BASE=dummy_secret_key_base_for_demo_fleet bin/build-production
 pnpm verify:rsc


### PR DESCRIPTION
Fixes #138

## Summary

- restore the broad demo verifier by using the supported production build entrypoint
- make TypeScript 6 and ESLint 10 validation executable without weakening existing lint policy
- repair helper RuboCop findings and preserve the affected client interactions
- add a supported high-severity pnpm audit and exercise lint, audit, and full validation in hosted CI

## Decision log

- Added `eslint.config.mjs` because ESLint 10 requires flat configuration; it carries forward the legacy rule severities and ignores.
- Added the official `@eslint/compat`, `@eslint/js`, `globals`, and `@types/node` dependencies needed by the supported config/type-check paths.
- Added a minimal CSS-module declaration for existing stylesheet imports.
- Fixed four narrow lint findings in existing JS/TS code; no rule was disabled or downgraded.
- Used a `lodash` override at 4.18.1 to remove the current high-severity advisory while retaining the existing dependency surface.

## Workflow change audit

- Semantic change: `.github/workflows/browser-smoke.yml` now runs `.agents/bin/lint`, `pnpm audit:high`, and `.agents/bin/validate`.
- Triggers, permissions, secrets, and action identities are unchanged.
- No new third-party GitHub Action was introduced.
- Post-merge ownership: issue #138 will receive the default-branch CI/smoke evidence.

## Dependency and stale-base evidence

- Root pnpm lockfile is the only applicable lockfile, and Dependabot's npm ecosystem is rooted at `/`.
- Changed dependency classes are lint/type metadata plus the lodash security override; there is no native or platform-precompiled dependency change.
- Open PRs #137, #128, and #85 also touch `package.json`/`pnpm-lock.yaml`. This branch was created and published from current `main` at `c8718ab`; exact-head checks and a fresh collision sweep are required before merge.

## Verification

- `.agents/bin/lint`
- `.agents/bin/validate`
- `.agents/bin/test`
- `actionlint .github/workflows/browser-smoke.yml`
- `pnpm audit:high` (0 high/critical; 4 moderate)
- `git diff --check`
- focused Chromium interaction checks for reading-mode persistence and product-search query edit/clear behavior
- independent Sol/xhigh autoreview: clean

## Explicit limitations

- `.agents/bin/setup` is non-portable in this worktree because its absolute-path check disagrees with `mise trust --show` returning a home-relative path. The underlying `bin/setup` completed after manually trusting the repo. The setup wrapper is outside this issue's accepted file scope and was not changed.
- `yamllint` is unavailable locally; `actionlint` passed and hosted workflow execution remains mandatory.
- Existing ESLint warnings, RuboCop new-cop notices, build-size warnings, and four moderate pnpm advisories remain non-blocking pre-existing debt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reading mode behavior during page hydration and restored saved preferences more reliably.
  - Fixed search input synchronization when the initial query changes.
  - Corrected layout positioning in the SSR/RSC playground.
  - Improved stylesheet handling to prevent duplicate entries.

- **Quality & Reliability**
  - Added stronger linting, type validation, and high-severity dependency auditing.
  - Improved demo validation and production build verification.
  - Added support for importing CSS files in TypeScript.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->