### PR TITLE
Fix PPR production boot under Zeitwerk

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -9,3 +9,7 @@
 #   inflect.irregular "person", "people"
 #   inflect.uncountable %w( fish sheep )
 # end
+
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'PPR'
+end

--- a/spec/ppr_production_boot_spec.rb
+++ b/spec/ppr_production_boot_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'rbconfig'
+
+RSpec.describe 'PPR production boot' do
+  it 'eager loads the PPR patches with Zeitwerk' do
+    root = File.expand_path('..', __dir__)
+    stdout, stderr, status = Open3.capture3(
+      {
+        'ENABLE_PPR' => 'true',
+        'RAILS_ENV' => 'production',
+        'SECRET_KEY_BASE' => 'dummy_secret_key_base_for_ppr_boot_spec'
+      },
+      RbConfig.ruby,
+      File.join(root, 'bin/rails'),
+      'runner',
+      'puts "PPR_PRODUCTION_BOOT_OK"',
+      chdir: root
+    )
+
+    expect(status).to be_success, "#{stdout}\n#{stderr}"
+    expect(stdout).to include('PPR_PRODUCTION_BOOT_OK')
+  end
+end


### PR DESCRIPTION
## Summary

- register PPR as an Active Support acronym so Zeitwerk maps lib/ppr_patches to the existing PPRPatches namespace
- add a standalone regression spec that boots Rails in production with ENABLE_PPR=true

## Verification

- PASS: bundle exec rspec spec/ppr_production_boot_spec.rb (1 example, 0 failures; observed RED before the fix)
- PASS: bundle exec rubocop config/initializers/inflections.rb spec/ppr_production_boot_spec.rb
- PASS: .agents/bin/validate (includes the new spec, RSC checks, production build, and chunk verification)
- PASS: RAILS_ENV=production ENABLE_PPR=true Rails runner printed PPR_PRODUCTION_BOOT_OK
- PASS: RAILS_ENV=production ENABLE_PPR=true bundle exec rails zeitwerk:check
- NON-BLOCKING BASELINE: full .agents/bin/lint reaches RuboCop but reports 34 pre-existing offenses in the existing PPR patch files; TypeScript type-check and ESLint completed with no errors, and the two changed files are RuboCop-clean

No benchmark, E2E, analytics, or react_on_rails changes.