### PR TITLE
Add Playwright coverage for blog and restaurant journeys

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -7,11 +7,18 @@ pnpm test:e2e
 ```
 
 The command prepares the Rails test database, starts the node renderer and Rails
-on fixed loopback ports, seeds deterministic product-search and product-page
-data, runs Playwright, and stops both servers. The cleanup command deletes
-products and product reviews from the dedicated test database before and after
-every test. Both the runner and app commands refuse database names that do not
-end in `_test` or `_playwright`.
+on fixed loopback ports, seeds deterministic product-search, product-page, and
+restaurant-detail data, runs Playwright journeys for products, search, blogs,
+and restaurants, and stops both servers. The cleanup command deletes products,
+product reviews, restaurants, and dependent restaurant records from the
+dedicated test database before and after every stateful test. Both the runner
+and app commands refuse database names that do not end in `_test` or
+`_playwright`.
+
+The test compiler writes `loadable-stats.json` under `public/packs-test`, while
+the node renderer copies configured companion assets from `public/packs`. The
+runner stages that generated test file at the renderer path before startup and
+restores or removes it during cleanup, including after failures and signals.
 
 ## Rails command security boundary
 

--- a/e2e/app_commands/clean.rb
+++ b/e2e/app_commands/clean.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 E2EProductCleanup.clean!
+E2ERestaurantCleanup.clean!
 
-{ products: Product.count, product_reviews: ProductReview.count }
+{ products: Product.count, product_reviews: ProductReview.count, restaurants: Restaurant.count }

--- a/e2e/app_commands/scenarios/product_search.rb
+++ b/e2e/app_commands/scenarios/product_search.rb
@@ -5,7 +5,7 @@ E2ERestaurantCleanup.clean!
 
 now = Time.zone.local(2026, 7, 18, 0, 0, 0)
 restaurant = Restaurant.create!(
-  id: 146_086,
+  id: E2ERestaurantCleanup::RESTAURANT_ID,
   name: 'E2E Restaurant',
   description: 'Deterministic restaurant fixture for Playwright journeys.',
   cuisine_type: 'Pacific Rim',

--- a/e2e/app_commands/scenarios/product_search.rb
+++ b/e2e/app_commands/scenarios/product_search.rb
@@ -1,8 +1,30 @@
 # frozen_string_literal: true
 
 E2EProductCleanup.clean!
+E2ERestaurantCleanup.clean!
 
 now = Time.zone.local(2026, 7, 18, 0, 0, 0)
+restaurant = Restaurant.create!(
+  id: 146_086,
+  name: 'E2E Restaurant',
+  description: 'Deterministic restaurant fixture for Playwright journeys.',
+  cuisine_type: 'Pacific Rim',
+  latitude: 21.3069,
+  longitude: -157.8583,
+  address: '123 Test Kitchen Way',
+  city: 'Honolulu',
+  state: 'HI',
+  zip_code: '96813',
+  phone: '(808) 555-0146',
+  website: 'https://example.com/e2e-restaurant',
+  timezone: 'Pacific/Honolulu',
+  average_rating: 4.75,
+  review_count: 128,
+  image_url: '/seed-images/placeholder.svg',
+  created_at: now,
+  updated_at: now
+)
+
 product_page = Product.create!(
   name: 'E2E Product Page Headphones',
   description: 'E2E Product Page Headphones deliver deterministic sound.',
@@ -114,4 +136,8 @@ products << {
 
 Product.create!(products)
 
-{ products: Product.count, categories: Product.group(:category).count }
+{
+  products: Product.count,
+  categories: Product.group(:category).count,
+  restaurant_id: restaurant.id
+}

--- a/e2e/bin/playwright-cleanup
+++ b/e2e/bin/playwright-cleanup
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+clean_renderer_bundle_cache() {
+  if [[ -d "${renderer_bundle_cache}" ]]; then
+    find "${renderer_bundle_cache}" -mindepth 1 -depth -delete || true
+    rmdir "${renderer_bundle_cache}" 2>/dev/null || true
+  fi
+}
+
+restore_renderer_loadable_stats() {
+  if [[ "${renderer_loadable_stats_staged}" != true ]]; then
+    return
+  fi
+
+  if [[ "${renderer_loadable_stats_target_existed}" == true ]]; then
+    if ! mkdir -p "$(dirname "${renderer_loadable_stats_target}")"; then
+      echo "Failed to recreate the renderer stats directory; backup retained at ${renderer_loadable_stats_backup}" >&2
+      return 1
+    fi
+    if cp "${renderer_loadable_stats_backup}" "${renderer_loadable_stats_target}"; then
+      rm -f "${renderer_loadable_stats_backup}"
+      renderer_loadable_stats_backup=""
+    else
+      echo "Failed to restore renderer stats; backup retained at ${renderer_loadable_stats_backup}" >&2
+      return 1
+    fi
+  else
+    rm -f "${renderer_loadable_stats_target}"
+    rmdir "$(dirname "${renderer_loadable_stats_target}")" 2>/dev/null || true
+  fi
+}
+
+cleanup() {
+  local exit_status=$?
+
+  trap - EXIT
+  trap '' INT TERM
+  stop_children "${renderer_pid}:${renderer_pgid}" "${rails_pid}:${rails_pgid}"
+  clean_renderer_bundle_cache
+  if ! restore_renderer_loadable_stats; then
+    if [[ "${exit_status}" -eq 0 ]]; then
+      exit_status=1
+    fi
+  fi
+  exit "${exit_status}"
+}

--- a/e2e/e2e_helper.rb
+++ b/e2e/e2e_helper.rb
@@ -27,3 +27,18 @@ module E2EProductCleanup
     Rails.cache.clear
   end
 end
+
+# Clears the deterministic restaurant fixture and its dependent records.
+module E2ERestaurantCleanup
+  module_function
+
+  def clean!
+    E2EDatabaseSafety.verify!
+
+    OrderLine.delete_all
+    Order.delete_all
+    MenuItem.delete_all
+    Restaurant.destroy_all
+    Rails.cache.clear
+  end
+end

--- a/e2e/e2e_helper.rb
+++ b/e2e/e2e_helper.rb
@@ -30,15 +30,26 @@ end
 
 # Clears the deterministic restaurant fixture and its dependent records.
 module E2ERestaurantCleanup
+  RESTAURANT_ID = 146_086
+
   module_function
 
   def clean!
     E2EDatabaseSafety.verify!
 
-    OrderLine.delete_all
-    Order.delete_all
-    MenuItem.delete_all
-    Restaurant.destroy_all
+    restaurant = Restaurant.find_by(id: RESTAURANT_ID)
+    destroy_fixture!(restaurant) if restaurant
     Rails.cache.clear
   end
+
+  def destroy_fixture!(restaurant)
+    fixture_order_ids = restaurant.orders.select(:id)
+    fixture_menu_item_ids = restaurant.menu_items.select(:id)
+    OrderLine
+      .where(order_id: fixture_order_ids)
+      .or(OrderLine.where(menu_item_id: fixture_menu_item_ids))
+      .delete_all
+    restaurant.destroy!
+  end
+  private_class_method :destroy_fixture!
 end

--- a/e2e/playwright/e2e/blog.spec.ts
+++ b/e2e/playwright/e2e/blog.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test';
+
+const variants = ['ssr', 'client', 'rsc'] as const;
+
+for (const variant of variants) {
+  test(`renders and hydrates the ${variant.toUpperCase()} blog journey`, async ({ page }) => {
+    const response = await page.goto(`/blog/${variant}`);
+    expect(response?.ok()).toBe(true);
+
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: 'Migrating to React Server Components with React on Rails',
+      }),
+    ).toBeVisible();
+    await expect(page.getByText('ShakaCode Team', { exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Why Migrate to RSC?' })).toBeVisible();
+
+    await page.getByRole('button', { name: /Table of Contents/ }).click();
+    const firstSection = page.getByRole('button', { name: 'Why Migrate to RSC?', exact: true });
+    await expect(firstSection).toBeVisible();
+    await firstSection.click();
+    await expect(firstSection).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Bookmark', exact: true }).click();
+    await expect(page.getByRole('button', { name: 'Bookmarked', exact: true })).toBeVisible();
+
+    const darkMode = page.getByRole('button', { name: /Dark$/ });
+    await darkMode.click();
+    await expect(darkMode).toHaveAttribute('aria-pressed', 'true');
+
+    const comment = `Playwright exercised the ${variant.toUpperCase()} blog journey`;
+    await page.getByRole('textbox', { name: 'Leave a comment' }).fill(comment);
+    await page.getByRole('button', { name: 'Post Comment' }).click();
+    await expect(page.getByText(comment, { exact: true })).toBeVisible();
+    await expect(page.getByText('Comment posted (local-only — not persisted).')).toBeVisible();
+  });
+}

--- a/e2e/playwright/e2e/restaurant.spec.ts
+++ b/e2e/playwright/e2e/restaurant.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test';
+
+import { app, appScenario } from '../support/on-rails.mjs';
+
+const variants = ['ssr', 'client', 'rsc'] as const;
+let restaurantId: number;
+
+test.beforeEach(async () => {
+  [{ restaurant_id: restaurantId }] = await appScenario('product_search');
+});
+
+test.afterEach(async () => {
+  await app('clean');
+});
+
+for (const variant of variants) {
+  test(`renders the ${variant.toUpperCase()} restaurant journey`, async ({ page }) => {
+    const response = await page.goto(`/restaurant/${restaurantId}/${variant}`);
+    expect(response?.ok()).toBe(true);
+
+    await expect(page.getByRole('heading', { level: 1, name: 'E2E Restaurant' })).toBeVisible();
+    await expect(page.getByText('Pacific Rim · Honolulu, HI', { exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'About E2E Restaurant' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'The Menu' })).toBeVisible();
+    await expect(page.getByText('80 dishes across 7 sections', { exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Reviews', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Find your way here' })).toBeVisible();
+
+    await expect(page.getByRole('link', { name: 'Reserve a table' })).toHaveAttribute(
+      'href',
+      'tel:8085550146',
+    );
+    await page.getByRole('link', { name: 'See the menu' }).click();
+    await expect(page).toHaveURL(new RegExp(`/restaurant/${restaurantId}/${variant}#menu$`));
+
+    if (variant === 'rsc') {
+      await page.getByRole('link', { name: 'Starters', exact: true }).click();
+      await expect(page).toHaveURL(
+        new RegExp(`/restaurant/${restaurantId}/${variant}#cat-starters$`),
+      );
+      await expect(page.getByRole('heading', { name: /^Starters 11$/ })).toBeVisible();
+    } else {
+      const menuItemHeadings = page.locator('#menu').getByRole('heading', { level: 3 });
+      await expect(menuItemHeadings).toHaveCount(80);
+      await page.getByRole('button', { name: 'Starters', exact: true }).click();
+      await expect(menuItemHeadings).toHaveCount(11);
+    }
+  });
+}

--- a/e2e/playwright/support/on-rails.d.mts
+++ b/e2e/playwright/support/on-rails.d.mts
@@ -1,4 +1,9 @@
 export type RailsCommand = 'clean' | 'scenarios/product_search';
+export interface ProductSearchScenario {
+  products: number;
+  categories: Record<string, number>;
+  restaurant_id: number;
+}
 
 export function app(name: RailsCommand): Promise<unknown>;
-export function appScenario(name: 'product_search'): Promise<unknown>;
+export function appScenario(name: 'product_search'): Promise<[ProductSearchScenario]>;

--- a/e2e/playwright_foundation_spec.rb
+++ b/e2e/playwright_foundation_spec.rb
@@ -3,6 +3,7 @@
 require 'open3'
 require 'socket'
 require 'stringio'
+require 'tmpdir'
 require_relative '../spec/rails_helper'
 require_relative 'e2e_helper'
 
@@ -220,16 +221,18 @@ RSpec.describe 'Rails-aware Playwright foundation' do
 
   it 'boundedly terminates and reaps every managed child during cleanup' do
     cleanup_helper = Rails.root.join('e2e/bin/process-cleanup')
+    playwright_cleanup = Rails.root.join('e2e/bin/playwright-cleanup').read
     runner = Rails.root.join('e2e/run-playwright').read
 
     expect(cleanup_helper).to exist
     expect(runner).to include('source "${repo_root}/e2e/bin/process-cleanup"')
-    expect(runner).to include('local exit_status=$?')
-    expect(runner).to include('trap - EXIT')
-    expect(runner).to include(
+    expect(runner).to include('source "${repo_root}/e2e/bin/playwright-cleanup"')
+    expect(playwright_cleanup).to include('local exit_status=$?')
+    expect(playwright_cleanup).to include('trap - EXIT')
+    expect(playwright_cleanup).to include(
       'stop_children "${renderer_pid}:${renderer_pgid}" "${rails_pid}:${rails_pgid}"'
     )
-    expect(runner).to include('exit "${exit_status}"')
+    expect(playwright_cleanup).to include('exit "${exit_status}"')
     expect(runner).to include("trap 'exit 130' INT")
     expect(runner).to include("trap 'exit 143' TERM")
     expect(runner).to match(
@@ -424,14 +427,58 @@ RSpec.describe 'Rails-aware Playwright foundation' do
 
   it 'stages test loadable stats for the node renderer and restores the prior asset' do
     runner = Rails.root.join('e2e/run-playwright').read
+    cleanup_helper = Rails.root.join('e2e/bin/playwright-cleanup').read
 
     expect(runner).to include('public/packs-test/loadable-stats.json')
     expect(runner).to include('renderer_loadable_stats_backup')
     expect(runner).to include('renderer_loadable_stats_staged')
-    expect(runner).to include('if [[ "${renderer_loadable_stats_staged}" != true ]]; then')
-    expect(runner).to include('restore_renderer_loadable_stats')
-    expect(runner).to include('clean_renderer_bundle_cache')
+    expect(runner).to include('source "${repo_root}/e2e/bin/playwright-cleanup"')
+    expect(cleanup_helper).to include('if [[ "${renderer_loadable_stats_staged}" != true ]]; then')
+    expect(cleanup_helper).to include('restore_renderer_loadable_stats')
+    expect(cleanup_helper).to include('if ! restore_renderer_loadable_stats; then')
+    conditional_restore = cleanup_helper.index(
+      'if cp "${renderer_loadable_stats_backup}" "${renderer_loadable_stats_target}"; then'
+    )
+    backup_removal = cleanup_helper.index('rm -f "${renderer_loadable_stats_backup}"', conditional_restore)
+    restore_failure = cleanup_helper.index('else', backup_removal)
+    failure_return = cleanup_helper.index('return 1', restore_failure)
+    expect(conditional_restore).to be < backup_removal
+    expect(backup_removal).to be < restore_failure
+    expect(restore_failure).to be < failure_return
+    expect(cleanup_helper).to include('clean_renderer_bundle_cache')
     expect(runner).to include('.node-renderer-bundles')
+  end
+
+  it 'retains the renderer stats backup and fails cleanup when restoration fails' do
+    Dir.mktmpdir('renderer-stats-cleanup') do |directory|
+      backup = File.join(directory, 'loadable-stats.backup.json')
+      blocked_parent = File.join(directory, 'blocked-parent')
+      target = File.join(blocked_parent, 'loadable-stats.json')
+      File.write(backup, '{"original":true}')
+      File.write(blocked_parent, 'not a directory')
+
+      cleanup_script = <<~BASH
+        source "#{Rails.root.join('e2e/bin/process-cleanup')}"
+        source "#{Rails.root.join('e2e/bin/playwright-cleanup')}"
+        renderer_pid=""
+        renderer_pgid=""
+        rails_pid=""
+        rails_pgid=""
+        renderer_bundle_cache="#{File.join(directory, 'renderer-cache')}"
+        renderer_loadable_stats_staged=true
+        renderer_loadable_stats_target_existed=true
+        renderer_loadable_stats_backup="#{backup}"
+        renderer_loadable_stats_target="#{target}"
+        true
+        cleanup
+      BASH
+
+      _stdout, stderr, status = Open3.capture3('bash', '-c', cleanup_script)
+
+      expect(status.exitstatus).to eq(1)
+      expect(File.read(backup)).to eq('{"original":true}')
+      expect(stderr).to include('backup retained')
+    end
   end
 
   it 'uses the non-instrumented Rails command client contract' do
@@ -447,7 +494,11 @@ RSpec.describe 'Rails-aware Playwright foundation' do
 
   it 'can load the product and restaurant scenarios repeatedly without accumulating fixtures' do
     scenario_path = Rails.root.join('e2e/app_commands/scenarios/product_search.rb')
-    stale_restaurant = Restaurant.create!(name: 'Stale Restaurant', cuisine_type: 'Test')
+    stale_restaurant = Restaurant.create!(
+      id: E2ERestaurantCleanup::RESTAURANT_ID,
+      name: 'Stale Restaurant',
+      cuisine_type: 'Test'
+    )
     stale_menu_item = stale_restaurant.menu_items.create!(name: 'Stale Item', price: 1)
     stale_order = stale_restaurant.orders.create!(
       order_number: "STALE-E2E-#{SecureRandom.hex(8)}",
@@ -456,16 +507,37 @@ RSpec.describe 'Rails-aware Playwright foundation' do
       total_price: 1
     )
     OrderLine.create!(order: stale_order, menu_item: stale_menu_item, quantity: 1, price_per_unit: 1)
+    unrelated_restaurant = Restaurant.create!(name: 'Unrelated Restaurant', cuisine_type: 'Test')
+    unrelated_menu_item = unrelated_restaurant.menu_items.create!(name: 'Unrelated Item', price: 2)
+    unrelated_order = unrelated_restaurant.orders.create!(
+      order_number: "UNRELATED-E2E-#{SecureRandom.hex(8)}",
+      status: 'pending',
+      placed_at: Time.current,
+      total_price: 2
+    )
+    unrelated_order_line = OrderLine.create!(
+      order: unrelated_order,
+      menu_item: unrelated_menu_item,
+      quantity: 1,
+      price_per_unit: 2
+    )
 
     2.times { load scenario_path }
 
-    expect(Restaurant.count).to eq(1)
-    expect(Restaurant.first).to have_attributes(
+    expect(Restaurant.find(E2ERestaurantCleanup::RESTAURANT_ID)).to have_attributes(
       id: 146_086,
       name: 'E2E Restaurant',
       cuisine_type: 'Pacific Rim',
       city: 'Honolulu'
     )
+    expect(Restaurant.find(unrelated_restaurant.id)).to eq(unrelated_restaurant)
+    expect(MenuItem.find(unrelated_menu_item.id)).to eq(unrelated_menu_item)
+    expect(Order.find(unrelated_order.id)).to eq(unrelated_order)
+    expect(OrderLine.find(unrelated_order_line.id)).to eq(unrelated_order_line)
+    expect(Restaurant.count).to eq(2)
+    expect(MenuItem.count).to eq(1)
+    expect(Order.count).to eq(1)
+    expect(OrderLine.count).to eq(1)
     expect(Product.count).to eq(28)
     expect(Product.distinct.count(:sku)).to eq(28)
     expect(ProductReview.count).to eq(2)

--- a/e2e/playwright_foundation_spec.rb
+++ b/e2e/playwright_foundation_spec.rb
@@ -422,6 +422,18 @@ RSpec.describe 'Rails-aware Playwright foundation' do
     expect(generation_offset).to be < compilation_offset
   end
 
+  it 'stages test loadable stats for the node renderer and restores the prior asset' do
+    runner = Rails.root.join('e2e/run-playwright').read
+
+    expect(runner).to include('public/packs-test/loadable-stats.json')
+    expect(runner).to include('renderer_loadable_stats_backup')
+    expect(runner).to include('renderer_loadable_stats_staged')
+    expect(runner).to include('if [[ "${renderer_loadable_stats_staged}" != true ]]; then')
+    expect(runner).to include('restore_renderer_loadable_stats')
+    expect(runner).to include('clean_renderer_bundle_cache')
+    expect(runner).to include('.node-renderer-bundles')
+  end
+
   it 'uses the non-instrumented Rails command client contract' do
     stdout, stderr, status = Open3.capture3(
       'node',
@@ -433,11 +445,27 @@ RSpec.describe 'Rails-aware Playwright foundation' do
     expect(status).to be_success, [stdout, stderr].join("\n")
   end
 
-  it 'can load the product scenarios repeatedly without accumulating fixtures' do
+  it 'can load the product and restaurant scenarios repeatedly without accumulating fixtures' do
     scenario_path = Rails.root.join('e2e/app_commands/scenarios/product_search.rb')
+    stale_restaurant = Restaurant.create!(name: 'Stale Restaurant', cuisine_type: 'Test')
+    stale_menu_item = stale_restaurant.menu_items.create!(name: 'Stale Item', price: 1)
+    stale_order = stale_restaurant.orders.create!(
+      order_number: "STALE-E2E-#{SecureRandom.hex(8)}",
+      status: 'pending',
+      placed_at: Time.current,
+      total_price: 1
+    )
+    OrderLine.create!(order: stale_order, menu_item: stale_menu_item, quantity: 1, price_per_unit: 1)
 
     2.times { load scenario_path }
 
+    expect(Restaurant.count).to eq(1)
+    expect(Restaurant.first).to have_attributes(
+      id: 146_086,
+      name: 'E2E Restaurant',
+      cuisine_type: 'Pacific Rim',
+      city: 'Honolulu'
+    )
     expect(Product.count).to eq(28)
     expect(Product.distinct.count(:sku)).to eq(28)
     expect(ProductReview.count).to eq(2)
@@ -451,6 +479,10 @@ RSpec.describe 'Rails-aware Playwright foundation' do
       in_stock: false
     )
   ensure
+    OrderLine.delete_all
+    Order.delete_all
+    MenuItem.delete_all
+    Restaurant.delete_all
     load Rails.root.join('e2e/app_commands/clean.rb')
   end
 

--- a/e2e/playwright_foundation_spec.rb
+++ b/e2e/playwright_foundation_spec.rb
@@ -494,6 +494,10 @@ RSpec.describe 'Rails-aware Playwright foundation' do
 
   it 'can load the product and restaurant scenarios repeatedly without accumulating fixtures' do
     scenario_path = Rails.root.join('e2e/app_commands/scenarios/product_search.rb')
+    baseline_restaurants = Restaurant.count
+    baseline_menu_items = MenuItem.count
+    baseline_orders = Order.count
+    baseline_order_lines = OrderLine.count
     stale_restaurant = Restaurant.create!(
       id: E2ERestaurantCleanup::RESTAURANT_ID,
       name: 'Stale Restaurant',
@@ -534,10 +538,10 @@ RSpec.describe 'Rails-aware Playwright foundation' do
     expect(MenuItem.find(unrelated_menu_item.id)).to eq(unrelated_menu_item)
     expect(Order.find(unrelated_order.id)).to eq(unrelated_order)
     expect(OrderLine.find(unrelated_order_line.id)).to eq(unrelated_order_line)
-    expect(Restaurant.count).to eq(2)
-    expect(MenuItem.count).to eq(1)
-    expect(Order.count).to eq(1)
-    expect(OrderLine.count).to eq(1)
+    expect(Restaurant.count).to eq(baseline_restaurants + 2)
+    expect(MenuItem.count).to eq(baseline_menu_items + 1)
+    expect(Order.count).to eq(baseline_orders + 1)
+    expect(OrderLine.count).to eq(baseline_order_lines + 1)
     expect(Product.count).to eq(28)
     expect(Product.distinct.count(:sku)).to eq(28)
     expect(ProductReview.count).to eq(2)
@@ -551,10 +555,9 @@ RSpec.describe 'Rails-aware Playwright foundation' do
       in_stock: false
     )
   ensure
-    OrderLine.delete_all
-    Order.delete_all
-    MenuItem.delete_all
-    Restaurant.delete_all
+    E2ERestaurantCleanup.clean!
+    OrderLine.where(id: unrelated_order_line&.id).delete_all
+    unrelated_restaurant&.destroy!
     load Rails.root.join('e2e/app_commands/clean.rb')
   end
 

--- a/e2e/run-playwright
+++ b/e2e/run-playwright
@@ -40,6 +40,37 @@ renderer_pid=""
 renderer_pgid=""
 rails_pid=""
 rails_pgid=""
+renderer_loadable_stats_source="${repo_root}/public/packs-test/loadable-stats.json"
+renderer_loadable_stats_target="${repo_root}/public/packs/loadable-stats.json"
+renderer_loadable_stats_backup=""
+renderer_loadable_stats_target_existed=false
+renderer_loadable_stats_staged=false
+renderer_bundle_cache="${repo_root}/.node-renderer-bundles"
+
+clean_renderer_bundle_cache() {
+  if [[ -d "${renderer_bundle_cache}" ]]; then
+    find "${renderer_bundle_cache}" -mindepth 1 -depth -delete || true
+    rmdir "${renderer_bundle_cache}" 2>/dev/null || true
+  fi
+}
+
+restore_renderer_loadable_stats() {
+  if [[ "${renderer_loadable_stats_staged}" != true ]]; then
+    return
+  fi
+
+  if [[ "${renderer_loadable_stats_target_existed}" == true ]]; then
+    mkdir -p "$(dirname "${renderer_loadable_stats_target}")" || true
+    cp "${renderer_loadable_stats_backup}" "${renderer_loadable_stats_target}" || true
+  else
+    rm -f "${renderer_loadable_stats_target}"
+    rmdir "$(dirname "${renderer_loadable_stats_target}")" 2>/dev/null || true
+  fi
+
+  if [[ -n "${renderer_loadable_stats_backup}" ]]; then
+    rm -f "${renderer_loadable_stats_backup}"
+  fi
+}
 
 cleanup() {
   local exit_status=$?
@@ -47,6 +78,8 @@ cleanup() {
   trap - EXIT
   trap '' INT TERM
   stop_children "${renderer_pid}:${renderer_pgid}" "${rails_pid}:${rails_pgid}"
+  clean_renderer_bundle_cache
+  restore_renderer_loadable_stats
   exit "${exit_status}"
 }
 trap cleanup EXIT
@@ -62,9 +95,24 @@ case "${database_name}" in
     ;;
 esac
 
+clean_renderer_bundle_cache
 bin/rails db:prepare
 bundle exec rake react_on_rails:generate_packs
 bin/shakapacker
+
+if [[ ! -f "${renderer_loadable_stats_source}" ]]; then
+  echo "Playwright E2E requires generated test loadable stats: ${renderer_loadable_stats_source}"
+  exit 1
+fi
+
+mkdir -p "$(dirname "${renderer_loadable_stats_target}")"
+if [[ -f "${renderer_loadable_stats_target}" ]]; then
+  renderer_loadable_stats_backup="$(mktemp "${TMPDIR:-/tmp}/marketplace-rsc-loadable-stats.XXXXXX")"
+  cp "${renderer_loadable_stats_target}" "${renderer_loadable_stats_backup}"
+  renderer_loadable_stats_target_existed=true
+fi
+renderer_loadable_stats_staged=true
+cp "${renderer_loadable_stats_source}" "${renderer_loadable_stats_target}"
 
 require-open-port 127.0.0.1 5017
 require-open-port 127.0.0.1 3800

--- a/e2e/run-playwright
+++ b/e2e/run-playwright
@@ -46,42 +46,7 @@ renderer_loadable_stats_backup=""
 renderer_loadable_stats_target_existed=false
 renderer_loadable_stats_staged=false
 renderer_bundle_cache="${repo_root}/.node-renderer-bundles"
-
-clean_renderer_bundle_cache() {
-  if [[ -d "${renderer_bundle_cache}" ]]; then
-    find "${renderer_bundle_cache}" -mindepth 1 -depth -delete || true
-    rmdir "${renderer_bundle_cache}" 2>/dev/null || true
-  fi
-}
-
-restore_renderer_loadable_stats() {
-  if [[ "${renderer_loadable_stats_staged}" != true ]]; then
-    return
-  fi
-
-  if [[ "${renderer_loadable_stats_target_existed}" == true ]]; then
-    mkdir -p "$(dirname "${renderer_loadable_stats_target}")" || true
-    cp "${renderer_loadable_stats_backup}" "${renderer_loadable_stats_target}" || true
-  else
-    rm -f "${renderer_loadable_stats_target}"
-    rmdir "$(dirname "${renderer_loadable_stats_target}")" 2>/dev/null || true
-  fi
-
-  if [[ -n "${renderer_loadable_stats_backup}" ]]; then
-    rm -f "${renderer_loadable_stats_backup}"
-  fi
-}
-
-cleanup() {
-  local exit_status=$?
-
-  trap - EXIT
-  trap '' INT TERM
-  stop_children "${renderer_pid}:${renderer_pgid}" "${rails_pid}:${rails_pgid}"
-  clean_renderer_bundle_cache
-  restore_renderer_loadable_stats
-  exit "${exit_status}"
-}
+source "${repo_root}/e2e/bin/playwright-cleanup"
 trap cleanup EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM


### PR DESCRIPTION
## Summary

- cover blog SSR, client, and RSC routes with visible content and hydrated interactions
- add deterministic restaurant fixtures and SSR, client, and RSC restaurant journeys
- make the Playwright runner stage loadable stats safely and clean renderer/test state deterministically

## Stack

Stacked on #145 (`codex/145-playwright-product`). Merge only after the base PR lands.

## Validation

- `./e2e/run-playwright --project=chromium` (9 passed)
- `bundle exec rspec e2e/playwright_foundation_spec.rb` (23 passed)
- `.agents/bin/lint`
- `.agents/bin/test`
- `.agents/bin/validate`
- exact-commit `codex review --commit 1d1b7dad6af8549e46f3c8fcd417269512e81a49` (clean)

Closes #146
Closes #86