### PR TITLE
Add Playwright product page journey

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -7,11 +7,11 @@ pnpm test:e2e
 ```
 
 The command prepares the Rails test database, starts the node renderer and Rails
-on fixed loopback ports, seeds deterministic product-search data, runs
-Playwright, and stops both servers. The cleanup command deletes products and
-product reviews from the dedicated test database before and after every test.
-Both the runner and app commands refuse database names that do not end in
-`_test` or `_playwright`.
+on fixed loopback ports, seeds deterministic product-search and product-page
+data, runs Playwright, and stops both servers. The cleanup command deletes
+products and product reviews from the dedicated test database before and after
+every test. Both the runner and app commands refuse database names that do not
+end in `_test` or `_playwright`.
 
 ## Rails command security boundary
 

--- a/e2e/app_commands/scenarios/product_search.rb
+++ b/e2e/app_commands/scenarios/product_search.rb
@@ -2,7 +2,76 @@
 
 E2EProductCleanup.clean!
 
-now = Time.current
+now = Time.zone.local(2026, 7, 18, 0, 0, 0)
+product_page = Product.create!(
+  name: 'E2E Product Page Headphones',
+  description: 'E2E Product Page Headphones deliver deterministic sound.',
+  price: 199,
+  original_price: 249,
+  category: 'E2E Product Page',
+  brand: 'E2E Test Brand',
+  sku: 'E2E-PRODUCT-PAGE',
+  images: [
+    { url: '/seed-images/placeholder.svg', alt: 'E2E headphones front', position: 1 },
+    { url: '/seed-images/placeholder.svg', alt: 'E2E headphones side', position: 2 }
+  ],
+  specs: { 'Connection' => 'USB-C', 'Warranty' => '2 years' },
+  features: ['Deterministic fixture', 'Hydrated cart controls'],
+  tags: ['e2e'],
+  average_rating: 4.5,
+  review_count: 2,
+  stock_quantity: 3,
+  in_stock: true,
+  created_at: now,
+  updated_at: now
+)
+
+ProductReview.create!(
+  [
+    {
+      product: product_page,
+      rating: 5,
+      title: 'Excellent deterministic audio',
+      comment: 'The repeatable fixture rendered every expected product section.',
+      reviewer_name: 'E2E Reviewer One',
+      verified_purchase: true,
+      helpful_count: 10,
+      created_at: now,
+      updated_at: now
+    },
+    {
+      product: product_page,
+      rating: 4,
+      title: 'Reliable browser journey',
+      comment: 'Quantity and cart controls hydrate consistently.',
+      reviewer_name: 'E2E Reviewer Two',
+      verified_purchase: true,
+      helpful_count: 5,
+      created_at: now,
+      updated_at: now
+    }
+  ]
+)
+
+Product.create!(
+  name: 'E2E Unavailable Product',
+  description: 'Deterministic unavailable product for the disabled purchase path.',
+  price: 75,
+  category: 'E2E Product Page',
+  brand: 'E2E Test Brand',
+  sku: 'E2E-PRODUCT-UNAVAILABLE',
+  images: [{ url: '/seed-images/placeholder.svg', alt: 'Unavailable E2E product', position: 1 }],
+  specs: { 'Availability' => 'Unavailable' },
+  features: ['Deterministic fixture'],
+  tags: ['e2e'],
+  average_rating: 0,
+  review_count: 0,
+  stock_quantity: 0,
+  in_stock: false,
+  created_at: now,
+  updated_at: now
+)
+
 products = (1..25).map do |number|
   {
     name: format('E2E Search Product %02d', number),

--- a/e2e/playwright/e2e/product_page.spec.ts
+++ b/e2e/playwright/e2e/product_page.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+
+import { app, appScenario } from '../support/on-rails.mjs';
+
+test.beforeEach(async () => {
+  await appScenario('product_search');
+});
+
+test.afterEach(async () => {
+  await app('clean');
+});
+
+test('renders the complete SSR product journey and hydrates cart controls', async ({ page }) => {
+  const response = await page.goto('/product/ssr');
+  expect(response?.ok()).toBe(true);
+
+  await expect(page.getByRole('heading', { level: 1, name: 'E2E Product Page Headphones' })).toBeVisible();
+  await expect(page.getByText('SKU: E2E-PRODUCT-PAGE')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Product Description' })).toBeVisible();
+  await expect(page.getByText('E2E Product Page Headphones deliver deterministic sound.')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Top Reviews' })).toBeVisible();
+  await expect(page.getByText('Excellent deterministic audio')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Customers Also Viewed' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'E2E Unavailable Product' })).toBeVisible();
+  await expect(page.getByText('Out of stock', { exact: true })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Increase quantity' }).click();
+  const addToCart = page.getByRole('button', { name: 'Add to Cart — $398.00' });
+  await expect(addToCart).toBeVisible();
+  await addToCart.click();
+  await expect(page.getByRole('button', { name: 'Added to Cart' })).toBeVisible();
+});
+
+test('keeps quantity inside the available stock boundaries', async ({ page }) => {
+  const response = await page.goto('/product/ssr');
+  expect(response?.ok()).toBe(true);
+
+  const decrease = page.getByRole('button', { name: 'Decrease quantity' });
+  const increase = page.getByRole('button', { name: 'Increase quantity' });
+  await expect(decrease).toBeDisabled();
+
+  await increase.click();
+  await increase.click();
+
+  await expect(page.getByRole('button', { name: 'Add to Cart — $597.00' })).toBeVisible();
+  await expect(increase).toBeDisabled();
+});

--- a/e2e/playwright_foundation_spec.rb
+++ b/e2e/playwright_foundation_spec.rb
@@ -433,13 +433,23 @@ RSpec.describe 'Rails-aware Playwright foundation' do
     expect(status).to be_success, [stdout, stderr].join("\n")
   end
 
-  it 'can load the product-search scenario repeatedly without accumulating fixtures' do
+  it 'can load the product scenarios repeatedly without accumulating fixtures' do
     scenario_path = Rails.root.join('e2e/app_commands/scenarios/product_search.rb')
 
     2.times { load scenario_path }
 
-    expect(Product.count).to eq(26)
-    expect(Product.distinct.count(:sku)).to eq(26)
+    expect(Product.count).to eq(28)
+    expect(Product.distinct.count(:sku)).to eq(28)
+    expect(ProductReview.count).to eq(2)
+    expect(Product.find_by!(sku: 'E2E-PRODUCT-PAGE')).to have_attributes(
+      name: 'E2E Product Page Headphones',
+      stock_quantity: 3,
+      in_stock: true
+    )
+    expect(Product.find_by!(sku: 'E2E-PRODUCT-UNAVAILABLE')).to have_attributes(
+      stock_quantity: 0,
+      in_stock: false
+    )
   ensure
     load Rails.root.join('e2e/app_commands/clean.rb')
   end


### PR DESCRIPTION
## Summary

- add deterministic product-page fixtures to the existing guarded Playwright scenario
- cover the SSR product page, reviews, related out-of-stock state, hydrated cart behavior, and stock boundaries
- preserve the existing search journey and test-only command security boundary

Issue: #145

## Validation

- `e2e/bin/pnpm test:e2e:unit` — 2 passed
- `e2e/bin/pnpm type-check:e2e` — passed
- `e2e/bin/pnpm lint:e2e` — passed
- `e2e/run-playwright` — 3 passed in Chromium
- `bundle exec rspec e2e/playwright_foundation_spec.rb` — 22 examples, 0 failures
- `PATH="$PWD/e2e/bin:$PATH" .agents/bin/lint` — passed; 41 pre-existing JavaScript warnings, 0 errors, and 0 RuboCop offenses
- `PATH="$PWD/e2e/bin:$PATH" .agents/bin/validate` — passed
- `e2e/bin/pnpm audit --audit-level high` — passed; 4 moderate advisories only
- `bundler-audit check` — inherited exact-base advisories in `loofah` and `rails-html-sanitizer`; no dependency changes in this PR
- immutable-commit Codex review — no actionable findings

## Stacked dependency

Base: `codex/144-playwright-search` / #149
