### PR TITLE
Expand Chromium smoke to every public route

### DIFF
--- a/.verify-routes.js
+++ b/.verify-routes.js
@@ -11,6 +11,9 @@ const publicRouteContract = require('./config/public_routes.json');
 const BASE = process.env.BASE_URL || 'http://localhost:3010';
 const BROWSER_PARAMETER_VALUES = { restaurant: '1' };
 const PERSISTENT_MEDIA_ROUTES = new Set(['/media-gallery', '/media-gallery/rsc']);
+const MEDIA_LIGHTBOX_THUMBNAIL_SELECTOR =
+  'button[aria-label="Open image 1 of 8 in the react-image-lightbox lightbox"]';
+const MEDIA_LIGHTBOX_CLOSE_SELECTOR = 'button[aria-label="Close lightbox"]';
 
 function browserRouteFor(routeCase) {
   const route = Object.entries(routeCase.parameters || {}).reduce(
@@ -199,6 +202,59 @@ async function checkProductSearchInteraction(page) {
   }
 }
 
+async function checkMediaClientInteraction(page) {
+  // The thumbnail is present in the server HTML, but opening and closing the
+  // lightbox requires its client-island event handlers to have hydrated.
+  const timeout = 25000;
+  const deadline = Date.now() + timeout;
+  const selectors = {
+    thumbnailSelector: MEDIA_LIGHTBOX_THUMBNAIL_SELECTOR,
+    closeSelector: MEDIA_LIGHTBOX_CLOSE_SELECTOR,
+  };
+  const timedOut = () => new Error(`Media lightbox did not open and close within ${timeout}ms`);
+  const evaluateBeforeDeadline = async (pageFunction) => {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) throw timedOut();
+
+    let timer;
+    try {
+      return await Promise.race([
+        page.evaluate(pageFunction, selectors),
+        new Promise((_resolve, reject) => {
+          timer = setTimeout(() => reject(timedOut()), remaining);
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+  const yieldToBrowser = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  let opened = false;
+  while (!opened) {
+    opened = await evaluateBeforeDeadline(({ thumbnailSelector, closeSelector }) => {
+      if (document.querySelector(closeSelector)) return true;
+
+      const thumbnail = document.querySelector(thumbnailSelector);
+      if (typeof thumbnail?.click === 'function') thumbnail.click();
+      return false;
+    });
+    if (!opened) await yieldToBrowser();
+  }
+
+  let closed = false;
+  while (!closed) {
+    closed = await evaluateBeforeDeadline(({ closeSelector }) => {
+      const close = document.querySelector(closeSelector);
+      if (!close) return true;
+
+      if (typeof close.click === 'function') close.click();
+      return false;
+    });
+    if (!closed) await yieldToBrowser();
+  }
+}
+
 async function checkRoute(browser, route) {
   const page = await browser.newPage();
   const consoleErrors = [];
@@ -242,6 +298,14 @@ async function checkRoute(browser, route) {
       duplicateScripts: [],
       consoleErrors, pageErrors, failedRequests,
     };
+  }
+
+  if (PERSISTENT_MEDIA_ROUTES.has(route)) {
+    try {
+      await checkMediaClientInteraction(page);
+    } catch (e) {
+      interactionError = e.message;
+    }
   }
 
   // Give React a beat to finish any post-paint work

--- a/.verify-routes.js
+++ b/.verify-routes.js
@@ -6,25 +6,50 @@
 // - reports anything that's not a clean load
 
 const puppeteer = require('puppeteer');
+const publicRouteContract = require('./config/public_routes.json');
 
 const BASE = process.env.BASE_URL || 'http://localhost:3010';
-const DEFAULT_ROUTES = [
-  '/',
-  '/products',
-  '/why-rsc',
-  '/measure',
-  '/rsc-performance',
-  '/rsc',
-  '/restaurant/1/ssr', '/restaurant/1/client', '/restaurant/1/rsc',
-  '/product/ssr', '/product/client', '/product/rsc',
-  '/product-search/ssr', '/product-search/client', '/product-search/rsc',
-  '/blog/ssr', '/blog/client', '/blog/rsc', '/blog/rsc-simple',
-  '/blog/rsc-step1', '/blog/rsc-step1b', '/blog/rsc-step1c',
-  '/blog/rsc-step2', '/blog/rsc-step3', '/blog/rsc-step4', '/blog/rsc-step5',
-];
+const BROWSER_PARAMETER_VALUES = { restaurant: '1' };
+const PERSISTENT_MEDIA_ROUTES = new Set(['/media-gallery', '/media-gallery/rsc']);
+
+function browserRouteFor(routeCase) {
+  const route = Object.entries(routeCase.parameters || {}).reduce(
+    (path, [parameter, fixtureName]) => {
+      const parameterValue = BROWSER_PARAMETER_VALUES[fixtureName];
+      if (parameterValue === undefined) {
+        throw new Error(
+          `No deterministic browser value for ${fixtureName} (${routeCase.path} :${parameter})`
+        );
+      }
+
+      return path.replace(`:${parameter}`, encodeURIComponent(parameterValue));
+    },
+    routeCase.request_path || routeCase.path
+  );
+
+  if (/:[A-Za-z_][A-Za-z0-9_]*/.test(route)) {
+    throw new Error(`Unresolved browser route parameter in ${route}`);
+  }
+
+  return route;
+}
+
+const DEFAULT_ROUTES = publicRouteContract.routes.flatMap((routeCase) => {
+  if (routeCase.expected_status === 200) return [browserRouteFor(routeCase)];
+  if (routeCase.expected_location) return [];
+
+  throw new Error(
+    `Public route ${routeCase.path} is neither browser-rendered nor an explicit redirect`
+  );
+});
+
+if (process.argv.includes('--list-routes')) {
+  console.log(JSON.stringify(DEFAULT_ROUTES));
+  process.exit(0);
+}
 
 // A harness can scope the run to a subset (e.g. just the RSC client-boundary
-// routes) via a comma-separated ROUTES env var; default is the full list above.
+// routes) via a comma-separated ROUTES env var; default is the canonical list.
 const ROUTES = process.env.ROUTES
   ? process.env.ROUTES.split(',').map((r) => r.trim()).filter(Boolean)
   : DEFAULT_ROUTES;
@@ -55,10 +80,20 @@ async function checkProductSearchInteraction(page) {
   };
 
   await page.waitForSelector(inputSelector, { visible: true, timeout: 5000 });
-  await page.click(inputSelector);
+  await page.focus(inputSelector);
+  const inputIsFocused = await page.evaluate(
+    (selector) => document.activeElement === document.querySelector(selector),
+    inputSelector
+  );
+  if (!inputIsFocused) {
+    throw new Error('search input did not receive focus');
+  }
 
+  // The explicit API waits below are the readiness gate for the updated
+  // search page; waiting for all network activity to stop is broader than the
+  // interaction contract and can remain unsettled in current Chromium.
   const [response, resultsResponse, facetsResponse] = await Promise.all([
-    page.waitForNavigation({ waitUntil: 'networkidle0', timeout: 25000 }),
+    page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 25000 }),
     page.waitForResponse(
       (candidate) => isSearchApiResponse(candidate, '/api/product_search/results'),
       { timeout: 25000 }
@@ -192,9 +227,15 @@ async function checkRoute(browser, route) {
   let httpStatus = null;
   let interactionError = null;
   try {
-    const resp = await page.goto(BASE + route, { waitUntil: 'networkidle0', timeout: 25000 });
+    // These two media pages keep requests active and media elements loading,
+    // so neither networkidle0 nor load completes. They still run every
+    // post-paint, HTTP, page/console error, and duplicate-script check. The
+    // pre-existing route set retains the stricter networkidle0 condition.
+    const waitUntil = PERSISTENT_MEDIA_ROUTES.has(route) ? 'domcontentloaded' : 'networkidle0';
+    const resp = await page.goto(BASE + route, { waitUntil, timeout: 25000 });
     httpStatus = resp ? resp.status() : null;
   } catch (e) {
+    await page.close().catch(() => {});
     return {
       route, httpStatus, ok: false, navError: e.message,
       bodyTextLength: 0, hasErrorPanel: false,
@@ -261,14 +302,16 @@ async function checkRoute(browser, route) {
   });
 
   const results = [];
-  for (const route of ROUTES) {
-    process.stderr.write(`checking ${route} ... `);
-    const r = await checkRoute(browser, route);
-    process.stderr.write(r.ok ? 'OK\n' : `FAIL (status=${r.httpStatus} pageErrors=${r.pageErrors.length} consoleErrs=${r.consoleErrors.filter(e=>e.kind!=='other').length} dupes=${r.duplicateScripts.length})\n`);
-    results.push(r);
+  try {
+    for (const route of ROUTES) {
+      process.stderr.write(`checking ${route} ... `);
+      const r = await checkRoute(browser, route);
+      process.stderr.write(r.ok ? 'OK\n' : `FAIL (status=${r.httpStatus} pageErrors=${r.pageErrors.length} consoleErrs=${r.consoleErrors.filter(e=>e.kind!=='other').length} dupes=${r.duplicateScripts.length})\n`);
+      results.push(r);
+    }
+  } finally {
+    await browser.close();
   }
-
-  await browser.close();
 
   // Summary
   console.log('\n========== SUMMARY ==========');

--- a/spec/requests/public_routes_spec.rb
+++ b/spec/requests/public_routes_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'open3'
 require 'rails_helper'
 
 RSpec.describe 'Public route rendering isolation' do
@@ -63,6 +64,37 @@ RSpec.describe 'Public routes', type: :request, public_route_contract: true do
       expect(
         PublicRouteContract.uncovered_get_route_patterns(exercised_patterns - ['/why-rsc'])
       ).to include('/why-rsc')
+    end
+
+    it 'derives Chromium paths from every rendered route and excludes redirects' do
+      rendered_route_count = PublicRouteContract.routes.count do |route_case|
+        route_case.fetch('expected_status') == 200
+      end
+
+      expect(PublicRouteContract.browser_route_paths.length).to eq(rendered_route_count)
+      expect(PublicRouteContract.browser_route_paths).to include(
+        '/restaurant/1/ssr-cached',
+        '/how-rsc-works',
+        '/lh-compare?left=blog_ssr-desktop&right=blog_rsc-desktop',
+        '/media-gallery/rsc',
+        '/css-demo/two/rsc-client',
+        '/product-search/client'
+      )
+      expect(PublicRouteContract.browser_route_paths).not_to include('/source', '/search-performance')
+      expect(PublicRouteContract.browser_route_paths).not_to include(a_string_matching(/:\w+/))
+    end
+
+    it 'keeps the Chromium verifier inventory identical to the canonical contract' do
+      stdout, stderr, status = Open3.capture3(
+        { 'PUPPETEER_EXECUTABLE_PATH' => '/bin/false' },
+        'node',
+        '.verify-routes.js',
+        '--list-routes',
+        chdir: Rails.root.to_s
+      )
+
+      expect(status).to be_success, stderr
+      expect(JSON.parse(stdout)).to eq(PublicRouteContract.browser_route_paths)
     end
   end
 

--- a/spec/support/public_route_contract.rb
+++ b/spec/support/public_route_contract.rb
@@ -6,6 +6,7 @@ require 'json'
 module PublicRouteContract
   CONTRACT_PATH = Rails.root.join('config/public_routes.json')
   FORMAT_SUFFIX = '(.:format)'
+  BROWSER_PARAMETER_VALUES = { 'restaurant' => '1' }.freeze
 
   module_function
 
@@ -19,6 +20,18 @@ module PublicRouteContract
 
   def exclusions
     data.fetch('exclusions')
+  end
+
+  def browser_route_paths
+    routes.filter_map do |route_case|
+      next unless route_case.fetch('expected_status') == 200
+
+      route_case.fetch('parameters', {}).reduce(
+        route_case.fetch('request_path', route_case.fetch('path')).dup
+      ) do |path, (parameter, fixture_name)|
+        path.sub(":#{parameter}", BROWSER_PARAMETER_VALUES.fetch(fixture_name))
+      end
+    end
   end
 
   def route_patterns


### PR DESCRIPTION
## Summary

- derive the default Chromium inventory from the canonical public route contract
- exercise all 46 rendered routes while leaving redirect-only routes in request coverage
- materialize deterministic restaurant ID 1 paths and fail fast on unresolved parameters or unclassified statuses
- preserve crash, hydration, console, duplicate-script, body, and product-search assertions
- use exact media-route readiness exceptions and deterministic browser cleanup

## TDD and browser evidence

- RED: focused contract spec failed with undefined browser_route_paths
- RED: verifier inventory check launched Chromium instead of listing routes and failed at the sentinel executable
- GREEN: contract/verifier inventory cross-check reports 46 identical rendered routes
- media evidence: both networkidle0 and load timed out at 25 seconds for /media-gallery and /media-gallery/rsc because their media requests/elements remain active; exact-path domcontentloaded plus all existing post-paint assertions passes 2/2
- Chromium compatibility evidence: the prior focus-only page.click hung on current Chrome 150 after goto 200 and visible-input success, while cached Chrome 146 passed; page.focus plus an explicit active-element assertion passes current Chrome without changing the search value, navigation, API payload, URL, or empty-state assertions
- final current-Chrome loopback replay: Total 46, OK 46, FAIL 0

## Validation

- bundle exec rspec spec/requests/public_routes_spec.rb: 64 examples, 0 failures
- .agents/bin/lint: pass; 0 errors, 41 pre-existing JavaScript warnings; RuboCop 87 files, 0 offenses
- .agents/bin/test: pass
- .agents/bin/validate: pass
- node --check .verify-routes.js: pass
- git diff --check against the stack base and origin/main: pass

Stacked on #142.

Closes #143