### PR TITLE
Use bidirectional (pull-mode) async props with unstable_cache and React.cache()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,9 @@ test-*.js
 .mcp.json
 .psi-key
 
+# Playwright MCP server artifacts
+.playwright-mcp/
+
 # Claude Code worktrees and session state
 .claude/
 

--- a/.verify-routes.js
+++ b/.verify-routes.js
@@ -16,7 +16,7 @@ const DEFAULT_ROUTES = [
   '/rsc-performance',
   '/rsc',
   '/restaurant/1/ssr', '/restaurant/1/client', '/restaurant/1/rsc',
-  '/product/ssr', '/product/client', '/product/rsc',
+  '/product/ssr', '/product/client', '/product/rsc', '/product/rsc-pull',
   '/product-search/ssr', '/product-search/client', '/product-search/rsc',
   '/blog/ssr', '/blog/client', '/blog/rsc', '/blog/rsc-simple',
   '/blog/rsc-step1', '/blog/rsc-step1b', '/blog/rsc-step1c',

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -5,7 +5,7 @@ class ProductsController < ApplicationController
   include ReactOnRailsPro::AsyncRendering
   include ProductSerialization
 
-  enable_async_react_rendering only: %i[show_rsc show_rsc_cached show_ppr]
+  enable_async_react_rendering only: %i[show_rsc show_rsc_cached show_rsc_pull show_ppr]
 
   before_action :set_seo_meta
 
@@ -13,6 +13,7 @@ class ProductsController < ApplicationController
     "show_ssr" => "Server-Side Rendering (SSR)",
     "show_client" => "Client-Side Rendering",
     "show_rsc" => "React Server Components (RSC)",
+    "show_rsc_pull" => "RSC Pull-Mode (Bidirectional Async Props)",
     "show_ppr" => "Partial Prerendering (PPR)"
   }.freeze
 
@@ -60,6 +61,16 @@ class ProductsController < ApplicationController
     @product = find_product
     @product_data = serialize_product(@product).except(:description, :features, :specs)
     stream_view_containing_react_components(template: "products/show_rsc_cached")
+  end
+
+  # V5: RSC Pull-Mode — bidirectional async props with unstable_cache.
+  # Uses push_props: [] so Rails waits for React to request each prop via propRequest
+  # instead of eagerly pushing everything. Combined with unstable_cache on the JS side,
+  # cached components never request their prop → Rails never queries the DB for it.
+  def show_rsc_pull
+    @product = find_product
+    @product_data = serialize_product(@product).except(:description, :features, :specs)
+    stream_view_containing_react_components(template: "products/show_rsc_pull")
   end
 
   # V4: PPR — static shell cached, dynamic content streams fresh.

--- a/app/javascript/components/product/AsyncProductDetailsPullRSC.tsx
+++ b/app/javascript/components/product/AsyncProductDetailsPullRSC.tsx
@@ -1,0 +1,43 @@
+// Server-only async component — pull-mode variant of AsyncProductDetailsRSC.
+//
+// Uses getAsyncProp() from the request-scoped asyncPropStore instead of
+// receiving getReactOnRailsAsyncProp as a prop. The async prop fetch happens
+// INSIDE the cacheComponent boundary:
+//
+// On MISS: getAsyncProp('product_details') fires → propRequest → Rails DB query → render → cache.
+// On HIT: cached Flight bytes replay directly — component never runs → no propRequest → no DB query.
+
+import React from 'react';
+import { cacheComponent } from '../../utils/rscCache';
+import { getAsyncProp } from '../../utils/asyncPropStore';
+import { ProductDescription } from './ProductDescription';
+import { ProductFeatures } from './ProductFeatures';
+import { ProductSpecs } from './ProductSpecs';
+
+interface ProductDetails {
+  description: string;
+  features: string[];
+  specs: Record<string, string>;
+}
+
+interface Props {
+  productId: number;
+}
+
+const CachedProductDetails = cacheComponent(
+  async ({ productId }: { productId: number }) => {
+    const details = (await getAsyncProp('product_details')) as ProductDetails;
+    return (
+      <>
+        <ProductDescription description={details.description} />
+        <ProductFeatures features={details.features} />
+        <ProductSpecs specs={details.specs} />
+      </>
+    );
+  },
+  { id: 'pull-product-details', revalidate: 60 },
+);
+
+export default async function AsyncProductDetailsPullRSC({ productId }: Props) {
+  return <CachedProductDetails productId={productId} />;
+}

--- a/app/javascript/components/product/AsyncRelatedProductsPullRSC.tsx
+++ b/app/javascript/components/product/AsyncRelatedProductsPullRSC.tsx
@@ -13,10 +13,24 @@ interface Props {
   productId: number;
 }
 
+interface RelatedProduct {
+  id: number;
+  name: string;
+  price: number;
+  original_price: number | null;
+  category: string;
+  brand: string;
+  images: { url: string; alt: string; position: number }[];
+  average_rating: number;
+  review_count: number;
+  in_stock: boolean;
+  discount_percentage: number | null;
+}
+
 const CachedPullRelatedProducts = cacheComponent(
   async ({ productId }: { productId: number }) => {
     const data = await getAsyncProp('related_products');
-    return <RelatedProducts products={data.products} />;
+    return <RelatedProducts products={data.products as RelatedProduct[]} />;
   },
   { id: 'pull-product-related', revalidate: 60 },
 );

--- a/app/javascript/components/product/AsyncRelatedProductsPullRSC.tsx
+++ b/app/javascript/components/product/AsyncRelatedProductsPullRSC.tsx
@@ -9,14 +9,18 @@ import { cacheComponent } from '../../utils/rscCache';
 import { getAsyncProp } from '../../utils/asyncPropStore';
 import { RelatedProducts } from './RelatedProducts';
 
+interface Props {
+  productId: number;
+}
+
 const CachedPullRelatedProducts = cacheComponent(
-  async (_props: Record<string, never>) => {
+  async ({ productId }: { productId: number }) => {
     const data = await getAsyncProp('related_products');
     return <RelatedProducts products={data.products} />;
   },
   { id: 'pull-product-related', revalidate: 60 },
 );
 
-export default async function AsyncRelatedProductsPullRSC() {
-  return <CachedPullRelatedProducts />;
+export default async function AsyncRelatedProductsPullRSC({ productId }: Props) {
+  return <CachedPullRelatedProducts productId={productId} />;
 }

--- a/app/javascript/components/product/AsyncRelatedProductsPullRSC.tsx
+++ b/app/javascript/components/product/AsyncRelatedProductsPullRSC.tsx
@@ -1,0 +1,22 @@
+// Server-only async component — pull-mode variant of AsyncRelatedProductsRSC.
+//
+// Uses getAsyncProp() from the request-scoped asyncPropStore. On a cache HIT
+// the component never runs, so no propRequest is sent and Rails skips the
+// related_products DB query entirely.
+
+import React from 'react';
+import { cacheComponent } from '../../utils/rscCache';
+import { getAsyncProp } from '../../utils/asyncPropStore';
+import { RelatedProducts } from './RelatedProducts';
+
+const CachedPullRelatedProducts = cacheComponent(
+  async (_props: Record<string, never>) => {
+    const data = await getAsyncProp('related_products');
+    return <RelatedProducts products={data.products} />;
+  },
+  { id: 'pull-product-related', revalidate: 60 },
+);
+
+export default async function AsyncRelatedProductsPullRSC() {
+  return <CachedPullRelatedProducts />;
+}

--- a/app/javascript/components/product/AsyncReviewStatsPullRSC.tsx
+++ b/app/javascript/components/product/AsyncReviewStatsPullRSC.tsx
@@ -1,0 +1,29 @@
+// Server-only async component — pull-mode variant of AsyncReviewStatsRSC.
+//
+// Uses getAsyncProp() from the request-scoped asyncPropStore. On a cache HIT
+// the component never runs, so no propRequest is sent and Rails skips the
+// review_stats DB query entirely.
+
+import React from 'react';
+import { RatingDistribution } from '../../types/product';
+import { cacheComponent } from '../../utils/rscCache';
+import { getAsyncProp } from '../../utils/asyncPropStore';
+import { ReviewDistributionChart } from './ReviewDistributionChart';
+
+const CachedPullReviewStats = cacheComponent(
+  async (_props: Record<string, never>) => {
+    const data = await getAsyncProp('review_stats');
+    return (
+      <ReviewDistributionChart
+        distribution={data.distribution as RatingDistribution[]}
+        averageRating={data.average_rating as number}
+        totalReviews={data.total_reviews as number}
+      />
+    );
+  },
+  { id: 'pull-product-review-stats', revalidate: 60 },
+);
+
+export default async function AsyncReviewStatsPullRSC() {
+  return <CachedPullReviewStats />;
+}

--- a/app/javascript/components/product/AsyncReviewStatsPullRSC.tsx
+++ b/app/javascript/components/product/AsyncReviewStatsPullRSC.tsx
@@ -10,8 +10,12 @@ import { cacheComponent } from '../../utils/rscCache';
 import { getAsyncProp } from '../../utils/asyncPropStore';
 import { ReviewDistributionChart } from './ReviewDistributionChart';
 
+interface Props {
+  productId: number;
+}
+
 const CachedPullReviewStats = cacheComponent(
-  async (_props: Record<string, never>) => {
+  async ({ productId }: { productId: number }) => {
     const data = await getAsyncProp('review_stats');
     return (
       <ReviewDistributionChart
@@ -24,6 +28,6 @@ const CachedPullReviewStats = cacheComponent(
   { id: 'pull-product-review-stats', revalidate: 60 },
 );
 
-export default async function AsyncReviewStatsPullRSC() {
-  return <CachedPullReviewStats />;
+export default async function AsyncReviewStatsPullRSC({ productId }: Props) {
+  return <CachedPullReviewStats productId={productId} />;
 }

--- a/app/javascript/components/product/AsyncReviewsPullRSC.tsx
+++ b/app/javascript/components/product/AsyncReviewsPullRSC.tsx
@@ -1,0 +1,23 @@
+// Server-only async component — pull-mode variant of AsyncReviewsRSC.
+//
+// Uses getAsyncProp() from the request-scoped asyncPropStore. On a cache HIT
+// the component never runs, so no propRequest is sent and Rails skips the
+// reviews DB query entirely.
+
+import React from 'react';
+import { cacheComponent } from '../../utils/rscCache';
+import { getAsyncProp } from '../../utils/asyncPropStore';
+import { ProductReview } from '../../types/product';
+import { ReviewsList } from './ReviewsList';
+
+const CachedPullReviewsList = cacheComponent(
+  async (_props: Record<string, never>) => {
+    const data = await getAsyncProp('reviews');
+    return <ReviewsList reviews={data.reviews as ProductReview[]} />;
+  },
+  { id: 'pull-product-reviews', revalidate: 60 },
+);
+
+export default async function AsyncReviewsPullRSC() {
+  return <CachedPullReviewsList />;
+}

--- a/app/javascript/components/product/AsyncReviewsPullRSC.tsx
+++ b/app/javascript/components/product/AsyncReviewsPullRSC.tsx
@@ -10,14 +10,18 @@ import { getAsyncProp } from '../../utils/asyncPropStore';
 import { ProductReview } from '../../types/product';
 import { ReviewsList } from './ReviewsList';
 
+interface Props {
+  productId: number;
+}
+
 const CachedPullReviewsList = cacheComponent(
-  async (_props: Record<string, never>) => {
+  async ({ productId }: { productId: number }) => {
     const data = await getAsyncProp('reviews');
     return <ReviewsList reviews={data.reviews as ProductReview[]} />;
   },
   { id: 'pull-product-reviews', revalidate: 60 },
 );
 
-export default async function AsyncReviewsPullRSC() {
-  return <CachedPullReviewsList />;
+export default async function AsyncReviewsPullRSC({ productId }: Props) {
+  return <CachedPullReviewsList productId={productId} />;
 }

--- a/app/javascript/components/product/ProductPagePullRSC.tsx
+++ b/app/javascript/components/product/ProductPagePullRSC.tsx
@@ -99,19 +99,19 @@ export default function ProductPagePullRSC({ product, getReactOnRailsAsyncProp }
           <h2 className="text-xl font-bold text-gray-900 mb-6">Customer Reviews</h2>
 
           <Suspense fallback={<ReviewStatsSkeleton />}>
-            <AsyncReviewStatsPullRSC />
+            <AsyncReviewStatsPullRSC productId={product.id} />
           </Suspense>
 
           <div className="mt-8">
             <Suspense fallback={<ReviewsSkeleton />}>
-              <AsyncReviewsPullRSC />
+              <AsyncReviewsPullRSC productId={product.id} />
             </Suspense>
           </div>
         </section>
 
         {/* Related products — pull-cached: on HIT, related_products prop is never requested */}
         <Suspense fallback={<RelatedProductsSkeleton />}>
-          <AsyncRelatedProductsPullRSC />
+          <AsyncRelatedProductsPullRSC productId={product.id} />
         </Suspense>
 
         {/* Long-form spec sheet — uses regular cacheComponent (sync data from product) */}

--- a/app/javascript/components/product/ProductPagePullRSC.tsx
+++ b/app/javascript/components/product/ProductPagePullRSC.tsx
@@ -1,0 +1,127 @@
+// No 'use client' — this is a server component (RSC bundle).
+//
+// V5: RSC Pull-Mode Streaming — bidirectional async props with unstable_cache.
+//
+// Like ProductPageRSC (V3) but uses pull-mode: React requests props on demand
+// instead of Rails pushing them eagerly. Combined with unstable_cache, cached
+// components never request their prop → Rails never queries the DB for it.
+//
+// Uses React.cache()-based asyncPropStore to eliminate prop drilling of
+// getReactOnRailsAsyncProp — children import getAsyncProp() directly.
+//
+// Libraries that stay SERVER-SIDE (never shipped to browser):
+//   - marked + highlight.js (~350KB) — used by ProductDescription
+//   - date-fns (~30KB) — used by ReviewCard
+//   - ReviewDistributionChart SVG rendering — component code stays server-side
+//   - ReviewsList, ReviewCard, RelatedProducts — all stay server-side
+//
+// Only shipped to client:
+//   - ProductImageGallery (~3KB) — interactive image navigation
+//   - AddToCartSection (~2KB) — quantity selector + add to cart
+
+import React, { Suspense } from 'react';
+import { cacheComponent } from '../../utils/rscCache';
+import { initAsyncPropStore } from '../../utils/asyncPropStore';
+import { Product } from '../../types/product';
+import { ProductImageGallery } from './ProductImageGalleryForServer';
+import { ProductInfo } from './ProductInfo';
+import { AddToCartSection } from './AddToCartSectionForServer';
+import AsyncProductDetailsPullRSC from './AsyncProductDetailsPullRSC';
+import AsyncReviewStatsPullRSC from './AsyncReviewStatsPullRSC';
+import AsyncReviewsPullRSC from './AsyncReviewsPullRSC';
+import AsyncRelatedProductsPullRSC from './AsyncRelatedProductsPullRSC';
+import { ProductDetailsSkeleton, ReviewStatsSkeleton, ReviewsSkeleton, RelatedProductsSkeleton } from './ProductSkeletons';
+import { Breadcrumb } from './Breadcrumb';
+import { buildProductCrumbs } from './productCrumbs';
+import { ProductSpecSheet } from './ProductSpecSheetForServer';
+import { buildProductSpecMarkdown } from './productSpecMarkdown';
+
+interface Props {
+  product: Product;
+  getReactOnRailsAsyncProp: (propName: string) => Promise<any>;
+}
+
+// #83: cache the rendered RSC payload of the long-form markdown spec sheet.
+const CachedProductSpecSheet = cacheComponent(
+  async ({
+    productName,
+    productPriceUsd,
+    specMarkdown,
+  }: {
+    sku: string;
+    productName: string;
+    productPriceUsd: number;
+    specMarkdown: string;
+  }) => (
+    <ProductSpecSheet productName={productName} productPriceUsd={productPriceUsd} specMarkdown={specMarkdown} />
+  ),
+  { id: 'product-spec-sheet', revalidate: 60 },
+);
+
+export default function ProductPagePullRSC({ product, getReactOnRailsAsyncProp }: Props) {
+  // Initialize the request-scoped async prop store. Children call
+  // getAsyncProp() from the store instead of receiving it as a prop.
+  initAsyncPropStore(getReactOnRailsAsyncProp);
+
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="container mx-auto max-w-6xl px-4 py-6">
+        {/* Version indicator */}
+        <p className="text-sm text-purple-700 bg-purple-50 border border-purple-200 rounded-lg px-4 py-2 mb-6">
+          V5: RSC Pull-Mode — bidirectional async props + unstable_cache. On cache hit, props are not pulled and DB queries are skipped.
+        </p>
+
+        {/* Breadcrumb — server-rendered HTML */}
+        <Breadcrumb crumbs={buildProductCrumbs(product)} />
+
+        {/* Hero section: Image gallery + Product info — renders IMMEDIATELY */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12 mb-12">
+          <ProductImageGallery images={product.images} productName={product.name} />
+          <div className="space-y-6">
+            <ProductInfo product={product} />
+            <div className="border-t border-gray-200 pt-6">
+              <AddToCartSection
+                price={product.price}
+                inStock={product.in_stock}
+                stockQuantity={product.stock_quantity}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Product details — pull-cached: on HIT, product_details prop is never requested */}
+        <Suspense fallback={<ProductDetailsSkeleton />}>
+          <AsyncProductDetailsPullRSC productId={product.id} />
+        </Suspense>
+
+        {/* Reviews section — pull-cached: on HIT, review_stats and reviews props are never requested */}
+        <section className="border-t border-gray-200 pt-8 mt-8">
+          <h2 className="text-xl font-bold text-gray-900 mb-6">Customer Reviews</h2>
+
+          <Suspense fallback={<ReviewStatsSkeleton />}>
+            <AsyncReviewStatsPullRSC />
+          </Suspense>
+
+          <div className="mt-8">
+            <Suspense fallback={<ReviewsSkeleton />}>
+              <AsyncReviewsPullRSC />
+            </Suspense>
+          </div>
+        </section>
+
+        {/* Related products — pull-cached: on HIT, related_products prop is never requested */}
+        <Suspense fallback={<RelatedProductsSkeleton />}>
+          <AsyncRelatedProductsPullRSC />
+        </Suspense>
+
+        {/* Long-form spec sheet — uses regular cacheComponent (sync data from product) */}
+        <CachedProductSpecSheet
+          sku={product.sku}
+          productName={product.name}
+          productPriceUsd={product.price}
+          specMarkdown={buildProductSpecMarkdown(product.name, product.sku)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/javascript/startup/ProductPagePullRSC.tsx
+++ b/app/javascript/startup/ProductPagePullRSC.tsx
@@ -1,0 +1,1 @@
+export { default } from '../components/product/ProductPagePullRSC';

--- a/app/javascript/utils/asyncPropStore.ts
+++ b/app/javascript/utils/asyncPropStore.ts
@@ -1,0 +1,74 @@
+// Request-scoped async prop store for pull-mode RSC pages (#165).
+//
+// Uses React.cache() to create a per-RSC-request singleton. This eliminates
+// prop drilling of `getReactOnRailsAsyncProp` — instead of threading the
+// function through every component, the root component calls
+// `initAsyncPropStore()` once and children import `getAsyncProp()` directly.
+//
+// Concurrency-safe: React.cache() is request-scoped via React's internal
+// AsyncLocalStorage. Two concurrent RSC renders never share cache entries.
+//
+// Server-only: React.cache() memoizes in the RSC server bundle. In client
+// builds it's a pass-through (no memoization), but this module is only
+// imported by server components so it never runs on the client.
+
+import { cache } from 'react';
+
+type GetAsyncProp = (propName: string) => Promise<any>;
+
+interface AsyncPropStoreState {
+  accessor: GetAsyncProp | null;
+}
+
+// cache() with no args = per-request singleton.
+// Returns the SAME mutable object within a single RSC request.
+// Different requests get different objects (React.cache is request-scoped).
+const getStore = cache((): AsyncPropStoreState => ({ accessor: null }));
+
+/**
+ * Initialize the async prop store for the current request.
+ * Must be called once by the root component during render, before any child
+ * component calls `getAsyncProp()`.
+ *
+ * @example
+ * ```tsx
+ * export default function MyPageRSC({ product, getReactOnRailsAsyncProp }) {
+ *   initAsyncPropStore(getReactOnRailsAsyncProp);
+ *   return <AsyncChild />;
+ * }
+ * ```
+ */
+export function initAsyncPropStore(accessor: GetAsyncProp): void {
+  getStore().accessor = accessor;
+}
+
+/**
+ * Get an async prop by name. The prop must have been registered via
+ * `stream_react_component_with_async_props` in the Rails view.
+ *
+ * In pull mode (`push_props: []`), calling this triggers a `propRequest` to
+ * Rails, which queries the DB and streams the result back. When the calling
+ * component is wrapped in `cacheComponent` / `unstable_cache`, a cache HIT
+ * means the component function never runs — so this function is never called
+ * — so no propRequest is sent — so no DB query runs.
+ *
+ * @example
+ * ```tsx
+ * import { getAsyncProp } from '../../utils/asyncPropStore';
+ *
+ * export default async function AsyncReviewsRSC() {
+ *   const data = await getAsyncProp('reviews');
+ *   return <ReviewsList reviews={data.reviews} />;
+ * }
+ * ```
+ */
+export function getAsyncProp(propName: string): Promise<any> {
+  const store = getStore();
+  if (!store.accessor) {
+    throw new Error(
+      `getAsyncProp('${propName}') called before initAsyncPropStore(). ` +
+      'Ensure the root component calls initAsyncPropStore(getReactOnRailsAsyncProp) before rendering children.',
+    );
+  }
+  return store.accessor(propName);
+}

--- a/app/javascript/utils/rscCache.ts
+++ b/app/javascript/utils/rscCache.ts
@@ -21,3 +21,4 @@ export function cacheComponent<P extends Record<string, unknown>>(
   }
   return fn;
 }
+

--- a/app/views/home/_demo_card.html.erb
+++ b/app/views/home/_demo_card.html.erb
@@ -30,9 +30,14 @@
     </div>
   <% end %>
 
-  <div class="flex items-center gap-2 text-xs">
+  <div class="flex items-center gap-2 text-xs flex-wrap">
     <a href="<%= base_path %>/ssr" class="rounded-full bg-amber-50 border border-amber-200 px-2 py-0.5 text-amber-700 hover:bg-amber-100 hover:border-amber-300 transition-colors">SSR</a>
     <a href="<%= base_path %>/client" class="rounded-full bg-blue-50 border border-blue-200 px-2 py-0.5 text-blue-700 hover:bg-blue-100 hover:border-blue-300 transition-colors">Client</a>
     <a href="<%= base_path %>/rsc" class="rounded-full bg-green-50 border border-green-200 px-2 py-0.5 text-green-700 font-semibold hover:bg-green-100 hover:border-green-300 transition-colors">RSC</a>
+    <% if local_assigns[:extra_variants].present? %>
+      <% extra_variants.each do |label, path_suffix, color| %>
+        <a href="<%= base_path %>/<%= path_suffix %>" class="rounded-full bg-<%= color %>-50 border border-<%= color %>-200 px-2 py-0.5 text-<%= color %>-700 hover:bg-<%= color %>-100 hover:border-<%= color %>-300 transition-colors"><%= label %></a>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/home/_demo_card.html.erb
+++ b/app/views/home/_demo_card.html.erb
@@ -35,8 +35,8 @@
     <a href="<%= base_path %>/client" class="rounded-full bg-blue-50 border border-blue-200 px-2 py-0.5 text-blue-700 hover:bg-blue-100 hover:border-blue-300 transition-colors">Client</a>
     <a href="<%= base_path %>/rsc" class="rounded-full bg-green-50 border border-green-200 px-2 py-0.5 text-green-700 font-semibold hover:bg-green-100 hover:border-green-300 transition-colors">RSC</a>
     <% if local_assigns[:extra_variants].present? %>
-      <% extra_variants.each do |label, path_suffix, color| %>
-        <a href="<%= base_path %>/<%= path_suffix %>" class="rounded-full bg-<%= color %>-50 border border-<%= color %>-200 px-2 py-0.5 text-<%= color %>-700 hover:bg-<%= color %>-100 hover:border-<%= color %>-300 transition-colors"><%= label %></a>
+      <% extra_variants.each do |label, path_suffix, classes| %>
+        <a href="<%= base_path %>/<%= path_suffix %>" class="<%= classes %>"><%= label %></a>
       <% end %>
     <% end %>
   </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -423,7 +423,7 @@
         icon_svg: '<svg width="20" height="20" viewBox="0 0 20 20" fill="none"><rect x="3" y="5" width="14" height="10" rx="2" stroke="#2563eb" stroke-width="1.5"/><path d="M7 5V3a3 3 0 0 1 6 0v2" stroke="#2563eb" stroke-width="1.5" stroke-linecap="round"/></svg>',
         report_slug: "product",
         bundle_anchor: "product",
-        extra_variants: [["Pull", "rsc-pull", "purple"]],
+        extra_variants: [["Pull", "rsc-pull", "rounded-full bg-purple-50 border border-purple-200 px-2 py-0.5 text-purple-700 hover:bg-purple-100 hover:border-purple-300 transition-colors"]],
       } %>
 
       <!-- 3) Restaurant Detail — +13 mobile perf. Long markdown + 80 items + 40 reviews. -->

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -423,6 +423,7 @@
         icon_svg: '<svg width="20" height="20" viewBox="0 0 20 20" fill="none"><rect x="3" y="5" width="14" height="10" rx="2" stroke="#2563eb" stroke-width="1.5"/><path d="M7 5V3a3 3 0 0 1 6 0v2" stroke="#2563eb" stroke-width="1.5" stroke-linecap="round"/></svg>',
         report_slug: "product",
         bundle_anchor: "product",
+        extra_variants: [["Pull", "rsc-pull", "purple"]],
       } %>
 
       <!-- 3) Restaurant Detail — +13 mobile perf. Long markdown + 80 items + 40 reviews. -->

--- a/app/views/pages/measure.html.erb
+++ b/app/views/pages/measure.html.erb
@@ -12,6 +12,7 @@
     ["Product Client", "/product/client", "https://rsc.reactonrails.com/product/client"],
     ["Product RSC",    "/product/rsc",    "https://rsc.reactonrails.com/product/rsc"],
     ["Product PPR",    "/product/ppr",    "https://rsc.reactonrails.com/product/ppr"],
+    ["Product RSC Pull", "/product/rsc-pull", "https://rsc.reactonrails.com/product/rsc-pull"],
     ["Restaurant Detail SSR",    "/restaurant/1/ssr",    "https://rsc.reactonrails.com/restaurant/1/ssr"],
     ["Restaurant Detail Client", "/restaurant/1/client", "https://rsc.reactonrails.com/restaurant/1/client"],
     ["Restaurant Detail RSC",    "/restaurant/1/rsc",    "https://rsc.reactonrails.com/restaurant/1/rsc"],

--- a/app/views/products/show_rsc_pull.html.erb
+++ b/app/views/products/show_rsc_pull.html.erb
@@ -1,0 +1,68 @@
+<% content_for :head do %>
+  <link rel="preload" as="image" href="<%= hero_image_url %>" fetchpriority="high">
+<% end %>
+<%# V5: Pull-mode async props — bidirectional streaming.
+    push_props: [] means NO props are eagerly pushed. React requests each prop
+    on demand via propRequest; Rails resolves them in the pull_requests loop.
+    Combined with unstable_cache on the JS side: on a cache HIT the component
+    never requests the prop, so the DB query below never runs.
+
+    Allowlisted prop names only — unknown names are rejected. %>
+<%= stream_react_component_with_async_props("ProductPagePullRSC",
+    props: { product: @product_data }, prerender: true,
+    push_props: []) do |emit|
+
+  while (prop_name = emit.pull_requests.dequeue)
+    case prop_name
+    when "product_details"
+      emit.call("product_details", {
+        description: @product.description,
+        features: @product.features,
+        specs: @product.specs,
+      })
+
+    when "review_stats"
+      emit.call("review_stats", @product.review_stats)
+
+    when "reviews"
+      reviews = @product.top_reviews(5)
+      emit.call("reviews", {
+        reviews: reviews.map { |r|
+          {
+            id: r.id,
+            rating: r.rating,
+            title: r.title,
+            comment: r.comment,
+            reviewer_name: r.reviewer_name,
+            verified_purchase: r.verified_purchase,
+            helpful_count: r.helpful_count,
+            created_at: r.created_at.iso8601,
+          }
+        }
+      })
+
+    when "related_products"
+      related = @product.related_products(4)
+      emit.call("related_products", {
+        products: related.map { |p|
+          {
+            id: p.id,
+            name: p.name,
+            price: p.price.to_f,
+            original_price: p.original_price&.to_f,
+            category: p.category,
+            brand: p.brand,
+            images: p.images,
+            average_rating: p.average_rating.to_f,
+            review_count: p.review_count,
+            in_stock: p.in_stock,
+            discount_percentage: p.discount_percentage,
+          }
+        }
+      })
+
+    else
+      emit.reject(prop_name, "Unknown async prop")
+    end
+  end
+end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
   get '/product/client', to: 'products#show_client'   # V2: Loadable components, client-side fetch
   get '/product/rsc', to: 'products#show_rsc'         # V3: RSC streaming
   get '/product/rsc-cached', to: 'products#show_rsc_cached' # V3 + cached_stream_react_component_with_async_props
+  get '/product/rsc-pull', to: 'products#show_rsc_pull' # V5: RSC pull-mode — bidirectional async props + unstable_cache
   get '/product/ppr', to: 'products#show_ppr'         # V4: PPR — cached shell + dynamic streaming
 
   # Product search results — three versions demonstrating search page RSC gains

--- a/docs/pull-mode-async-props-benchmark.md
+++ b/docs/pull-mode-async-props-benchmark.md
@@ -1,0 +1,117 @@
+# Pull-Mode Async Props + `unstable_cache` Benchmark
+
+Issue: [#165 — Use bidirectional (pull-mode) async props in the demo and verify they work with unstable_cache](https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/issues/165)
+
+Branch: `165-use-bidirectional-pull-mode-async-props` | Stack: React on Rails 17.0.0 | Date: 2026-08-03
+
+## What pull-mode async props do
+
+In **push mode** (existing `/product/rsc`), Rails eagerly pushes all async props to the Node renderer regardless of whether the JS-side `unstable_cache` would use them. Every request runs all 4 DB queries even when the cached component would replay Flight bytes without touching the data.
+
+In **pull mode** (`/product/rsc-pull`), React requests each prop on demand via `propRequest`. Rails only queries the DB when it receives a request. Combined with `unstable_cache`, cached components never call `getAsyncProp()` → no `propRequest` → no DB query.
+
+### Architecture: React.cache()-based async prop store
+
+Instead of threading `getReactOnRailsAsyncProp` through every component as a prop, we use `React.cache()` to create a **per-RSC-request singleton** (`asyncPropStore.ts`):
+
+- Root component calls `initAsyncPropStore(getReactOnRailsAsyncProp)` once
+- Child components import `getAsyncProp(propName)` directly — no prop drilling
+- `React.cache()` is request-scoped via React's internal `AsyncLocalStorage` — fully concurrency-safe
+
+### Pull-mode cached components
+
+| Component | Cache ID | Prop name | What it caches |
+|-----------|----------|-----------|----------------|
+| `AsyncProductDetailsPullRSC` | `pull-product-details` | `product_details` | description + features + specs (marked + highlight.js) |
+| `AsyncReviewStatsPullRSC` | `pull-product-review-stats` | `review_stats` | rating distribution SVG bar chart |
+| `AsyncReviewsPullRSC` | `pull-product-reviews` | `reviews` | 5 customer reviews (date-fns formatting) |
+| `AsyncRelatedProductsPullRSC` | `pull-product-related` | `related_products` | 4 related product cards |
+
+All entries use `revalidate: 60` (60-second TTL). Cache key includes `productId` to prevent cross-product cache collisions.
+
+## DB query reduction
+
+Methodology: Rails `development.log` `Completed` line showing query count and ActiveRecord time. Server warmed with 3+ requests before measurement to ensure both node-renderer workers have warm caches.
+
+### Results
+
+| Mode | Cache state | DB queries | ActiveRecord time | Total response time |
+|------|-------------|------------|-------------------|---------------------|
+| Push (`/product/rsc`) | Every request | **4 queries** | ~30–90 ms | ~500–865 ms |
+| Pull (`/product/rsc-pull`) | MISS (cold) | **4 queries** | ~42–1202 ms | ~1000–5500 ms |
+| Pull (`/product/rsc-pull`) | **HIT (warm)** | **1 query** | **~4–19 ms** | **~775–800 ms** |
+
+The single remaining query on cache HIT is the controller's `find_product` for sync props (hero section). The 3 async prop queries (`review_stats`, `reviews`, `related_products`) are completely eliminated.
+
+### Raw query log (representative samples)
+
+**Push mode — always 4 queries:**
+```
+Completed 200 OK in 497ms (ActiveRecord: 28.0ms (4 queries, 0 cached))
+Completed 200 OK in 572ms (ActiveRecord: 89.9ms (4 queries, 0 cached))
+Completed 200 OK in 806ms (ActiveRecord: 54.4ms (4 queries, 0 cached))
+```
+
+**Pull mode — cache MISS (cold):**
+```
+Completed 200 OK in 3780ms (ActiveRecord: 91.1ms (4 queries, 0 cached))
+```
+
+**Pull mode — cache HIT (warm):**
+```
+Completed 200 OK in 775ms (ActiveRecord: 3.6ms (1 query, 0 cached))
+Completed 200 OK in 800ms (ActiveRecord: 18.8ms (1 query, 0 cached))
+Completed 200 OK in 800ms (ActiveRecord: 4.3ms (1 query, 0 cached))
+```
+
+## Web Vitals comparison
+
+Methodology: `pnpm vitals:quick` — Puppeteer headless Chrome, 3 iterations (1 warmup, 2 measured), no throttle, local dev server (`localhost:3100`), `RSC_CACHE_ENABLED=true`. Both pages measured with warm `unstable_cache` (pull-mode has been loaded enough times for both node-renderer workers to have warm caches).
+
+### Results (median of 2 measured runs)
+
+| Metric | Push (`/product/rsc`) | Pull (`/product/rsc-pull`) | Delta | Improvement |
+|--------|----------------------|---------------------------|-------|-------------|
+| **TTFB** | 298.6 ms | 200.3 ms | −98.3 ms | **−33%** |
+| **FCP** | 638.0 ms | 352.0 ms | −286.0 ms | **−45%** |
+| **LCP** | 654.0 ms | 368.0 ms | −286.0 ms | **−44%** |
+| **TBT** | 185.0 ms | 13.0 ms | −172.0 ms | **−93%** |
+| **INP** | 144.0 ms | 120.0 ms | −24.0 ms | **−17%** |
+| **Streaming** | 174.7 ms | 68.7 ms | −106.0 ms | **−61%** |
+| **CLS** | 0.0000 | 0.0000 | 0 | Same |
+| **JS Transfer** | 1640.1 KB | 1640.1 KB | 0 | Same |
+| **JS Decoded** | 1638.9 KB | 1639.0 KB | +0.1 KB | Same |
+
+### Raw data
+
+| Page | Run | TTFB | FCP | LCP | TBT | INP | CLS | Streaming |
+|------|-----|------|-----|-----|-----|-----|-----|-----------|
+| Push | warmup | 260.8 | 564.0 | 564.0 | 146.0 | 128.0 | 0 | 120.3 |
+| Push | 1 | 357.7 | 636.0 | 652.0 | 185.0 | 152.0 | 0 | 229.2 |
+| Push | 2 | 239.5 | 640.0 | 656.0 | 185.0 | 136.0 | 0 | 120.2 |
+| Pull | warmup | 199.0 | 440.0 | 472.0 | 8.0 | 104.0 | 0 | 35.0 |
+| Pull | 1 | 201.7 | 352.0 | 368.0 | 18.0 | 136.0 | 0 | 102.5 |
+| Pull | 2 | 198.9 | 352.0 | 368.0 | 8.0 | 104.0 | 0 | 34.9 |
+
+### Analysis
+
+1. **Pull-mode with warm cache is dramatically faster across every timing metric.** The TTFB improvement (−33%) comes from Rails responding faster when it skips 3 DB queries. FCP and LCP improve by the same −286ms because the first paint is not blocked on async prop resolution.
+
+2. **TBT drops 93% (185ms → 13ms)** — the main thread is almost never blocked. In push mode, the browser processes all 4 async prop streams even though their rendered output is the same. In pull mode with warm cache, the cached Flight bytes are replayed instantly with minimal JS execution.
+
+3. **Streaming duration drops 61%** — from 174.7ms to 68.7ms. On a cache HIT, the response stream completes faster because cached components emit pre-rendered bytes without waiting for the render pipeline.
+
+4. **JS bundle size is identical** — pull-mode uses the same client components (ProductImageGallery, AddToCartSection) as push-mode. The only difference is the server-side rendering path.
+
+5. **CLS is 0 across both modes** — pull-mode introduces no layout shift regressions. The Suspense fallback skeletons match the rendered content dimensions.
+
+## Comparison with `unstable_cache` alone (issue #83)
+
+The earlier `unstable_cache` benchmark ([docs/unstable-cache-benchmark.md](./unstable-cache-benchmark.md)) showed that `unstable_cache` **alone** saves server-side render time (31% for product page) but has **no measurable effect on Web Vitals** because the DB queries still run on every request in push mode.
+
+Pull-mode changes this: by combining `unstable_cache` with bidirectional async props, cached components skip both the render **and** the DB query. This produces the Web Vitals improvements that `unstable_cache` alone couldn't deliver.
+
+| Approach | Server render savings | DB query savings | Web Vitals impact |
+|----------|----------------------|------------------|-------------------|
+| `unstable_cache` alone (push) | 31% (product) | None — queries always run | **None** |
+| `unstable_cache` + pull-mode | 31% (product) | **75% fewer queries on HIT** (4→1) | **FCP −45%, LCP −44%, TBT −93%** |

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "smoke:routes": "node .verify-routes.js",
     "report:rsc:manifest": "node scripts/report-rsc-manifest.mjs",
     "test:renderer-context": "node --test scripts/renderer-context.test.mjs",
+    "test:pull-mode": "node scripts/verify-pull-mode-e2e.js",
     "postinstall": "node scripts/apply-ppr-patches.js"
   },
   "dependencies": {

--- a/scripts/lib/constants.mjs
+++ b/scripts/lib/constants.mjs
@@ -23,6 +23,7 @@ export const PAGES = {
   'rsc-cached': { path: '/blog/rsc-cached', label: 'RSC cached', hasStreaming: true },
   'product-ssr-cached': { path: '/product/ssr-cached', label: 'Product SSR cached', hasStreaming: false, selectors: { likeButton: 'button', relatedHeadingText: 'Customers Also Viewed' } },
   'product-rsc-cached': { path: '/product/rsc-cached', label: 'Product RSC cached', hasStreaming: true, selectors: { likeButton: 'button', relatedHeadingText: 'Customers Also Viewed' } },
+  'product-rsc-pull': { path: '/product/rsc-pull', label: 'Product RSC Pull', hasStreaming: true, selectors: { likeButton: 'button', relatedHeadingText: 'Customers Also Viewed' } },
   'product-ppr': { path: '/product/ppr', label: 'Product PPR', hasStreaming: true, selectors: { likeButton: 'button', relatedHeadingText: 'Customers Also Viewed' } },
   'search-ssr-cached': { path: '/product-search/ssr-cached', label: 'Search SSR cached', hasStreaming: false },
   'search-rsc-cached': { path: '/product-search/rsc-cached', label: 'Search RSC cached', hasStreaming: true },

--- a/scripts/verify-pull-mode-e2e.js
+++ b/scripts/verify-pull-mode-e2e.js
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+
+// End-to-end test for bidirectional (pull-mode) async props with unstable_cache.
+//
+// Verifies that /product/rsc-pull:
+// 1. SSR renders correctly with all expected sections
+// 2. Hydrates without errors (no console errors, no hydration mismatches)
+// 3. Interactive client components work (image gallery, quantity selector)
+// 4. On cache HIT, the page still renders correctly
+// 5. No duplicate <script> tags, no error panels
+//
+// Requires: Rails server + Node renderer running (with RSC_CACHE_ENABLED=true).
+// Usage:   BASE_URL=http://localhost:3100 node scripts/verify-pull-mode-e2e.js
+//   or:    pnpm test:pull-mode
+
+const puppeteer = require('puppeteer');
+
+const BASE = process.env.BASE_URL || 'http://localhost:3010';
+const ROUTE = '/product/rsc-pull';
+const TIMEOUT = 25000;
+
+// React minified-error codes that mean a hydration mismatch
+const HYDRATION_ERROR_CODES = new Set(['418', '419', '420', '421', '422', '423', '425']);
+
+function isHydrationError(text) {
+  if (!text) return false;
+  const m = text.match(/Minified React error #(\d+)/);
+  if (m && HYDRATION_ERROR_CODES.has(m[1])) return true;
+  if (/Hydration failed/i.test(text)) return true;
+  if (/Text content does not match/i.test(text)) return true;
+  return false;
+}
+
+class TestRunner {
+  constructor() {
+    this.passed = 0;
+    this.failed = 0;
+    this.errors = [];
+  }
+
+  assert(condition, message) {
+    if (condition) {
+      this.passed++;
+      process.stderr.write(`  ✓ ${message}\n`);
+    } else {
+      this.failed++;
+      this.errors.push(message);
+      process.stderr.write(`  ✗ ${message}\n`);
+    }
+  }
+
+  assertEqual(actual, expected, message) {
+    this.assert(actual === expected, `${message} (got ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)})`);
+  }
+
+  assertIncludes(text, substring, message) {
+    this.assert(
+      typeof text === 'string' && text.includes(substring),
+      `${message} (looking for ${JSON.stringify(substring)})`,
+    );
+  }
+
+  summary() {
+    process.stderr.write(`\n========== PULL-MODE E2E RESULTS ==========\n`);
+    process.stderr.write(`Passed: ${this.passed}, Failed: ${this.failed}\n`);
+    if (this.errors.length > 0) {
+      process.stderr.write(`\nFailures:\n`);
+      for (const e of this.errors) {
+        process.stderr.write(`  ✗ ${e}\n`);
+      }
+    }
+    return this.failed === 0;
+  }
+}
+
+async function collectPageState(page) {
+  return page.evaluate(() => {
+    const body = document.body;
+    const text = body?.innerText || '';
+    const scripts = Array.from(document.querySelectorAll('script[src]')).map(s => s.getAttribute('src'));
+    const dupes = scripts.filter((s, i, a) => a.indexOf(s) !== i);
+
+    return {
+      bodyText: text,
+      bodyTextLength: text.length,
+      hasErrorPanel: !!document.getElementById('error-diagnostic'),
+      duplicateScripts: dupes,
+      title: document.title,
+      // Check for key content sections
+      hasV5Banner: text.includes('V5: RSC Pull-Mode'),
+      hasProductName: text.includes('ProSound Elite X1'),
+      hasProductDescription: text.includes('Product Description'),
+      hasReviewStats: text.includes('Customer Reviews'),
+      hasRelatedProducts: text.includes('Customers Also Viewed'),
+      hasSpecSheet: text.includes('Pricing — global ladder'),
+      hasAddToCart: text.includes('Add to Cart'),
+      hasBreadcrumb: text.includes('Headphones'),
+      // Interactive element states
+      quantity: (() => {
+        // Find the quantity display between Decrease/Increase buttons
+        const btns = Array.from(document.querySelectorAll('button'));
+        const increaseBtn = btns.find(b => b.getAttribute('aria-label') === 'Increase quantity'
+          || b.textContent?.trim() === '+');
+        if (!increaseBtn) return null;
+        const container = increaseBtn.parentElement;
+        if (!container) return null;
+        // The quantity is in a span/div between the two buttons
+        const spans = container.querySelectorAll('span, div');
+        for (const s of spans) {
+          const num = parseInt(s.textContent?.trim(), 10);
+          if (!isNaN(num) && num > 0) return num;
+        }
+        return null;
+      })(),
+      cartButtonText: (() => {
+        const btns = Array.from(document.querySelectorAll('button'));
+        const cart = btns.find(b => b.textContent?.includes('Add to Cart'));
+        return cart?.textContent?.trim() || null;
+      })(),
+    };
+  });
+}
+
+(async () => {
+  const t = new TestRunner();
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  // ===================================================================
+  // TEST 1: First load (cache cold) — full SSR + hydration
+  // ===================================================================
+  process.stderr.write(`\n--- Test 1: First load (SSR + hydration) ---\n`);
+  {
+    const page = await browser.newPage();
+    const consoleErrors = [];
+    const pageErrors = [];
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+    page.on('pageerror', (err) => {
+      pageErrors.push(err.message);
+    });
+
+    const resp = await page.goto(BASE + ROUTE, { waitUntil: 'networkidle0', timeout: TIMEOUT });
+    // Let React finish any post-paint work
+    await new Promise(r => setTimeout(r, 1000));
+
+    t.assertEqual(resp.status(), 200, 'HTTP status is 200');
+    t.assert(pageErrors.length === 0, `No page errors (got ${pageErrors.length}: ${pageErrors.join('; ')})`);
+
+    const hydrationErrors = consoleErrors.filter(isHydrationError);
+    t.assert(hydrationErrors.length === 0, `No hydration errors (got ${hydrationErrors.length}: ${hydrationErrors.join('; ')})`);
+
+    const state = await collectPageState(page);
+
+    t.assert(!state.hasErrorPanel, 'No error diagnostic panel');
+    t.assert(state.duplicateScripts.length === 0, `No duplicate scripts (got ${state.duplicateScripts.length})`);
+    t.assert(state.bodyTextLength > 500, `Body has substantial content (${state.bodyTextLength} chars)`);
+
+    // Content sections
+    t.assert(state.hasV5Banner, 'V5 Pull-Mode banner is visible');
+    t.assert(state.hasProductName, 'Product name (ProSound Elite X1) is rendered');
+    t.assert(state.hasProductDescription, 'Product Description section is rendered');
+    t.assert(state.hasReviewStats, 'Customer Reviews section is rendered');
+    t.assert(state.hasRelatedProducts, 'Related products (Customers Also Viewed) are rendered');
+    t.assert(state.hasSpecSheet, 'Spec sheet (Pricing — global ladder) is rendered');
+    t.assert(state.hasAddToCart, 'Add to Cart button is present');
+    t.assert(state.hasBreadcrumb, 'Breadcrumb (Headphones) is present');
+
+    await page.close();
+  }
+
+  // ===================================================================
+  // TEST 2: Second load (cache warm) — still renders correctly
+  // ===================================================================
+  process.stderr.write(`\n--- Test 2: Second load (cache warm) ---\n`);
+  {
+    const page = await browser.newPage();
+    const consoleErrors = [];
+    const pageErrors = [];
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    const resp = await page.goto(BASE + ROUTE, { waitUntil: 'networkidle0', timeout: TIMEOUT });
+    await new Promise(r => setTimeout(r, 1000));
+
+    t.assertEqual(resp.status(), 200, 'Cache-warm HTTP status is 200');
+    t.assert(pageErrors.length === 0, `No page errors on cache-warm load (got ${pageErrors.length})`);
+
+    const hydrationErrors = consoleErrors.filter(isHydrationError);
+    t.assert(hydrationErrors.length === 0, `No hydration errors on cache-warm load (got ${hydrationErrors.length})`);
+
+    const state = await collectPageState(page);
+    t.assert(state.hasV5Banner, 'Cache-warm: V5 banner visible');
+    t.assert(state.hasProductDescription, 'Cache-warm: Product Description rendered');
+    t.assert(state.hasReviewStats, 'Cache-warm: Customer Reviews rendered');
+    t.assert(state.hasRelatedProducts, 'Cache-warm: Related products rendered');
+    t.assert(state.hasSpecSheet, 'Cache-warm: Spec sheet rendered');
+
+    await page.close();
+  }
+
+  // ===================================================================
+  // TEST 3: Hydration — interactive client components work
+  // ===================================================================
+  process.stderr.write(`\n--- Test 3: Client component hydration ---\n`);
+  {
+    const page = await browser.newPage();
+    const pageErrors = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    await page.goto(BASE + ROUTE, { waitUntil: 'networkidle0', timeout: TIMEOUT });
+    await new Promise(r => setTimeout(r, 1000));
+
+    // Test quantity selector
+    const initialState = await collectPageState(page);
+    t.assertEqual(initialState.quantity, 1, 'Initial quantity is 1');
+    t.assertIncludes(initialState.cartButtonText, '$299.99', 'Initial cart button shows $299.99');
+
+    // Click increase quantity
+    const clicked = await page.evaluate(() => {
+      const btns = Array.from(document.querySelectorAll('button'));
+      const btn = btns.find(b => b.getAttribute('aria-label') === 'Increase quantity'
+        || b.textContent?.trim() === '+');
+      if (btn) { btn.click(); return true; }
+      return false;
+    });
+    t.assert(clicked, 'Found and clicked increase quantity button');
+
+    await new Promise(r => setTimeout(r, 300));
+    const afterIncrease = await collectPageState(page);
+    t.assertEqual(afterIncrease.quantity, 2, 'Quantity updated to 2 after click');
+    t.assertIncludes(afterIncrease.cartButtonText, '$599.98', 'Cart button updated to $599.98');
+
+    // Test image gallery — click second thumbnail
+    const imageChanged = await page.evaluate(() => {
+      const images = Array.from(document.querySelectorAll('button img'));
+      if (images.length < 2) return false;
+      const secondThumb = images[1].closest('button');
+      if (!secondThumb) return false;
+      secondThumb.click();
+      return true;
+    });
+    t.assert(imageChanged, 'Clicked second image thumbnail');
+
+    await new Promise(r => setTimeout(r, 300));
+    const imageState = await page.evaluate(() => {
+      // Check if the main image alt text changed or if "2 / 5" is visible
+      const text = document.body?.innerText || '';
+      return text.includes('2 / 5') || text.includes('2/5');
+    });
+    t.assert(imageState, 'Image gallery shows 2 / 5 after clicking second thumbnail');
+
+    t.assert(pageErrors.length === 0, `No page errors during interaction (got ${pageErrors.length})`);
+
+    await page.close();
+  }
+
+  // ===================================================================
+  // TEST 4: Multiple loads — page renders consistently
+  // ===================================================================
+  process.stderr.write(`\n--- Test 4: Consistency across multiple loads ---\n`);
+  {
+    let allOk = true;
+    for (let i = 0; i < 3; i++) {
+      const page = await browser.newPage();
+      const pageErrors = [];
+      page.on('pageerror', (err) => pageErrors.push(err.message));
+
+      const resp = await page.goto(BASE + ROUTE, { waitUntil: 'networkidle0', timeout: TIMEOUT });
+      await new Promise(r => setTimeout(r, 500));
+
+      const state = await collectPageState(page);
+      if (resp.status() !== 200 || pageErrors.length > 0 || !state.hasProductDescription || !state.hasReviewStats) {
+        allOk = false;
+      }
+      await page.close();
+    }
+    t.assert(allOk, 'Page renders correctly across 3 consecutive loads');
+  }
+
+  // ===================================================================
+  // TEST 5: Push-mode regression — /product/rsc still works
+  // ===================================================================
+  process.stderr.write(`\n--- Test 5: Push-mode regression (/product/rsc) ---\n`);
+  {
+    const page = await browser.newPage();
+    const pageErrors = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    const resp = await page.goto(BASE + '/product/rsc', { waitUntil: 'networkidle0', timeout: TIMEOUT });
+    await new Promise(r => setTimeout(r, 500));
+
+    t.assertEqual(resp.status(), 200, 'Push-mode HTTP status is 200');
+    t.assert(pageErrors.length === 0, `Push-mode: no page errors (got ${pageErrors.length})`);
+
+    const state = await collectPageState(page);
+    t.assert(state.hasProductDescription, 'Push-mode: Product Description rendered');
+    t.assert(state.hasReviewStats, 'Push-mode: Customer Reviews rendered');
+    t.assert(state.hasRelatedProducts, 'Push-mode: Related products rendered');
+
+    await page.close();
+  }
+
+  await browser.close();
+
+  const ok = t.summary();
+  process.exit(ok ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary

Closes #165 — Adds a new product page route at `/product/rsc-pull` that uses **bidirectional (pull-mode) async props** combined with **`unstable_cache`** and **`React.cache()`**.

### What pull-mode does differently

In push mode (existing `/product/rsc`), Rails eagerly pushes all async props regardless of whether the JS-side cache would use them. In pull mode, React requests each prop on demand via `propRequest`. Combined with `unstable_cache`, cached components never call `getAsyncProp()` → no `propRequest` → no DB query.

### DB query reduction: cache HIT drops from 4 → 1

| Mode | Cache state | DB queries | ActiveRecord time |
|------|-------------|------------|-------------------|
| Push (`/product/rsc`) | Every request | 4 queries | ~30–90ms |
| **Pull (`/product/rsc-pull`)** | MISS | 4 queries | ~42–1202ms |
| **Pull (`/product/rsc-pull`)** | **HIT** | **1 query** | **~4–19ms** |

The single remaining query on HIT is the controller's `find_product` for sync props (hero section).

### Web Vitals: push vs pull (warm cache)

| Metric | Push (`/product/rsc`) | Pull (`/product/rsc-pull`) | Improvement |
|--------|----------------------|---------------------------|-------------|
| **TTFB** | 298.6 ms | 200.3 ms | **−33%** |
| **FCP** | 638.0 ms | 352.0 ms | **−45%** |
| **LCP** | 654.0 ms | 368.0 ms | **−44%** |
| **TBT** | 185.0 ms | 13.0 ms | **−93%** |
| **INP** | 144.0 ms | 120.0 ms | **−17%** |
| **Streaming** | 174.7 ms | 68.7 ms | **−61%** |
| **CLS** | 0.0000 | 0.0000 | Same |
| **JS Transfer** | 1640.1 KB | 1640.1 KB | Same |

Full benchmark: [`docs/pull-mode-async-props-benchmark.md`](https://github.com/shakacode/react-on-rails-demo-marketplace-rsc/blob/165-use-bidirectional-pull-mode-async-props/docs/pull-mode-async-props-benchmark.md)

### Architecture: React.cache()-based async prop store

Instead of threading `getReactOnRailsAsyncProp` through every component as a prop, we use `React.cache()` to create a **per-RSC-request singleton**:

- Root component calls `initAsyncPropStore(getReactOnRailsAsyncProp)` once
- Child components import `getAsyncProp(propName)` directly — no prop drilling
- `React.cache()` scopes the store per-request via React's internal AsyncLocalStorage — fully concurrency-safe

### Files

**New files:**
- `app/javascript/utils/asyncPropStore.ts` — React.cache()-based request-scoped store
- `app/javascript/components/product/ProductPagePullRSC.tsx` — root page component (V5)
- `app/javascript/components/product/Async{ProductDetails,ReviewStats,Reviews,RelatedProducts}PullRSC.tsx` — pull-cached async components
- `app/javascript/startup/ProductPagePullRSC.tsx` — auto-bundle entry
- `app/views/products/show_rsc_pull.html.erb` — ERB view with `push_props: []` and `emit.pull_requests.dequeue` loop
- `scripts/verify-pull-mode-e2e.js` — Puppeteer e2e test (36 assertions)
- `docs/pull-mode-async-props-benchmark.md` — full benchmark writeup

**Modified files:**
- `app/controllers/products_controller.rb` — `show_rsc_pull` action
- `config/routes.rb` — `/product/rsc-pull` route
- `.verify-routes.js` — added `/product/rsc-pull` to smoke test routes
- `app/views/home/_demo_card.html.erb` — support `extra_variants` pills
- `app/views/home/index.html.erb` — purple "Pull" pill on product card
- `app/views/pages/measure.html.erb` — added pull-mode to benchmark page
- `scripts/lib/constants.mjs` — added `product-rsc-pull` vitals key
- `package.json` — `test:pull-mode` script
- `.gitignore` — `.playwright-mcp/`

### Testing

- **E2E (36/36):** SSR renders all sections, zero hydration errors, client components work (quantity selector, image gallery), cache-warm renders correctly, push-mode regression passes
- **Smoke test:** `/product/rsc-pull` added to `.verify-routes.js` — passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Product RSC Pull page at `/product/rsc-pull`.
  * Product details, reviews, review statistics, specifications, and related products now load progressively with caching.
  * Added a “Pull” variant to the Product Page demo.

* **Bug Fixes**
  * Improved demo card layout on narrow screens by wrapping variant links.

* **Documentation**
  * Added benchmark documentation covering pull-mode loading and performance.

* **Tests**
  * Added end-to-end coverage for rendering, caching, hydration, interactions, and regression checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->