### PR TITLE
Fix Browser Smoke pnpm action pin

### DIFF
--- a/.github/workflows/browser-smoke.yml
+++ b/.github/workflows/browser-smoke.yml
@@ -56,7 +56,7 @@ jobs:
           bundler-cache: true
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e


### PR DESCRIPTION
## Why

The Browser Smoke workflow references a pnpm/action-setup commit that is no longer available upstream, preventing the workflow from starting.

## Implementation

- Replace that unavailable SHA with the immutable commit resolved from pnpm/action-setup v6.0.9.
- Record the upstream version beside the pin.

## Verification

- Confirmed the old commit is unavailable through the upstream commit API.
- Confirmed the v6.0.9 annotated tag resolves to `0ebf47130e4866e96fce0953f49152a61190b271`.
- `actionlint .github/workflows/browser-smoke.yml`
- `git diff --check`
- `yamllint` is not installed locally (non-portable duplicate check).
- Review-app verification is not configured as a repository check; this is a documented non-blocking skip.
- Post-merge Browser Smoke exercise is tracked by #157.

## Codex Decision Log

- **Non-blocking:** The repository has no configured hosted-CI trigger command.
  - **Decision:** Rely on the workflow's pull-request trigger and inspect current-head execution after opening this PR.
  - **Why:** The repository seam declares CI runs on every PR.
  - **Review later:** None.
